### PR TITLE
Hide Legend when there are numerous sites in one server farm

### DIFF
--- a/AngularApp/src/app/shared/components/instance-view-graph/instance-view-graph.component.html
+++ b/AngularApp/src/app/shared/components/instance-view-graph/instance-view-graph.component.html
@@ -17,7 +17,7 @@
             <span class="tool-tip-text">{{description}}</span>
         </div>
     </div>
-    <div class="row" style="padding-right: 10px; height: 200px">
+    <div class="row" style="padding-right: 10px; height: 300px">
         <div class="row" style="text-align: center; padding-top:85px" *ngIf="!chartData">
             <i class="fa fa-circle-o-notch fa-2x fa-spin spin-icon" aria-hidden="true"></i>
         </div>

--- a/AngularApp/src/app/shared/components/instance-view-graph/instance-view-graph.component.ts
+++ b/AngularApp/src/app/shared/components/instance-view-graph/instance-view-graph.component.ts
@@ -12,6 +12,7 @@ import { ChartSeries, ChartType } from '../../models/chartdata';
 export class InstanceViewGraphComponent implements OnInit {
     constructor() {
         this.chartOptions = GraphHelper.getDefaultChartOptions();
+        this.chartOptions.chart.height = 300;
         this.chartType = ChartType.lineChart;
     }
 
@@ -59,6 +60,7 @@ export class InstanceViewGraphComponent implements OnInit {
     selectInstance(instance: string) {
         this.selectedInstance = instance;
         this.chartData = this.allChartData.filter((series: ChartSeries) => series.roleInstance === this.selectedInstance);
+        this.chartOptions.chart.showLegend = this.chartData.length <= 24;
         this.updateInstance.emit(this.selectedInstance);
     }
 }


### PR DESCRIPTION
This is what the customers were seeing:

![image](https://user-images.githubusercontent.com/7739017/48646696-744b5a00-e99e-11e8-96ad-52ad67f96f2f.png)

I increased the height but also hid the legend when there are too many sites so that this doesn't happen. 