### PR TITLE
Moving chat to left for case submission flow

### DIFF
--- a/src/app/shared/services/livechat.service.ts
+++ b/src/app/shared/services/livechat.service.ts
@@ -33,7 +33,7 @@ export class LiveChatService {
 
                 setTimeout(() => {
 
-                    this.startChat(false, '', LiveChatSettings.DemoModeForCaseSubmission);
+                    this.startChat(false, '', LiveChatSettings.DemoModeForCaseSubmission, 'ltr');
 
                 }, LiveChatSettings.InactivityTimeoutInMs);
 
@@ -55,7 +55,7 @@ export class LiveChatService {
         });
     }
 
-    public startChat(autoOpen: boolean, source: string, demoMode: boolean = false) {
+    public startChat(autoOpen: boolean, source: string, demoMode: boolean = false, chatPosition: string = '') {
 
         let restoreId: string = '';
         let externalId: string = '';
@@ -86,6 +86,9 @@ export class LiveChatService {
                                     restoreId: restoreId,
                                     firstName: this.currentResource.name,
                                     config: {
+                                        headerProperty: {
+                                            direction: chatPosition
+                                        },
                                         content: {
                                             placeholders: {
                                                 reply_field: 'Describe your problem or reply here',


### PR DESCRIPTION
We noticed in case submission that our blade opens in full screen, so customers have to scroll left to type in customer verbatim. Due to that, chat widget (which is right now on the right hand side of our blade) and the popup is not visible on smaller screen sizes.

Hence for case submission, moving the chat icon to left