### PR TITLE
Allowing DAAS to work only on Standard SKU and giving an option to Scale Up

### DIFF
--- a/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
+++ b/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
@@ -15,10 +15,11 @@
         <div *ngIf="!checkingSupportedTier && !supportedTier">
           <div class="focus-box focus-box-warning">
             <div>
-              <strong>Error</strong> - This tool is supported only in Standard, Premium or Isolated tiers because the diagnostic
+              <strong>Error</strong> - This tool is supported only in <strong>Standard, Premium</strong> or <strong>Isolated</strong> tiers because the diagnostic
               tools require the Always-On setting to be enabled to collect data.
             </div>
           </div>
+          <daas-scaleup></daas-scaleup>
         </div>
         <div class="col" *ngIf="checkingSupportedTier">
           <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>

--- a/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
+++ b/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
@@ -28,7 +28,7 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges {
 
   Diagnosers = [{ Name: "Memory Dump", Description: "Collects memory dumps of the process and the child processes hosting your app and analyzes them for errors" },
   { Name: "CLR Profiler", Description: "Profiles ASP.NET application code to identify exceptions and performance issues" },
-  { Name: "CLR Profiler With ThreadStacks", Description: "Profiles ASP.NET application code to identify exceptions and performance issues and dumps stacks to identify deadlocks" },
+  { Name: "CLR Profiler With Thread Stacks", Description: "Profiles ASP.NET application code to identify exceptions and performance issues and dumps stacks to identify deadlocks" },
   { Name: "JAVA Memory Dump", Description: "Collects a binary memory dump using jMap of all java.exe processes running for this web app" },
   { Name: "JAVA Thread Dump", Description: "Collects jStack output of all java.exe processes running for this app and analyzes the same" }];
   DiagnoserOptions = [
@@ -49,8 +49,8 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges {
       if (serverFarm) {
         if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
           this.supportedTier = true;
+          this.checkingSupportedTier = false;
           this._siteService.getAlwaysOnSetting(this.siteToBeDiagnosed).subscribe(alwaysOnSetting => {
-            this.checkingSupportedTier = false;
             if (alwaysOnSetting) {
               this.alwaysOnEnabled = true;
             }
@@ -61,12 +61,18 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges {
 
           this.initComponent();
         }
+        else {
+          this.checkingSupportedTier = false;
+        }
 
         // This is required in case someone lands on Mitigate page
         // without ever hitting DAAS endpoint. Browsing to any DAAS 
         // endpoint, will ensure that DaaSConsole is copied to the
         // right folders and will allow autohealing to work correctly
         this.makeDaasWarmupCall();
+      }
+      else {
+        this.checkingSupportedTier = false;
       }
     });
 

--- a/src/app/auto-healing/autohealing.component.ts
+++ b/src/app/auto-healing/autohealing.component.ts
@@ -297,7 +297,7 @@ export class AutohealingComponent extends DetectorViewBaseComponent implements O
 
       this.validationWarning.push(appDomainRestartWarning);
 
-      if (FormatHelper.timespanToSeconds(this.autohealingSettings.autoHealRules.actions.minProcessExecutionTime) < 600) {
+      if (this.autohealingSettings.autoHealRules.actions.minProcessExecutionTime!=null && FormatHelper.timespanToSeconds(this.autohealingSettings.autoHealRules.actions.minProcessExecutionTime) < 600) {
         this.validationWarning.push(minProcessExecutionTimeNotSet);
       }
 

--- a/src/app/shared/components/daas-main/daas-main.component.html
+++ b/src/app/shared/components/daas-main/daas-main.component.html
@@ -7,8 +7,17 @@
         diagnostic capabilities of different technology stacks to provide you insights on your app performance and availability.
         To get started, click on the tile for the tool you want to use.
     </p>
-
-    <div style="margin-bottom: 10px;" *ngIf="platform !=null && platform === operatingSystem.windows">
+    <div *ngIf="!checkingSupportedTier && !supportedTier">
+        <div class="focus-box focus-box-warning" style="margin-top:20px">
+            <div>
+                <strong>Error</strong> - This tool is supported only on
+                <b>Standard, Premium </b> and
+                <b>Isolated</b> SKU's only.
+            </div>
+        </div>
+        <daas-scaleup></daas-scaleup>
+    </div>
+    <div style="margin-bottom: 10px;" *ngIf="platform !=null && platform === operatingSystem.windows && supportedTier">
 
         <div *ngIf="toolCategory !=null && (toolCategory.Subcategories | toolstack:AppStack | platformfilter:platform  | apptype:appType).length > 0">
             <div class="col zoomIn animated category-box" *ngFor="let subcategory of toolCategory.Subcategories | toolstack:AppStack | platformfilter:platform | apptype:appType"
@@ -57,5 +66,5 @@
             Diagnostics as a Service is supported on Windows Platform only.
         </div>
     </div>
-   
+
 </div>

--- a/src/app/shared/components/daas-main/daas-main.component.html
+++ b/src/app/shared/components/daas-main/daas-main.component.html
@@ -66,5 +66,4 @@
             Diagnostics as a Service is supported on Windows Platform only.
         </div>
     </div>
-
 </div>

--- a/src/app/shared/components/daas-main/daas-main.component.ts
+++ b/src/app/shared/components/daas-main/daas-main.component.ts
@@ -28,6 +28,8 @@ export class DaasMainComponent implements OnInit {
   sku: Sku;
   showToolsDropdown: boolean = false;
   operatingSystem:any = OperatingSystem; 
+  checkingSupportedTier:boolean = true;
+  supportedTier:boolean = false;
 
   constructor(private _siteService: SiteService, private _logger: AvailabilityLoggingService,
     private _categoryService: CategoriesService,
@@ -51,6 +53,7 @@ export class DaasMainComponent implements OnInit {
         this.sku = Sku[site.sku];
 
         this._authService.getStartupInfo().subscribe((startupInfo: StartupInfo) => {
+          this.checkingSupportedTier = false;
           let resourceUriParts = this._siteService.parseResourceUri(startupInfo.resourceId);
           this._appAnalysisService.getDiagnosticProperties(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName).subscribe((data: IDiagnosticProperties) => {
             this.AppStack = data && data.appStack && data.appStack != "" ? data.appStack : "ASP.Net";
@@ -58,6 +61,7 @@ export class DaasMainComponent implements OnInit {
             this._categoryService.Categories.subscribe(categories => {
               let toolsCategories = categories.filter(x => x.Name === "Diagnostic Tools");
               if (toolsCategories.length > 0 && (this.sku & Sku.Paid)){
+                this.supportedTier = true;
                 this.toolCategory= toolsCategories[0];
               }
             });

--- a/src/app/shared/components/daas-sessions/daas-sessions.component.html
+++ b/src/app/shared/components/daas-sessions/daas-sessions.component.html
@@ -68,7 +68,7 @@
                     <b>{{ session.StartTime }} UTC</b>
                     <span>- {{ session.StartTime | datetimediff }} ago</span>
 
-                    <div class="inline" style="margin-left:30px" *ngIf="!isSessionInProgress(i)">
+                    <div class="inline" style="margin-left:30px" *ngIf="!isSessionInProgress(session)">
                         <div class="inline tool-tip hotspot-clickable" style="font-size:medium" >
                             <span style="margin-left:30px;width:250px;margin-top:30px" class="tool-tip-text">Click here to delete this session and any collected logs and reports generated for this session</span>
                             <i class="fa fa-trash" aria-hidden="true" (click)="deleteSession(i)"></i>

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.css
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.css
@@ -1,15 +1,3 @@
-.header1 {
-    font-size: 24px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-
-.header2 {
-    font-size: 20px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-
 .action-box {
     border: 1px solid #ebebeb;
     padding:15px;
@@ -17,13 +5,7 @@
 }
 
 .highlight-blue {
+    font-size:20px;
+    font-weight:500;
     color: #286090;
-}
-
-.highlight-orange {
-    color: #da622b;
-}
-
-td {
-    padding-right:30px;
 }

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.css
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.css
@@ -1,0 +1,29 @@
+.header1 {
+    font-size: 24px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.header2 {
+    font-size: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.action-box {
+    border: 1px solid #ebebeb;
+    padding:15px;
+    background-color: #f9f9f9
+}
+
+.highlight-blue {
+    color: #286090;
+}
+
+.highlight-orange {
+    color: #da622b;
+}
+
+td {
+    padding-right:30px;
+}

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.html
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.html
@@ -1,35 +1,19 @@
-<div class="action-box">
-  <div *ngIf="currentServerFarm">
-      <div>Current App Service Plan</div>
-      <table style="border:none;padding:5px">
-          <tr style="font-size:20px;font-weight:500;color: #286090;" *ngIf="currentServerFarm">
-              <td>{{currentServerFarm.sku.name + ' ' + currentServerFarm.sku.tier}}</td>
-              <td>{{currentServerFarm.additionalProperties.ramInGB}}
-                  <span style="font-size:16px">GB</span>
-              </td>
-              <td>{{currentServerFarm.additionalProperties.cores}}</td>
-              <td>{{currentServerFarm.sku.capacity}}</td>
-              <!-- <td>{{currentServerFarm.properties.numberOfSites}}</td> -->
-          </tr>
-          <tr id="table-labels" style="font-size:11px">
-              <td>Tier</td>
-              <td>RAM</td>
-              <td>Cores</td>
-              <td>Instance Count</td>
-              <!-- <td>App Count</td> -->
-          </tr>
-      </table>
-      <br/>
-      <p [innerHtml]="suggestion"></p>
-      <div style="text-align:right">
-          <button class="btn btn-primary" (click)="openBlade()">Open Scale Up App Service Plan</button>
-      </div>
-
-  </div>
-  <div style="text-align:center" *ngIf="!currentServerFarm">
-      <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-  </div>
+<div class="action-box" style="margin-top: 10px">
+    <div *ngIf="currentServerFarm">
+        <div>Current App Service Plan Tier</div>
+        <div class="highlight-blue" *ngIf="currentServerFarm">
+            {{currentServerFarm.sku.name + ' ' + currentServerFarm.sku.tier}}
+        </div>
+        <br/>
+        <p>
+            You can upgrade to a Standard Plan to use Diagnostics as a Service
+        </p>
+        <div style="text-align:right">
+            <button class="btn btn-primary" (click)="openBlade()">Open Scale Up App Service Plan</button>
+        </div>
+    </div>
+    <div style="text-align:center" *ngIf="!currentServerFarm">
+        <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+    </div>
 
 </div>
-
-<p style="padding: 10px 0px 0px 0px" [innerHtml]="secondarySuggestion" *ngIf="secondarySuggestion"></p>

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.html
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.html
@@ -1,0 +1,35 @@
+<div class="action-box">
+  <div *ngIf="currentServerFarm">
+      <div>Current App Service Plan</div>
+      <table style="border:none;padding:5px">
+          <tr style="font-size:20px;font-weight:500;color: #286090;" *ngIf="currentServerFarm">
+              <td>{{currentServerFarm.sku.name + ' ' + currentServerFarm.sku.tier}}</td>
+              <td>{{currentServerFarm.additionalProperties.ramInGB}}
+                  <span style="font-size:16px">GB</span>
+              </td>
+              <td>{{currentServerFarm.additionalProperties.cores}}</td>
+              <td>{{currentServerFarm.sku.capacity}}</td>
+              <!-- <td>{{currentServerFarm.properties.numberOfSites}}</td> -->
+          </tr>
+          <tr id="table-labels" style="font-size:11px">
+              <td>Tier</td>
+              <td>RAM</td>
+              <td>Cores</td>
+              <td>Instance Count</td>
+              <!-- <td>App Count</td> -->
+          </tr>
+      </table>
+      <br/>
+      <p [innerHtml]="suggestion"></p>
+      <div style="text-align:right">
+          <button class="btn btn-primary" (click)="openBlade()">Open Scale Up App Service Plan</button>
+      </div>
+
+  </div>
+  <div style="text-align:center" *ngIf="!currentServerFarm">
+      <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+  </div>
+
+</div>
+
+<p style="padding: 10px 0px 0px 0px" [innerHtml]="secondarySuggestion" *ngIf="secondarySuggestion"></p>

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.spec.ts
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DaasScaleupComponent } from './daas-scaleup.component';
+
+describe('DaasScaleupComponent', () => {
+  let component: DaasScaleupComponent;
+  let fixture: ComponentFixture<DaasScaleupComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DaasScaleupComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DaasScaleupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.ts
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit } from '@angular/core';
+import { ServerFarm } from '../../../models/server-farm';
+import { ServerFarmDataService } from '../../../services/server-farm-data.service';
+import { PortalActionService } from '../../../services/portal-action.service';
+import { SolutionData } from '../../../models/solution';
+import { AvailabilityLoggingService } from '../../../services/logging/availability.logging.service';
+
+@Component({
+  selector: 'daas-scaleup',
+  templateUrl: './daas-scaleup.component.html',
+  styleUrls: ['./daas-scaleup.component.css']
+})
+export class DaasScaleupComponent implements OnInit {
+
+  data: SolutionData;
+
+  title: string = "Scale up your App Service Plan";
+    description: string = "Increase the size of the instances in your app service plan. Each instance will have more cores (CPU), memory, and disk space.";
+
+    whyToScale: string[] = [
+        "Your app is designed to do a lot of processing that requires a high amount of CPU and you want more cores for each instance",
+        "Your app is designed to need a lot of memory. You want each instance to have a larger RAM size. "
+    ];
+
+    whyNotToScale: string[] = [
+        "Your app is experiencing high CPU or memory, but it is not designed to. This could be the result of a bug in your app code and scaling will not necessarily help.",
+        "You experience high resource usage during the hours of peak traffic for your app. A more cost effective solution would be AutoScale."
+    ];
+
+    currentServerFarm: ServerFarm;
+
+    suggestion: string;
+
+    secondarySuggestion: string;
+
+    constructor(private _serverFarmService: ServerFarmDataService, private _portalActionService: PortalActionService, private _logger: AvailabilityLoggingService) {
+        this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
+            if (serverFarm) {
+                this.currentServerFarm = serverFarm;
+                this.generateSuggestion();
+                
+                
+            }
+        }, error => {
+            //TODO: handle error
+        })
+    }
+
+    ngOnInit() {
+        //this.data.solution.order = this.data.solution.order ? this.data.solution.order : 9999;
+        this._logger.LogSolutionDisplayed('Scale Up', this.data.solution.order.toString(), 'bot-sitecpuanalysis');
+    }
+
+    generateSuggestion() {
+        let sizeId = parseInt(this.currentServerFarm.sku.name.replace(this.currentServerFarm.sku.family, ''));
+
+        // TODO: if it is an ASE, we should offer premium sized instances
+
+        if (sizeId < 3) {
+            this.suggestion = `You can increase your App Service Plan to the next tier <b>${this.currentServerFarm.sku.family + (sizeId + 1)}</b>. ` +
+                `This would increase your RAM size to <b>${this.currentServerFarm.additionalProperties.ramInGB * 2}GB</b> ` +
+                `and the number of cores to <b>${this.currentServerFarm.additionalProperties.cores * 2}</b>.`
+
+            this.secondarySuggestion = "<b>Note:</b> Scaling up will increase the cost of your App Service Plan. You can try scaling up and see if it solves your problem, and if not scale back down."
+        }
+        else {
+            this.suggestion = 'You are already scaled to the maximum instance size. You could try scaling out instead.'
+        }
+    }
+
+    openBlade() {
+        this._logger.LogSolutionTried('Scale Up', this.data.solution.order.toString(), 'blade', '');
+        this._portalActionService.openBladeScaleUpBlade();
+    }
+}

--- a/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.ts
+++ b/src/app/shared/components/daas/daas-scaleup/daas-scaleup.component.ts
@@ -10,66 +10,22 @@ import { AvailabilityLoggingService } from '../../../services/logging/availabili
   templateUrl: './daas-scaleup.component.html',
   styleUrls: ['./daas-scaleup.component.css']
 })
-export class DaasScaleupComponent implements OnInit {
-
-  data: SolutionData;
-
-  title: string = "Scale up your App Service Plan";
-    description: string = "Increase the size of the instances in your app service plan. Each instance will have more cores (CPU), memory, and disk space.";
-
-    whyToScale: string[] = [
-        "Your app is designed to do a lot of processing that requires a high amount of CPU and you want more cores for each instance",
-        "Your app is designed to need a lot of memory. You want each instance to have a larger RAM size. "
-    ];
-
-    whyNotToScale: string[] = [
-        "Your app is experiencing high CPU or memory, but it is not designed to. This could be the result of a bug in your app code and scaling will not necessarily help.",
-        "You experience high resource usage during the hours of peak traffic for your app. A more cost effective solution would be AutoScale."
-    ];
+export class DaasScaleupComponent  {
 
     currentServerFarm: ServerFarm;
-
-    suggestion: string;
-
-    secondarySuggestion: string;
-
     constructor(private _serverFarmService: ServerFarmDataService, private _portalActionService: PortalActionService, private _logger: AvailabilityLoggingService) {
         this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
             if (serverFarm) {
                 this.currentServerFarm = serverFarm;
-                this.generateSuggestion();
-                
-                
             }
         }, error => {
             //TODO: handle error
         })
     }
 
-    ngOnInit() {
-        //this.data.solution.order = this.data.solution.order ? this.data.solution.order : 9999;
-        this._logger.LogSolutionDisplayed('Scale Up', this.data.solution.order.toString(), 'bot-sitecpuanalysis');
-    }
-
-    generateSuggestion() {
-        let sizeId = parseInt(this.currentServerFarm.sku.name.replace(this.currentServerFarm.sku.family, ''));
-
-        // TODO: if it is an ASE, we should offer premium sized instances
-
-        if (sizeId < 3) {
-            this.suggestion = `You can increase your App Service Plan to the next tier <b>${this.currentServerFarm.sku.family + (sizeId + 1)}</b>. ` +
-                `This would increase your RAM size to <b>${this.currentServerFarm.additionalProperties.ramInGB * 2}GB</b> ` +
-                `and the number of cores to <b>${this.currentServerFarm.additionalProperties.cores * 2}</b>.`
-
-            this.secondarySuggestion = "<b>Note:</b> Scaling up will increase the cost of your App Service Plan. You can try scaling up and see if it solves your problem, and if not scale back down."
-        }
-        else {
-            this.suggestion = 'You are already scaled to the maximum instance size. You could try scaling out instead.'
-        }
-    }
-
     openBlade() {
-        this._logger.LogSolutionTried('Scale Up', this.data.solution.order.toString(), 'blade', '');
+        this._logger.LogClickEvent("ScaleUp", "DaaS");
         this._portalActionService.openBladeScaleUpBlade();
+
     }
 }

--- a/src/app/shared/components/daas/daas-validator.component.html
+++ b/src/app/shared/components/daas/daas-validator.component.html
@@ -1,15 +1,17 @@
 <div *ngIf="!checkingSupportedTier && !supportedTier">
   <div class="focus-box focus-box-warning" style="margin-top:20px">
     <div>
-      <strong>Error</strong> - This tool is supported only on Dedicated SKU's
+      <strong>Error</strong> - This tool is supported only on Standard, Premium and Isolated SKU's      
     </div>
-  </div>  
+  </div>
+  <daas-scaleup></daas-scaleup>  
 </div>
 
 <div *ngIf="!daasRunnerJobRunning" class="focus-box focus-box-warning" style="margin-top:20px">
   <div>
     <strong>Error</strong> - We found that the DAAS Web job is in a stopped state. Please go to WebJobs under this Web App and start
-    the DAAS Web job manually and re-run this tool.
+    the DAAS Web job manually and re-run this tool. If this is the first time you are running these tools, try hitting the refresh button
+    after a few seconds
   </div>
 </div>
 

--- a/src/app/shared/components/daas/daas-validator.component.html
+++ b/src/app/shared/components/daas/daas-validator.component.html
@@ -1,17 +1,35 @@
 <div *ngIf="!checkingSupportedTier && !supportedTier">
-  <div class="focus-box focus-box-warning" style="margin-top:20px">
+  <div class="focus-box focus-box-warning" style="margin-top:20px;margin-left:10px">
     <div>
-      <strong>Error</strong> - This tool is supported only on Standard, Premium and Isolated SKU's      
+      <strong>Error</strong> - This tool is supported only on <b>Standard, Premium </b> and <b>Isolated</b> SKU's only with <strong>AlwaysOn</strong> setting enabled to TRUE
     </div>
   </div>
-  <daas-scaleup></daas-scaleup>  
+  <daas-scaleup></daas-scaleup>
+</div>
+
+<div *ngIf="error !=='' && !checkingSupportedTier">
+  <div class="focus-box focus-box-warning" style="margin-top:20px;margin-left:10px">
+    <div>
+      <strong>Error</strong> - {{ error }}
+    </div>
+  </div>
+</div>
+
+<div *ngIf="!checkingSupportedTier && supportedTier && !alwaysOnEnabled">
+  <div class="focus-box focus-box-warning">
+    <div>
+      <strong>Error</strong> - We determined that the web app does not have Always-On enabled and due to these the diagnostic
+      tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the properties
+      of the web app and then run these tools.
+    </div>
+  </div>
 </div>
 
 <div *ngIf="!daasRunnerJobRunning" class="focus-box focus-box-warning" style="margin-top:20px">
   <div>
     <strong>Error</strong> - We found that the DAAS Web job is in a stopped state. Please go to WebJobs under this Web App and start
     the DAAS Web job manually and re-run this tool. If this is the first time you are running these tools, try hitting the refresh button
-    after a few seconds
+    after a few minutes
   </div>
 </div>
 
@@ -27,15 +45,10 @@
 
 <div class="col" *ngIf="checkingSupportedTier">
   <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-  Checking if the WebApp is running in a supported Tier
+  Checking suppported tier and retrieving daas settings
 </div>
 
-<div class="col" *ngIf="retrievingDiagnosers">
-  <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-  Retrieving Diagnoser settings...
-</div>
-
-<div style="margin-top:15px" *ngIf="(!supportedTier || !daasRunnerJobRunning || foundDiagnoserWarnings) && (!checkingDaasWebJobStatus && !checkingSupportedTier && !retrievingDiagnosers)">
+<div style="margin-top:15px" *ngIf="(!supportedTier || !daasRunnerJobRunning || foundDiagnoserWarnings) && (!checkingDaasWebJobStatus && !checkingSupportedTier)">
     <span class="hotspot-clickable" (click)="validateDaasSettings()">
         <i class="fa fa-refresh refresh-icon"></i> Refresh
     </span>

--- a/src/app/shared/components/daas/daas-validator.component.ts
+++ b/src/app/shared/components/daas/daas-validator.component.ts
@@ -4,6 +4,7 @@ import { DaasService } from '../../services/daas.service';
 import { SiteDaasInfo } from '../../models/solution-metadata';
 import { DiagnoserDefinition } from '../../models/daas';
 import { Observable } from 'rxjs/Observable';
+import { SiteService } from '../../services/site.service';
 
 @Component({
   selector: 'daas-validator',
@@ -22,85 +23,96 @@ export class DaasValidatorComponent implements OnInit {
   checkingDaasWebJobStatus: boolean = false;
   checkingSupportedTier: boolean = true;
   foundDiagnoserWarnings: boolean = false;
-  retrievingDiagnosers: boolean = false;
-  error: any;
+  alwaysOnEnabled: boolean = true;
+  error: string = "";
 
-  constructor(private _serverFarmService: ServerFarmDataService, private _daasService: DaasService) {
-
+  constructor(private _serverFarmService: ServerFarmDataService, private _siteService: SiteService, private _daasService: DaasService) {
   }
 
   validateDaasSettings() {
+    this.error = "";
     this.supportedTier = false;
     this.diagnoserWarning = "";
     this.daasRunnerJobRunning = true;
     this.checkingDaasWebJobStatus = false;
     this.checkingSupportedTier = true;
     this.foundDiagnoserWarnings = false;
-    this.retrievingDiagnosers = false;
 
-    this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
-      if (serverFarm) {
-        this.checkingSupportedTier = false;
-        if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
-          this.supportedTier = true;
+    Observable.combineLatest(
+      this._serverFarmService.siteServerFarm,
+      this._siteService.getAlwaysOnSetting(this.siteToBeDiagnosed),
+      this._daasService.getDiagnosers(this.siteToBeDiagnosed).retry(2),
+    ).subscribe(results => {
+      this.checkingSupportedTier = false;
+      let serverFarm = results[0];
+      this.alwaysOnEnabled = results[1];
+      let diagnosers: DiagnoserDefinition[] = results[2];
+      if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
+        this.supportedTier = true;
+      }
+      else {
+        return;
+      }
 
-          this.retrievingDiagnosers = true;
-          this._daasService.getDiagnosers(this.siteToBeDiagnosed).retry(2)
-            .subscribe(result => {
-              this.retrievingDiagnosers = false;
-              let diagnosers: DiagnoserDefinition[] = result;
-              let thisDiagnoser = diagnosers.find(x => x.Name === this.diagnoserName);
-              if (thisDiagnoser) {
-                if (thisDiagnoser.Warnings.length > 0) {
-                  this.diagnoserWarning = thisDiagnoser.Warnings.join(',');
-                  this.foundDiagnoserWarnings = true;
-                  return;
-                }
-              }
+      if (!this.alwaysOnEnabled) {
+        return;
+      }
 
-              if (!this.foundDiagnoserWarnings) {
-                this.checkingDaasWebJobStatus = true;
-                let retryCount: number = 0;
-                this._daasService.getDaasWebjobState(this.siteToBeDiagnosed)
-                  .map(webjobstate => {
-                    if (webjobstate !== "Running" && retryCount < 2) {
-                      ++retryCount;
-                      throw webjobstate;
-                    }
-                    return webjobstate;
-                  })
-                  .retryWhen(obs => {
-                    // take(3) is required in case the original ARM call fails
-                    return obs.delay(4000).take(3).concat(Observable.throw(new Error('Retry limit exceeded!')))
-                  })
-                  .subscribe(webjobstate => {
-                    this.checkingDaasWebJobStatus = false;
-                    if (webjobstate !== "Running") {
-                      this.daasRunnerJobRunning = false;
-                      return;
-                    }
-                    else {
-                      this.DaasValidated.emit(true);
-                    }
-                  }, error => {
-                    // We come in this block if the ARM call to get webjob fails
-                    this.checkingDaasWebJobStatus = false;
-                    this.daasRunnerJobRunning = false;
-                  });
-              }
-            },
-              error => {
-                this.error = error;
-              });
+      let thisDiagnoser = diagnosers.find(x => x.Name === this.diagnoserName);
+      if (thisDiagnoser) {
+        if (thisDiagnoser.Warnings.length > 0) {
+          this.diagnoserWarning = thisDiagnoser.Warnings.join(',');
+          this.foundDiagnoserWarnings = true;
+          return;
         }
       }
-    }, error => {
-      //TODO: handle error
-    })
+
+      if (!this.foundDiagnoserWarnings) {
+        this.checkDaasWebjobState();
+      }
+    }, err => {
+      this.checkingSupportedTier = false;
+      this.error = `Failed with an error ${JSON.stringify(err)} while retrieving site and DaaS settings`;
+    });
+
   }
 
   ngOnInit(): void {
     this.validateDaasSettings();
   }
+
+  checkDaasWebjobState() {
+
+    this.checkingDaasWebJobStatus = true;
+    let retryCount: number = 0;
+    this._daasService.getDaasWebjobState(this.siteToBeDiagnosed)
+      .map(webjobstate => {
+        if (webjobstate !== "Running" && retryCount < 2) {
+          ++retryCount;
+          throw webjobstate;
+        }
+        return webjobstate;
+      })
+      .retryWhen(obs => {
+        // take(3) is required in case the original ARM call fails
+        return obs.delay(4000).take(3).concat(Observable.throw(new Error('Retry limit exceeded!')))
+      })
+      .subscribe(webjobstate => {
+        this.checkingDaasWebJobStatus = false;
+        if (webjobstate !== "Running") {
+          this.daasRunnerJobRunning = false;
+          return;
+        }
+        else {
+          this.DaasValidated.emit(true);
+        }
+      }, error => {
+        // We come in this block if the ARM call to get webjob fails
+        this.checkingDaasWebJobStatus = false;
+        this.daasRunnerJobRunning = false;
+        this.error = `Failed while retrieving DaaS webjob state `;
+      });
+  }
+
 
 }

--- a/src/app/shared/components/daas/daas-validator.component.ts
+++ b/src/app/shared/components/daas/daas-validator.component.ts
@@ -41,7 +41,7 @@ export class DaasValidatorComponent implements OnInit {
     this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
       if (serverFarm) {
         this.checkingSupportedTier = false;
-        if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier === "Basic" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
+        if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
           this.supportedTier = true;
 
           this.retrievingDiagnosers = true;

--- a/src/app/shared/components/daas/daas.component.html
+++ b/src/app/shared/components/daas/daas.component.html
@@ -13,6 +13,12 @@
                 <tr *ngIf="!error">
                     <td valign="top">
                         Instance(s):
+                        <div class="tool-tip">
+                            <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
+                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for the instances to update if you recently Scaled-Up or Scaled-down
+                                the App Service Plan.
+                            </span>
+                        </div>
                     </td>
                     <td class="highlight-blue">
                         <div *ngFor="let instance of instancesSelected;let i = index">

--- a/src/app/shared/components/daas/daas.component.ts
+++ b/src/app/shared/components/daas/daas.component.ts
@@ -112,15 +112,15 @@ export class DaasComponent implements OnInit, OnDestroy {
 
     }
 
-   
+
     checkRunningSessions() {
         this.operationInProgress = true;
-        this.operationStatus = "Checking active sessions...";        
+        this.operationStatus = "Checking active sessions...";
 
         this._daasService.getDaasActiveSessionsWithDetails(this.siteToBeDiagnosed).retry(2)
             .subscribe(sessions => {
                 this.operationInProgress = false;
-                this.operationStatus = "";                                            
+                this.operationStatus = "";
 
                 var runningSession;
                 for (var index = 0; index < sessions.length; index++) {
@@ -191,6 +191,16 @@ export class DaasComponent implements OnInit, OnDestroy {
             }
             else if (daasDiagnoser.AnalyzerStatus === 2) {
                 this.WizardStepStatus = "";
+                if (daasDiagnoser.AnalyzerStatusMessages.length > 0) {
+                    var thisInstanceMessages = daasDiagnoser.AnalyzerStatusMessages.filter(x => x.EntityType.startsWith(this.selectedInstance));
+                    if (thisInstanceMessages != null) {
+                        var messagesLength = thisInstanceMessages.length;
+                        if (messagesLength > 0) {
+                            this.WizardStepStatus = thisInstanceMessages[messagesLength - 1].Message
+                        }
+                    }
+                }
+
                 this.sessionStatus = 3;
             }
         }
@@ -236,7 +246,7 @@ export class DaasComponent implements OnInit, OnDestroy {
     }
 
     collectDiagnoserData() {
-        
+
         this.instancesChanged = false;
         this.operationInProgress = true;
         this.operationStatus = "Validating instances..."

--- a/src/app/shared/components/daas/profiler.component.html
+++ b/src/app/shared/components/daas/profiler.component.html
@@ -13,6 +13,12 @@
                 <tr *ngIf="!error">
                     <td valign="top">
                         Instance(s):
+                        <div class="tool-tip">
+                            <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
+                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for the instances to update if you recently Scaled-Up or Scaled-down
+                                the App Service Plan.
+                            </span>
+                        </div>
                     </td>
                     <td class="highlight-blue">
                         <div *ngFor="let instance of instancesSelected;let i = index">

--- a/src/app/shared/components/daas/profiler.component.ts
+++ b/src/app/shared/components/daas/profiler.component.ts
@@ -100,8 +100,19 @@ export class ProfilerComponent extends DaasComponent implements OnInit, OnDestro
             else if (clrDiagnoser.AnalyzerStatus === 2) {
 
                 // once we are at the analyzer, lets just set all instances's status to 
-                // analyzing as we will reach here once all the collectors have finsihed                
+                // analyzing as we will reach here once all the collectors have finsihed
                 this.sessionStatus = 4;
+
+                this.WizardStepStatus = "";
+                if (clrDiagnoser.AnalyzerStatusMessages.length > 0) {
+                    var thisInstanceMessages = clrDiagnoser.AnalyzerStatusMessages.filter(x => x.EntityType.startsWith(this.selectedInstance));
+                    if (thisInstanceMessages != null) {
+                        var messagesLength = thisInstanceMessages.length;
+                        if (messagesLength > 0) {
+                            this.WizardStepStatus = thisInstanceMessages[messagesLength - 1].Message
+                        }
+                    }
+                }
 
             }
         }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -187,7 +187,8 @@ import { DaasScaleupComponent } from './components/daas/daas-scaleup/daas-scaleu
         IncidentSummaryComponent,
         LiveAgentChatComponent,
         TimespanComponent,
-        ToggleButtonComponent
+        ToggleButtonComponent,
+        DaasScaleupComponent
     ]
 })
 export class SharedModule {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -75,6 +75,7 @@ import { TimespanComponent } from './components/timespan/timespan.component';
 import { ToggleButtonComponent } from './components/toggle-button/toggle-button.component';
 import { ToolStackPipe, AppTypePipe, SkuPipe, PlatformPipe } from './pipes/categoryfilters.pipe';
 import { DaasMainComponent } from './components/daas-main/daas-main.component';
+import { DaasScaleupComponent } from './components/daas/daas-scaleup/daas-scaleup.component';
 
 @NgModule({
     declarations: [
@@ -125,7 +126,8 @@ import { DaasMainComponent } from './components/daas-main/daas-main.component';
         DaasMainComponent,
         LiveAgentChatComponent,
         TimespanComponent,
-        ToggleButtonComponent
+        ToggleButtonComponent,
+        DaasScaleupComponent
     ],
     imports: [
         HttpModule,


### PR DESCRIPTION
1. Allowing DAAS to work only on Standard Tier and removing the Basic Tier
2. Brought back the analyzerStatus messages that got lot over a period of time
3. Adding a DAAS Scale up Component
4. Parallelizing a few calls in DAAS Validator component
5. Added Retry on check for Daas Webjob state as that can take some time to load
6. Fixing some null checks.

Quick Preview when non paid tier used...

![image](https://user-images.githubusercontent.com/5299838/44043919-a623e5ee-9f41-11e8-8ff1-9d5f23815834.png)


![image](https://user-images.githubusercontent.com/5299838/44043944-baebd054-9f41-11e8-9f9b-b8548f465d36.png)
