### PR TITLE
Changes to diagnostic tools so website contributors can collect data

### DIFF
--- a/AngularApp/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.css
+++ b/AngularApp/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.css
@@ -33,7 +33,7 @@
 .diagnostic-options {
     border: 1px #0058ad solid;
     border-radius: 0px 0px 5px 5px;
-    padding: 0px 0px 0px 5px;
+    padding: 0px 0px 0px 10px;
     margin-left:1px;
 }
 
@@ -72,4 +72,14 @@ label {
     font-size: smaller;
     margin-top: 5px;
     margin-bottom: 5px;
+}
+
+.alert-section{
+    margin-top:5px;
+    font-size: 12px;
+    width:90%;
+    padding: 10px;
+    padding-right: 30px;
+    padding-bottom: 10px;
+    border-radius: 10px;
 }

--- a/AngularApp/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
+++ b/AngularApp/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
@@ -1,10 +1,12 @@
 <div class="row" style="margin-bottom: 5px;margin-left:0;margin-top:10px">
 
   <div class="btn-group" role="group" aria-label="...">
-    <button type="button" class="btn btn-default btn-xs" [ngClass]="{'btn-primary':customActionType==='Diagnostics'}" (click)="customActionType='Diagnostics';initDiagnosticsIfRequired()">
+    <button type="button" class="btn btn-default btn-xs" [ngClass]="{'btn-primary':customActionType==='Diagnostics'}"
+      (click)="customActionType='Diagnostics';initDiagnosticsIfRequired()">
       Run Diagnostics
     </button>
-    <button type="button" class="btn btn-default btn-xs" [ngClass]="{'btn-primary':customActionType==='Custom'}" (click)="customActionType='Custom'">
+    <button type="button" class="btn btn-default btn-xs" [ngClass]="{'btn-primary':customActionType==='Custom'}"
+      (click)="customActionType='Custom'">
       Run Any Executable
     </button>
   </div>
@@ -12,10 +14,11 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <div *ngIf="customActionType == 'Diagnostics'">
-        <div *ngIf="!checkingSupportedTier && !supportedTier">
+        <div *ngIf="!checkingSupportedTier && !supportedTier && checkingSkuSucceeded">
           <div class="focus-box focus-box-warning">
             <div>
-              <strong>Error</strong> - This tool is supported only in <strong>Standard, Premium</strong> or <strong>Isolated</strong> tiers because the diagnostic
+              <strong>Error</strong> - This tool is supported only in <strong>Standard, Premium</strong> or <strong>Isolated</strong>
+              tiers because the diagnostic
               tools require the Always-On setting to be enabled to collect data.
             </div>
           </div>
@@ -25,17 +28,19 @@
           <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
           Checking if the WebApp is running in a supported Tier
         </div>
-        <div *ngIf="!checkingSupportedTier && supportedTier && !alwaysOnEnabled">
+        <div *ngIf="!checkingSupportedTier && (supportedTier || !checkingSkuSucceeded) && !alwaysOnEnabled">
           <div class="focus-box focus-box-warning">
             <div>
-              <strong>Error</strong> - We determined that the web app does not have Always-On enabled and due to these the diagnostic
-              tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the properties
+              <strong>Error</strong> - We determined that the web app does not have Always-On enabled and due to these
+              the diagnostic
+              tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the
+              properties
               of the web app and then configure mitigation tools.
             </div>
           </div>
         </div>
 
-        <div *ngIf="alwaysOnEnabled && supportedTier && !checkingSupportedTier && customAction != null">
+        <div *ngIf="alwaysOnEnabled && (supportedTier || !checkingSkuSucceeded) && !checkingSupportedTier && customAction != null">
           <div class="row">
             <div class="detail-cards">
               <ng-container *ngFor="let item of Diagnosers;let i = index">
@@ -51,20 +56,31 @@
             Tool Options
           </div>
           <div class="row diagnostic-options">
