### PR TITLE
Fix scrollbars coming in Edge while the component is loading

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/cpu-monitoring-tool/cpu-monitoring-tool.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/cpu-monitoring-tool/cpu-monitoring-tool.component.html
@@ -2,7 +2,7 @@
   <div class="header1">{{ title }}<span class="preview">PREVIEW</span></div>
 
   <span>{{ description }}</span>
-  <div style="margin-top:10px">
+  <div style="margin-top:10px;margin-bottom: 5px">
     <cpu-monitoring [siteToBeDiagnosed]="siteToBeDiagnosed" [scmPath]="scmPath"></cpu-monitoring>
   </div>
 </div>


### PR DESCRIPTION
Without this margin there is a wobbling scrollbar that is coming in Edge which is really annoying. In most of the components we have some text below the animation so this effect is not visible.