### PR TITLE
Enable Chat for More Support Topics in Linux

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/liveChatSettings.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/liveChatSettings.ts
@@ -40,7 +40,8 @@ export class LiveChatSettings {
         '32570954',     //Availability and Performance/Web App Restarted
         '32440123',     //Configuration and Management/Configuring SSL
         '32440122',     //Configuration and Management/Configuring custom domain names
-        '32542208'      //Configuration and Management/Backup and Restore
+        '32542208',     //Configuration and Management/Backup and Restore
+        '32542210'      //Configuration and Management/IP Configuration
       ]
     };
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/liveChatSettings.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/liveChatSettings.ts
@@ -37,6 +37,10 @@ export class LiveChatSettings {
       ],
       "Azure Web App(Linux)": [
         '32542218',     //Availability and Performance/Web App Down
+        '32570954',     //Availability and Performance/Web App Restarted
+        '32440123',     //Configuration and Management/Configuring SSL
+        '32440122',     //Configuration and Management/Configuring custom domain names
+        '32542208'      //Configuration and Management/Backup and Restore
       ]
     };
 


### PR DESCRIPTION
#### Enabling Chat on Following Support Topics for Linux on 3/11:

| Support Topics |
|---------------------|
| Web App Restarted |
| Configuring SSL     |
| Configuring Domains |
| Backup and Restore  |

Will wait for `IP Configuration` support topic as the detector needs to be enabled/modified for Linux Web App