-            <div style="margin-top: 10px;">
-              Configure additional options that control how the diagnostic tools chosen above should behave:
+            <div class="row">
+              <div style="margin-top: 10px;">
+                Configure additional options that control how the diagnostic tools chosen above should behave:
+              </div>
+              <div class="col-sm-3">
+                <ng-container *ngFor="let option of DiagnoserOptions">
+                  <div class="radio">
+                    <label>
+                      <input type="radio" name="optradio" [checked]="diagnoserOption.option === option.option" [value]="option.option"
+                        (change)="chooseDiagnoserAction(option)"> {{ option.option }}
+                    </label>
+                  </div>
+                </ng-container>
+              </div>
+              <div class="col-sm-9">
+                <div class="diagnoser-option"> {{ diagnoserOption.Description}} </div>
+              </div>
             </div>
-            <div class="col-sm-3">
-              <ng-container *ngFor="let option of DiagnoserOptions">
-                <div class="radio">
-                  <label>
-                    <input type="radio" name="optradio" [checked]="diagnoserOption.option === option.option" [value]="option.option" (change)="chooseDiagnoserAction(option)"> {{ option.option }}
-                  </label>
-                </div>
-              </ng-container>
-            </div>
-            <div class="col-sm-9">
-              <div class="diagnoser-option"> {{ diagnoserOption.Description}} </div>
+            <div class="row" style="margin-bottom: 5px; margin-left: 5px">
+              <div class="alert-section alert-danger" *ngIf="showDiagnoserOptionWarning">
+                You have chosen a tool option that does not restart the process. This can cause
+                auto-healing actions to kick in multiple times thus generating a lot of data. It is
+                recommended to choose <strong>CollectKillAnalyze</strong> option to ensure that the process gets
+                restarted after collecting data.
+              </div>
             </div>
           </div>
         </div>
@@ -77,7 +93,8 @@
             <input style="width:400px" type="text" id="executable" aria-describedby="executableHelp" (input)="updateCustomActionExe($event.target.value)"
               [ngModel]="customActionExe" placeholder="for e.g. d:\home\data\anycustomexe.exe">
             <div>
-              <small id="executableHelp" class="form-text text-muted">This process will be launched when the above mentioned triggers are met</small>
+              <small id="executableHelp" class="form-text text-muted">This process will be launched when the above
+                mentioned triggers are met</small>
             </div>
           </div>
         </div>
@@ -91,12 +108,14 @@
       </div>
     </div>
 
-    <div *ngIf="customActionType == 'Custom' || ( alwaysOnEnabled && supportedTier && !checkingSupportedTier)" style="margin-top:15px;margin-left:15px">
+    <div *ngIf="customActionType == 'Custom' || ( alwaysOnEnabled && (supportedTier || !checkingSkuSucceeded) && !checkingSupportedTier)" style="margin-top:15px;margin-left:15px">
       Action chosen:
-      <span *ngIf="customActionType === 'Diagnostics'" class="final-action">D:\home\data\DaaS\bin\DaasConsole.exe -{{diagnoserOption.option}} "{{diagnoser.Name}}" 60</span>
-      <span *ngIf="customActionType === 'Custom'" class="final-action">{{this.customActionExe}} {{this.customActionParams}} </span>
+      <span *ngIf="customActionType === 'Diagnostics'" class="final-action">D:\home\data\DaaS\bin\DaasConsole.exe
+        -{{diagnoserOption.option}} "{{diagnoser.Name}}" 60</span>
+      <span *ngIf="customActionType === 'Custom'" class="final-action">{{this.customActionExe}}
+        {{this.customActionParams}} </span>
       <div class="custom-action-note">
-        <strong>Note:</strong> The custom action is executed only once during the lifetime of the worker process
+        <strong>Note:</strong> The custom action is executed <strong>each time</strong> the auto-healing condition is met in the process
       </div>
       <div style="margin-top:10px;margin-bottom: 10px">
         <button type="button" class="btn btn-primary btn-sm" (click)="saveCustomAction()">Save</button>

