### PR TITLE
Incorrect order of enum in server side vs client side caused UI error

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -86,9 +86,9 @@ export enum RenderingType {
     DetectorList,
     DropDown,
     Cards,
+    Solution,
     Guage,
-    Form,
-    Solution
+    Form
 }
 
 export enum TimeSeriesType {


### PR DESCRIPTION
I had merge conflicts when merging forms-ui branch to master, while resolving it the enums got out of order causing solution to render instead of form. 