### PR TITLE
Allow only enabled resource types in AppLens and make those routes case insensitive 

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/models/resources.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/resources.ts
@@ -28,6 +28,10 @@ export interface ArmResource {
     resourceName: string;
 }
 
+export interface ResourceServiceInputsJsonResponse{
+    enabledResourceTypes : ResourceServiceInputs[];
+}
+
 export interface ResourceServiceInputs {
     resourceType: string;
     templateFileName: string;


### PR DESCRIPTION
Allow only enabled resource types in AppLens and make those routes case insensitive. If some random resource is entered, the following error message will show up.

![image](https://user-images.githubusercontent.com/20996681/53665907-92715900-3c21-11e9-9b86-26ea2f0f3b8a.png)