--- a/AngularApp/src/app/auto-healing/autohealing.component.css
+++ b/AngularApp/src/app/auto-healing/autohealing.component.css
@@ -39,7 +39,6 @@
 .tile:hover {
     -webkit-box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, .2);
     box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, .2);
-    margin: 0 2px
 }
 
 .icon-template {

--- a/AngularApp/src/app/shared/components/daas/daas-validator.component.html
+++ b/AngularApp/src/app/shared/components/daas/daas-validator.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!checkingSupportedTier && !supportedTier">
+<div *ngIf="!checkingSupportedTier && checkingSkuSucceeded && !supportedTier">
   <div class="focus-box focus-box-warning" style="margin-top:20px;margin-left:10px">
     <div>
       <strong>Error</strong> - This tool is supported only on <b>Standard, Premium </b> and <b>Isolated</b> SKU's only with <strong>AlwaysOn</strong> setting enabled to TRUE
@@ -17,12 +17,12 @@
   </div>
 </div>
 
-<div *ngIf="!checkingSupportedTier && supportedTier && !alwaysOnEnabled">
+<div *ngIf="!checkingSupportedTier && (supportedTier || !checkingSkuSucceeded) && !alwaysOnEnabled">
   <div class="focus-box focus-box-warning">
     <div>
       <strong>Error</strong> - We determined that the web app does not have Always-On enabled and due to these the diagnostic
-      tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the properties
-      of the web app and then run these tools.
+      tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the Application Settings
+      for the web app and then run these tools.
     </div>
   </div>
 </div>

--- a/AngularApp/src/app/shared/components/daas/daas-validator.component.ts
+++ b/AngularApp/src/app/shared/components/daas/daas-validator.component.ts
@@ -17,6 +17,7 @@ export class DaasValidatorComponent implements OnInit {
   @Output() DaasValidated: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   supportedTier: boolean = false;
+  checkingSkuSucceeded: boolean = false;
   diagnoserWarning: string = "";
   daasRunnerJobRunning: boolean = true;
   checkingDaasWebJobStatus: boolean = false;
@@ -57,15 +58,24 @@ export class DaasValidatorComponent implements OnInit {
       let serverFarm = results[0];
       this.alwaysOnEnabled = results[1];
       let diagnosers: DiagnoserDefinition[] = results[2];
-      if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
-        this.supportedTier = true;
-      }
-      else {
-        return;
+
+      if (serverFarm != null) {
+        this.checkingSkuSucceeded = true;
+        if (serverFarm.sku.tier === "Standard" || serverFarm.sku.tier.indexOf("Premium") > -1 || serverFarm.sku.tier === "Isolated") {
+          this.supportedTier = true;
+        }
+        else {
+          return;
+        }
       }
 
       if (!this.alwaysOnEnabled) {
         return;
+      }
+      else {
+        // If AlwaysOn is set to TRUE, we can be sure that the site is running in a 
+        // supported tier as AlwaysOn is not available in BASIC SKU
+        this.supportedTier = true;
       }
 
       if (this.error === "") {

--- a/AngularApp/src/app/shared/components/daas/daas.component.html
+++ b/AngularApp/src/app/shared/components/daas/daas.component.html
@@ -15,15 +15,17 @@
                         Instance(s):
                         <div class="tool-tip">
                             <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
-                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for the instances to update if you recently Scaled-Up or Scaled-down
+                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for
+                                the instances to update if you recently Scaled-Up or Scaled-down
                                 the App Service Plan.
                             </span>
                         </div>
                     </td>
                     <td class="highlight-blue">
                         <div *ngFor="let instance of instancesSelected;let i = index">
-                            <input type="checkbox" [disabled]="sessionInProgress" value="{{ instance.InstanceName }}" name="{{ instance.InstanceName }}"
-                                [(ngModel)]="instancesSelected[i].Selected" /> {{ instance.InstanceName}}
+                            <input type="checkbox" [disabled]="sessionInProgress" value="{{ instance.InstanceName }}"
+                                name="{{ instance.InstanceName }}" [(ngModel)]="instancesSelected[i].Selected" /> {{
+                            instance.InstanceName}}
                         </div>
                     </td>
                 </tr>
@@ -35,24 +37,43 @@
                     {{ operationStatus }}
                 </div>
 
-                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted" class="btn btn-primary"
-                    (click)="collectDiagnoserData()">Collect {{ diagnoserName }}</button>
+                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
+                    class="btn btn-primary" (click)="collectDiagnoserData()">Collect {{ diagnoserName }}</button>
             </div>
 
             <div class="status-box" *ngIf="sessionInProgress">
-                <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
-                    <option *ngFor="let instancestatus of instancesStatus | mapValues" value={{instancestatus.key}}>
-                        {{instancestatus.key}}
-                    </option>
-                </select>
+                <div *ngIf="!cancellingSession">
+                    <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
+                        <option *ngFor="let instancestatus of instancesStatus | mapValues" value={{instancestatus.key}}>
+                            {{instancestatus.key}}
+                        </option>
+                    </select>
 
-                <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]="WizardStepStatus"></step-wizard>
+                    <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]="WizardStepStatus"></step-wizard>
+                </div>
 
+                <!-- Uncomment the Cancel button once DaaS logic to fix cancellation is corrected -->
+                <!-- <button class="btn btn-primary btn-sm" (click)="cancellationRequested=true" *ngIf="!cancellationRequested">Cancel</button> -->
+                <div *ngIf="cancellationRequested && !cancellingSession">
+                    <div><strong>Caution:</strong> Based on the stage of the diagnostic tool that you are running, cancelling a session might end
+                        up killing the process serving the app and this can impact in-flight requests. Are you sure you want to continue ?</div>
+                    <button type="button" class="btn btn-default btn-xs" (click)="cancelSession()">
+                        Yes
+                    </button>
+                    <button type="button" class="btn btn-default btn-xs" (click)="cancellationRequested=false">
+                        No
+                    </button>
+                </div>
+                <div *ngIf="cancellingSession">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Cancelling session...
+                </div>
             </div>
         </div>
         <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
             <div *ngIf="error.code === 'GatewayTimeout'">
-                <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to any diagnostic
+                <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to
+                any diagnostic
                 calls under high CPU situations. Please retry this investigation after some time.
             </div>
             <div *ngIf="error.code != 'GatewayTimeout'">
@@ -60,7 +81,8 @@
             </div>
         </div>
         <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="instancesChanged">
-            <strong>Error</strong> - We detected that instances serving the Web App has changed so please re-select the instances
+            <strong>Error</strong> - We detected that instances serving the Web App has changed so please re-select the
+            instances
             and run diagnostics again.
         </div>
     </div>

--- a/AngularApp/src/app/shared/components/daas/daas.component.ts
+++ b/AngularApp/src/app/shared/components/daas/daas.component.ts
@@ -54,6 +54,8 @@ export class DaasComponent implements OnInit, OnDestroy {
     instancesChanged: boolean = false;
 
     daasValidated: boolean = false;
+    cancellingSession:boolean = false;
+    cancellationRequested:boolean = false;
 
     constructor(private _serverFarmService: ServerFarmDataService, private _siteService: SiteService, private _daasService: DaasService, private _windowService: WindowService, private _logger: AvailabilityLoggingService) {
     }
@@ -319,5 +321,13 @@ export class DaasComponent implements OnInit, OnDestroy {
         }
         this.Reports = [];
 
+    }
+
+    cancelSession(): void {
+        this.cancellingSession = true;
+        this._daasService.cancelDaasSession(this.siteToBeDiagnosed, this.sessionId).subscribe(resp=>{
+            this.cancellingSession = false;
+            this.sessionInProgress = false;
+        });
     }
 }

--- a/AngularApp/src/app/shared/components/daas/profiler.component.html
+++ b/AngularApp/src/app/shared/components/daas/profiler.component.html
@@ -15,15 +15,17 @@
                         Instance(s):
                         <div class="tool-tip">
                             <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
-                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for the instances to update if you recently Scaled-Up or Scaled-down
+                            <span class="tool-tip-text" style="width:250px;left:5px"> It may take up to 10 minutes for
+                                the instances to update if you recently Scaled-Up or Scaled-down
                                 the App Service Plan.
                             </span>
                         </div>
                     </td>
                     <td class="highlight-blue">
                         <div *ngFor="let instance of instancesSelected;let i = index">
-                            <input type="checkbox" [disabled]="sessionInProgress" value="{{ instance.InstanceName }}" name="{{ instance.InstanceName }}"
-                                [(ngModel)]="instancesSelected[i].Selected" /> {{ instance.InstanceName}}
+                            <input type="checkbox" [disabled]="sessionInProgress" value="{{ instance.InstanceName }}"
+                                name="{{ instance.InstanceName }}" [(ngModel)]="instancesSelected[i].Selected" /> {{
+                            instance.InstanceName}}
                         </div>
                     </td>
                 </tr>
@@ -35,19 +37,24 @@
                     {{ operationStatus }}
                 </div>
 
-                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted" class="btn btn-primary"
-                    (click)="collectProfilerTrace()">Collect Profiler Trace</button>
+                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
+                    class="btn btn-primary" (click)="collectProfilerTrace()">Collect Profiler Trace</button>
 
                 <div style="margin-top:5px">
-                    <input type="checkbox" [(ngModel)]="collectStackTraces" [disabled]="sessionInProgress" /> Add thread report
+                    <input type="checkbox" [(ngModel)]="collectStackTraces" [disabled]="sessionInProgress" /> Add
+                    thread report
                     <div class="tool-tip" style="z-index:2">
                         <i class="fa fa-info-circle" style="color:rgb(84, 143, 255)"></i>
-                        <span class="tool-tip-text">If this option is enabled, then along with the profiler trace, a thread report of all the threads
-                            in the process is also collected at the end of the profiler trace. This is useful especially
-                            if you are troubleshooting totally hung processes, deadlocks or requests taking more than 60
+                        <span class="tool-tip-text">If this option is enabled, then along with the profiler trace, a
+                            thread report of all the threads
+                            in the process is also collected at the end of the profiler trace. This is useful
+                            especially
+                            if you are troubleshooting totally hung processes, deadlocks or requests taking more than
+                            60
                             seconds. This will pause your process for a few seconds until the thread dump is generated.
                             <div style="margin-top:10px">
-                                CAUTION: This option is NOT recommended if you are experiencing high CPU on the instance.
+                                CAUTION: This option is NOT recommended if you are experiencing high CPU on the
+                                instance.
                             </div>
                         </span>
                     </div>
@@ -56,19 +63,27 @@
             </div>
 
             <div class="status-box" *ngIf="sessionInProgress">
-                <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
-                    <option *ngFor="let instancestatus of instancesStatus | mapValues" value={{instancestatus.key}}>
-                        {{instancestatus.key}}
-                    </option>
-                </select>
+                <div *ngIf="!cancellingSession">
+                    <select id="selectInstances" (change)="onInstanceChange($event.target.value)">
+                        <option *ngFor="let instancestatus of instancesStatus | mapValues" value={{instancestatus.key}}>
+                            {{instancestatus.key}}
+                        </option>
+                    </select>
 
-                <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]="WizardStepStatus"></step-wizard>
-
+                    <step-wizard [CurrentStep]="sessionStatus" [WizardSteps]="WizardSteps" [WizardStepStatus]="WizardStepStatus"></step-wizard>
+                </div>
+                <!-- Uncomment the Cancel button once DaaS logic to fix cancellation is corrected -->
+                <!-- <button class="btn btn-primary btn-sm" (click)="cancelSession()" *ngIf="!cancellingSession">Cancel</button> -->
+                <div *ngIf="cancellingSession">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    Cancelling...
+                </div>
             </div>
         </div>
         <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="error">
             <div *ngIf="error.code === 'GatewayTimeout'">
