### PR TITLE
Decommission ZRay feature

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/availability/tools-menu/tools-menu.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/availability/tools-menu/tools-menu.component.ts
@@ -131,16 +131,6 @@ export class ToolsMenuComponent  {
         });
 
         this.premiumTools.push({
-            title: "PHP Debugging",
-            description: "",
-            enabled: true,
-            action: () => { 
-                this.logToolUse("PHPDebugging");
-                this._portalActionService.openPHPDebuggingBlade();
-            }
-        });
-
-        this.premiumTools.push({
             title: "Security Scanning",
             description: "",
             enabled: true,

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -117,7 +117,7 @@ export class SiteFeatureService extends FeatureService {
       
       if (data && data.value) {
         let premierAddOns: any[] = data.value;
-        let zRayAddOn = premierAddOns.find(x => (x.plan && (x.plan.product == "z-ray")));
+        let zRayAddOn = premierAddOns.find(x => (x.plan && (x.plan.product === "z-ray")));
         if (zRayAddOn) {
           this.premiumTools.push({
             appType: AppType.WebApp,

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -33,7 +33,7 @@ export class SiteFeatureService extends FeatureService {
       }
       this.addDiagnosticTools(startupInfo.resourceId);
       this.addProactiveTools(startupInfo.resourceId);
-      this.addPremiumTools();
+      this.addPremiumTools(startupInfo.resourceId);
     });
   }
 
@@ -93,24 +93,8 @@ export class SiteFeatureService extends FeatureService {
     ];
   }
 
-  addPremiumTools() {
+  addPremiumTools(resourceId: string) {
     this.premiumTools = <SiteFilteredItem<Feature>[]>[
-      {
-        appType: AppType.WebApp,
-        platform: OperatingSystem.windows,
-        sku: Sku.NotDynamic,
-        stack: '',
-        item: {
-          id: 'zray',
-          name: 'PHP Debugging',
-          category: 'Premium Tools',
-          description: '',
-          featureType: FeatureTypes.Tool,
-          clickAction: this._createFeatureAction('zray', 'Premium Tools', () => {
-            this._portalActionService.openPHPDebuggingBlade();
-          })
-        }
-      },
       {
         appType: AppType.WebApp,
         platform: OperatingSystem.windows,
@@ -128,6 +112,36 @@ export class SiteFeatureService extends FeatureService {
         }
       }
     ];
+
+    this._resourceService.getSitePremierAddOns(resourceId).subscribe(data => {
+      
+      if (data && data.value) {
+        let premierAddOns: any[] = data.value;
+        let zRayAddOn = premierAddOns.find(x => (x.plan && (x.plan.product == "z-ray")));
+        if (zRayAddOn) {
+          this.premiumTools.push({
+            appType: AppType.WebApp,
+            platform: OperatingSystem.windows,
+            sku: Sku.NotDynamic,
+            stack: '',
+            item: {
+              id: 'zray',
+              name: 'PHP Debugging',
+              category: 'Premium Tools',
+              description: '',
+              featureType: FeatureTypes.Tool,
+              clickAction: this._createFeatureAction('zray', 'Premium Tools', () => {
+                const site: Site = <Site>this._resourceService.resource.properties;
+                let scmHostName = site.enabledHostNames.find(h => h.indexOf('.scm.') > 0);
+                if (scmHostName) {
+                  window.open(`https://${scmHostName}/ZendServer`, '_blank');
+                }
+              })
+            }
+          });
+        }
+      }
+    });
   }
 
   addProactiveTools(resourceId: string) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -6,6 +6,7 @@ import { AppAnalysisService } from '../../../shared/services/appanalysis.service
 import { ArmService } from '../../../shared/services/arm.service';
 import { Sku } from '../../../shared/models/server-farm';
 import { IDiagnosticProperties } from '../../../shared/models/diagnosticproperties';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class WebSitesService extends ResourceService {
@@ -36,6 +37,10 @@ export class WebSitesService extends ResourceService {
         && (this.sku & Sku.Paid) > 0
         && (this.appType & AppType.WebApp) > 0
         && (this.platform & (OperatingSystem.windows | OperatingSystem.linux)) > 0;
+    }
+
+    public getSitePremierAddOns(resourceUri: string): Observable<any> {
+        return this._armService.getArmResource(`${resourceUri}/premieraddons`, '2018-02-01');
     }
 
     protected makeWarmUpCalls() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/support-tools/support-tools.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/support-tools/support-tools.component.ts
@@ -108,16 +108,6 @@ export class SupportToolsComponent {
         });
 
         this.premiumTools.push({
-            title: 'PHP Debugging',
-            description: '',
-            enabled: true,
-            action: () => {
-                this.logToolUse('PHPDebugging', 'Premium Tools');
-                this._portalActionService.openPHPDebuggingBlade();
-            }
-        });
-
-        this.premiumTools.push({
             title: 'Security Scanning',
             description: '',
             enabled: true,

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-action.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-action.service.ts
@@ -110,19 +110,6 @@ export class PortalActionService {
         this._portalService.openBlade(bladeInfo, 'troubleshoot');
     }
 
-    public openPHPDebuggingBlade() {
-        const resourceUriSplit = this.currentSite.id.split('/');
-
-        const bladeInfo = {
-            detailBlade: 'ZendZRayBlade',
-            detailBladeInputs: {
-                WebsiteId: this.getWebsiteId(resourceUriSplit[2], resourceUriSplit[4], resourceUriSplit[8]),
-            }
-        };
-
-        this._portalService.openBlade(bladeInfo, 'troubleshoot');
-    }
-
     public openTifoilSecurityBlade() {
         const resourceUriSplit = this.currentSite.id.split('/');
 


### PR DESCRIPTION
## Decommission ZRay Feature

### Description
Azure app services is decommissioning Z-Ray for web apps. Starting Monday (3/11), no new web apps will be able to install this add-on. The existing sites which has this add-on will continue to use it till some time. These sites have been proactively notified.

### Changes on our Side
- For sites which doesn't use Zray, the option to enable it (shown as `PHP Debugging` in `Diagnostic Tools`) will not show up
- If the site has Zray premier add-on enabled, the option will show up and instead of opening Ibiza blade(which is also getting removed), customers will be redirected to ZRay Site Extension in Kudu.
