### PR TITLE
Updating Nuget Packages

### DIFF
--- a/ApplensBackend/AppLensV3.csproj
+++ b/ApplensBackend/AppLensV3.csproj
@@ -14,9 +14,8 @@
     <PackageReference Include="Dapper.Contrib" Version="1.50.5" />
     <PackageReference Include="Kusto.Rest.Client" Version="1.0.10" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.6.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.4" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />


### PR DESCRIPTION
Solving these two errors:

```
warning NU1608: Detected package version outside of dependency constraint: Microsoft.ApplicationInsights.DependencyCollector 2.4.1 requires Microsoft.ApplicationInsights (= 2.4.0) but version Microsoft.ApplicationInsights 2.6.4 was resolved.
 warning NU1701: Package 'Microsoft.ApplicationInsights.Web 2.6.4' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.0'. This package may not be fully compatible with your project
```