-                <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to any diagnostic
+                <strong>Error</strong> - Failed to fetch instances for the Web App. The instance may fail to respond to
+                any diagnostic
                 calls under high CPU situations. Please retry this investigation after some time.
             </div>
             <div *ngIf="error.code != 'GatewayTimeout'">
@@ -76,7 +91,8 @@
             </div>
         </div>
         <div class="focus-box focus-box-warning" style="margin-top:20px" *ngIf="instancesChanged">
-            <strong>Error</strong> - We detected that instances serving the Web App has changed so please re-select the instances
+            <strong>Error</strong> - We detected that instances serving the Web App has changed so please re-select the
+            instances
             and run diagnostics again.
         </div>
     </div>

--- a/AngularApp/src/app/shared/components/tools/network-trace-tool/network-trace-tool.component.html
+++ b/AngularApp/src/app/shared/components/tools/network-trace-tool/network-trace-tool.component.html
@@ -26,24 +26,42 @@
             <a href='https://www.wireshark.org/'>Wireshark</a> that can open the network captures. </li>
     </ul>
 
-    <div *ngIf="!supportedTier && !checkingValidity">
+    <div *ngIf="!checkingValidity && networkTraceDisabled">
         <div class="focus-box focus-box-warning" style="margin-top:20px">
-            <div>
-                <strong>Error</strong> - This tool is supported only on Web App running on Dedicated SKU's and not
-                connected to Azure Virtual networks
+            <div *ngIf="traceDisabledReason === NetworkTraceDisabledReasonType.AppNotOnDedicatedTier">
+                <strong>Error</strong> - This tool is supported only on App running on Dedicated SKU's (Basic,
+                Standard, Premium and PremiumV2)
             </div>
