### PR TITLE
Passing the x-ms-internal-view header now for ARM resource types

### DIFF
--- a/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
+++ b/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
@@ -116,6 +116,7 @@ namespace AppLensV3
                     {
                         var requestMessage = new HttpRequestMessage(HttpMethod.Post, "api/invoke");
                         requestMessage.Headers.Add("x-ms-path-query", path);
+                        requestMessage.Headers.Add("x-ms-internal-view", internalView.ToString());
                         requestMessage.Headers.Add("x-ms-verb", method);
                         requestMessage.Content = new StringContent(body ?? string.Empty, Encoding.UTF8, "application/json");
                         if (additionalHeaders != null)


### PR DESCRIPTION
Passing the x-ms-internal-view header now for ARM resource types in DiagnosticRoleClient Execute method. AddAscInsight was not working due to this missing header for Logic Apps and AKS.