### PR TITLE
Adding a warning for diagnostics when customers select all instances

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas.component.html
@@ -53,8 +53,21 @@
                     {{ operationStatus }}
                 </div>
 
-                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
-                    class="btn btn-primary" (click)="collectDiagnoserData()">Collect {{ diagnoserName }}</button>
+                <button [disabled]="getSelectedInstanceCount() === 0 || sessionInProgress || operationInProgress || retrievingInstancesFailed || showInstanceWarning" [hidden]="sessionCompleted"
+                    class="btn btn-primary" (click)="collectDiagnoserData(true)">Collect {{ diagnoserName }}</button>
+                    <div *ngIf="getSelectedInstanceCount() === 0" style="font-size: smaller;color: red;margin-top: 5px;margin-right: 20px;">* Choose at least one instance</div>
+            </div>
+            <div *ngIf="showInstanceWarning"  style="margin-top: 10px;padding: 15px;">
+                <div style="margin-bottom:10px"><strong>CAUTION:</strong> You are choosing to run diagnostics on more than 50% of the instances
+                    serving your app. If you already know a particular instance is misbehaving, you can choose to run
+                    Diagnostic only on that instance. Running diagnostic tools on all instances simultaneously can cause
+                    significant downtime for your web app. Are you sure you want to continue ?</div>
+                <button type="button" class="btn btn-default btn-xs" (click)="collectDiagnoserData(false)">
+                    Yes
+                </button>
+                <button type="button" class="btn btn-default btn-xs" (click)="showInstanceWarning = false">
+                    No
+                </button>
             </div>
 
             <div class="status-box" *ngIf="sessionInProgress">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
@@ -105,7 +105,7 @@
                 <button [disabled]="getSelectedInstanceCount() === 0 || sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
                     class="btn btn-primary" (click)="collectProfilerTrace()">Collect
                     Profiler Trace</button>
-                    <div *ngIf="getSelectedInstanceCount() === 0" style="font-size: smaller;color: red;margin-top: 5px;margin-right: 20px;">* Choose at least one instance</div>
+                    <div *ngIf="getSelectedInstanceCount() === 0" style="font-size: smaller;color: red;margin-top: 5px;margin-right: 10px;">* Choose at least one instance</div>
                 <div *ngIf="!isAspnetCore" style="margin-top:5px">
                     <input type="checkbox" [attr.aria-label]="'Add thread report'" [(ngModel)]="collectStackTraces"
                         [disabled]="sessionInProgress" /> Add

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
@@ -102,10 +102,10 @@
                     {{ operationStatus }}
                 </div>
 
-                <button [disabled]="sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
+                <button [disabled]="getSelectedInstanceCount() === 0 || sessionInProgress || operationInProgress || retrievingInstancesFailed" [hidden]="sessionCompleted"
                     class="btn btn-primary" (click)="collectProfilerTrace()">Collect
                     Profiler Trace</button>
-
+                    <div *ngIf="getSelectedInstanceCount() === 0" style="font-size: smaller;color: red;margin-top: 5px;margin-right: 20px;">* Choose at least one instance</div>
                 <div *ngIf="!isAspnetCore" style="margin-top:5px">
                     <input type="checkbox" [attr.aria-label]="'Add thread report'" [(ngModel)]="collectStackTraces"
                         [disabled]="sessionInProgress" /> Add

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.ts
@@ -62,7 +62,7 @@ export class ProfilerComponent extends DaasComponent implements OnInit, OnDestro
             this.diagnoserName = 'CLR Profiler';
         }
 
-        this.collectDiagnoserData();
+        this.collectDiagnoserData(false);
     }
 
     initWizard(): void {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5299838/52842344-a6f71280-30b3-11e9-867e-6b2a57f7a709.png)

@stevenernst131 - would appreciate if you validate the english of this sentence too :) 

_CAUTION: You are choosing to run diagnostics on more than 50% of the instances serving your app. If you already know a particular instance is misbehaving, you can choose to run Diagnostic only on that instance. Running diagnostic tools on all instances simultaneously can cause significant downtime for your web app. Are you sure you want to continue ?_