-        </div>
-    </div>
-
-    <div *ngIf="errorMessage">
-        <div class="focus-box focus-box-warning" style="margin-top:20px">
-            <div>
+            <div *ngIf="traceDisabledReason === NetworkTraceDisabledReasonType.AppConnectedToVNet">
+                <strong>Error</strong> - This tool is not supported only on App connected to Azure Virtual Networks
+            </div>
+            <div *ngIf="traceDisabledReason === NetworkTraceDisabledReasonType.NoPermsOnAppServicePlan">
+                <strong>Error</strong> - It appears that you do not have permissions on the App Service Plan. This
+                happens typically if you have Website Contributor access only and no permissions on the App Service
+                Plan
+            </div>
+            <div *ngIf="traceDisabledReason === NetworkTraceDisabledReasonType.AppOnAppServiceEnvironment">
+                <strong>Error</strong> - This tool is not supported only on Web App that are part of App Service
+                Environments
+            </div>
+            <div *ngIf="errorMessage !=''">
                 <strong>Error</strong> - {{ errorMessage }}
             </div>
         </div>
     </div>
 
-    <div *ngIf="supportedTier && !errorMessage && status < NetworkTraceStatus.Started">
+    <div class="col" *ngIf="checkingValidity">
+        <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+        Checking App configuration...
+    </div>
+
+    <div *ngIf="!checkingValidity && !networkTraceDisabled && status < NetworkTraceStatus.Started">
+        
+        <div class="pastNetworkTracesMessage">
+            View past collected Network traces in <strong>{{traceLocation}}</strong> folder in <a href='https://{{scmPath}}'>Kudu
+                Console</a> for the App.
+        </div>
+
         <div style="margin-top:20px;">
             Choose duration to collect the Network Trace
             <select [(ngModel)]="duration" [disabled]="status >= NetworkTraceStatus.Starting">
