### PR TITLE
Remove perfmon button in favor of Metrics per Instance

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -309,22 +309,6 @@ export class SiteFeatureService extends FeatureService {
         sku: Sku.NotDynamic,
         stack: '',
         item: {
-          id: 'metrics',
-          name: 'Metrics / Performance Counters',
-          category: 'Support Tools',
-          description: '',
-          featureType: FeatureTypes.Tool,
-          clickAction: this._createFeatureAction('metrics', 'Support Tools', () => {
-            this._portalActionService.openMdmMetricsBlade();
-          })
-        }
-      },
-      {
-        appType: AppType.WebApp,
-        platform: OperatingSystem.windows,
-        sku: Sku.NotDynamic,
-        stack: '',
-        item: {
           id: SupportBladeDefinitions.MetricPerInstance.Identifier,
           name: 'Metrics per Instance (Apps)',
           category: 'Support Tools',

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/support-tools/support-tools.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/support-tools/support-tools.component.ts
@@ -67,16 +67,6 @@ export class SupportToolsComponent {
         });
 
         this.supportTools.push({
-            title: 'Performance Counters',
-            description: '',
-            enabled: true,
-            action: () => {
-                this.logToolUse(SupportBladeDefinitions.MetricPerInstance.Identifier);
-                this._portalActionService.openMdmMetricsBlade();
-            }
-        });
-
-        this.supportTools.push({
             title: 'Metrics per Instance (App Service Plan)',
             description: this.hasReadAccessToServerFarm ? 'View Metrics for applications on your App Service Plan' :
                 'You do not have access to the the app service plan to which this site belongs',

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-action.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-action.service.ts
@@ -49,18 +49,6 @@ export class PortalActionService {
         this._portalService.openBlade(bladeInfo, 'troubleshoot');
     }
 
-    public openMdmMetricsBlade() {
-        const bladeInfo = {
-            detailBlade: 'MetricsBladeV2',
-            extension: 'Microsoft_Azure_Monitoring',
-            detailBladeInputs: {
-                id: this.currentSite.id
-            }
-        };
-
-        this._portalService.openBlade(bladeInfo, 'troubleshoot');
-    }
-
     public openMdmMetricsV3Blade(resourceUri?: string) {
         const bladeInfo = {
             detailBlade: 'MetricsBladeV3',


### PR DESCRIPTION
Deprecating Performance Counters button since we need to get rid of references to v2 metrics blade in favor of v3. 