@@ -57,10 +75,6 @@
         </div>
 
         <div style="margin-top:10px">
-            <div class="col" *ngIf="checkingValidity">
-                <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                Checking App configuration...
-            </div>
             <button [disabled]="status >= NetworkTraceStatus.Starting" class="btn btn-primary" (click)="collectNetworkTrace()">Collect
                 Network Trace</button>
         </div>
@@ -73,7 +87,9 @@
                 </div>
                 <div *ngIf="durationRemaining > 0" style="display: table-cell;">
                     Network trace started and will automatically stop after
-                    <strong>{{ durationRemaining }}</strong> seconds.
+                    <strong>{{ durationRemaining }}</strong> seconds. Network traces collected will be available in
+                    <strong>{{traceLocation}}</strong> folder in <a href='https://${this.scmPath}'>Kudu Console</a> for
+                    the App.
                 </div>
                 <div *ngIf="durationRemaining <= 0" style="display: table-cell;">
                     Stopping trace and collecting files (Note:This step can take a few minutes to complete)

--- a/AngularApp/src/app/shared/components/tools/styles/daasstyles.css
+++ b/AngularApp/src/app/shared/components/tools/styles/daasstyles.css
@@ -33,3 +33,11 @@ td {
 .wizardcontainer {
     width:60%;
 }
+
+.pastNetworkTracesMessage{
+    margin-top: 25px;
+    margin-bottom: 5px;
+    border-radius: 6px;
+    padding: 7px;
+    background-color: #efefef;
+}

--- a/AngularApp/src/app/shared/services/daas.service.ts
+++ b/AngularApp/src/app/shared/services/daas.service.ts
@@ -35,6 +35,12 @@ export class DaasService {
         let resourceUri: string = this._uriElementsService.getDiagnosticsSessionsUrl(site);
         return <Observable<string>>(this._armClient.postResource(resourceUri, session, null, true));
     }
+    
+    cancelDaasSession(site: SiteDaasInfo, sessionId: string): Observable<boolean> {
+        let resourceUri: string = this._uriElementsService.getDiagnosticsSingleSessionUrl(site, sessionId, "cancel");
+        return <Observable<boolean>>(this._armClient.postResource(resourceUri, null, null, true));
+    }
+
     getDaasSessionsWithDetails(site: SiteDaasInfo): Observable<Session[]> {
         let resourceUri: string = this._uriElementsService.getDiagnosticsSessionsDetailsUrl(site, "all", true);
         return <Observable<Session[]>>this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri, null, true);
@@ -73,7 +79,7 @@ export class DaasService {
                 if (daasWebJob != null && daasWebJob.length > 0 && daasWebJob[0].properties != null) {
                     return daasWebJob[0].properties.status;
                 }
-                else{
+                else {
                     return "";
                 }
             }

--- a/AngularApp/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/src/app/shared/services/urielements.service.ts
@@ -78,7 +78,7 @@ export class UriElementsService {
         return this._getSiteResourceUrl(subscriptionId, resourceGroupName, siteName, slot) + this._virtualNetworkConnections;
     }
 
-    getDiagnosticsSingleSessionUrl(site: SiteDaasInfo, sessionId: string, detailed: boolean) {
+    getDiagnosticsSingleSessionUrl(site: SiteDaasInfo, sessionId: string, detailed: any) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsSingleSessionDetailsPath
         .replace("{sessionId}", sessionId)
         .replace("{details}", detailed.toString());


### PR DESCRIPTION
In this PR

- Ensuring user can run diagnostic tools if he is part of Website Contributor
- Improving error handling message for Network Trace component if user does not have app service plan permissions
- correcting message in AutoHealing component to call out that custom action can execute multiple times and suggesting user to choose CollectKillAnalyze option
- Autohealing component -> DAAS Tools will show properly even for Website contributor
- Added logic to implement a Cancel Session button in DAAS UI but I found that the DAAS Cancellation logic from backend needs some improvement **so leaving the Cancel button in commented mode** but adding the required code logic so this can be flipped easily when required.