### PR TITLE
Time range check on detectors

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
@@ -10,7 +10,11 @@
           <input class="date-input" [(ngModel)]="endTime" (keyup.enter)="setManualDate()"/>
       </div>
     </div> -->
-
+    <div class="control-group" *ngIf="timeDiffError !==''">
+      <div class="control control-static errorMessage">
+        Error : {{timeDiffError}}
+      </div>
+    </div>
     <div class="control-group" *ngIf="detectorControlService.duration">
       <div (click)="detectorControlService.moveBackwardDuration()" class="control">
         <i class="fa fa-chevron-left"></i>
@@ -23,7 +27,8 @@
     </div>
 
     <div class="control-group">
-      <div *ngFor="let duration of detectorControlService.durationSelections | internal:isInternal" class="control" (click)="detectorControlService.selectDuration(duration)"
+      <div *ngFor="let duration of detectorControlService.durationSelections | internal:isInternal" class="control"
+        (click)="detectorControlService.selectDuration(duration)"
         [class.control-selected]="detectorControlService.duration === duration">{{duration.displayName}}</div>
     </div>
 
@@ -41,11 +46,11 @@
     </div>
 
     <div class="control-group" *ngIf="isInternal">
-        <div class="control" (click)="detectorControlService.toggleInternalExternal()">
-          <span *ngIf="detectorControlService.isInternalView">Internal</span>
-          <span *ngIf="!detectorControlService.isInternalView">External</span>
-        </div>
+      <div class="control" (click)="detectorControlService.toggleInternalExternal()">
+        <span *ngIf="detectorControlService.isInternalView">Internal</span>
+        <span *ngIf="!detectorControlService.isInternalView">External</span>
       </div>
+    </div>
 
     <div class="control-group">
       <div class="control" (click)="detectorControlService.refresh()">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
@@ -10,11 +10,7 @@
           <input class="date-input" [(ngModel)]="endTime" (keyup.enter)="setManualDate()"/>
       </div>
     </div> -->
-    <div class="control-group" *ngIf="timeDiffError !==''">
-      <div class="control control-static errorMessage">
-        Error : {{timeDiffError}}
-      </div>
-    </div>
+    
     <div class="control-group" *ngIf="detectorControlService.duration">
       <div (click)="detectorControlService.moveBackwardDuration()" class="control">
         <i class="fa fa-chevron-left"></i>
@@ -57,5 +53,11 @@
         <i class="fa fa-refresh"></i>
       </div>
     </div>
+  </div>
+</div>
+
+<div class="outer-container" *ngIf="timeDiffError !==''">
+  <div class=" errorMessage">
+      <strong>Error :</strong> {{timeDiffError}}<span style='vertical-align:super'>*</span>
   </div>
 </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.scss
@@ -1,3 +1,5 @@
+@import "../../../../../app-service-diagnostics/src/styles/main.scss";
+
 .control-container {
     display: flex;
 }
@@ -52,6 +54,5 @@
 }
 
 .errorMessage {
-    background-color: darkred;
-    color: white;
+    color: $error-color;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.scss
@@ -50,3 +50,8 @@
 .date-control > input:focus {
     outline: none;
 }
+
+.errorMessage {
+    background-color: darkred;
+    color: white;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
@@ -13,6 +13,7 @@ export class DetectorControlComponent implements OnInit {
   endTime: string;
 
   isInternal: boolean;
+  timeDiffError: string;
 
   constructor(public _router: Router, private _activatedRoute: ActivatedRoute, public detectorControlService: DetectorControlService,
     @Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
@@ -20,6 +21,7 @@ export class DetectorControlComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.timeDiffError = '';
     this.detectorControlService.update.subscribe(validUpdate => {
       if (validUpdate) {
         this.startTime = this.detectorControlService.startTimeString;
@@ -39,7 +41,11 @@ export class DetectorControlComponent implements OnInit {
   }
 
   setManualDate() {
-    this.detectorControlService.setCustomStartEnd(this.startTime, this.endTime);
+    this.timeDiffError = '';
+    this.timeDiffError = this.detectorControlService.getTimeDurationError(this.startTime, this.endTime);
+    if(this.timeDiffError === ''){
+      this.detectorControlService.setCustomStartEnd(this.startTime, this.endTime);
+    }
   }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
@@ -22,6 +22,9 @@ export class DetectorControlComponent implements OnInit {
 
   ngOnInit() {
     this.timeDiffError = '';
+    if(this.detectorControlService.timeRangeDefaulted){
+      this.timeDiffError = 'Defaulting to last 24 hrs. Start and End date time must not be more than 24 hrs apart and Start date must be within the past 30 days.';
+    } 
     this.detectorControlService.update.subscribe(validUpdate => {
       if (validUpdate) {
         this.startTime = this.detectorControlService.startTimeString;
@@ -41,10 +44,9 @@ export class DetectorControlComponent implements OnInit {
   }
 
   setManualDate() {
-    this.timeDiffError = '';
     this.timeDiffError = this.detectorControlService.getTimeDurationError(this.startTime, this.endTime);
     if(this.timeDiffError === ''){
-      this.detectorControlService.setCustomStartEnd(this.startTime, this.endTime);
+      this.detectorControlService.setCustomStartEnd(this.startTime, this.endTime);     
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@angular/core';
 import * as momentNs from 'moment';
 import { BehaviorSubject } from 'rxjs';
 import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../config/diagnostic-data-config';
+import { stringify } from '@angular/core/src/render3/util';
 
 const moment = momentNs;
 
@@ -49,7 +50,7 @@ export class DetectorControlService {
   private _refresh: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
 
   private detectorQueryParams: BehaviorSubject<string> = new BehaviorSubject<string>("");
- 
+
   public DetectorQueryParams = this.detectorQueryParams.asObservable();
 
   constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
@@ -62,6 +63,59 @@ export class DetectorControlService {
 
   public setDefault() {
     this.selectDuration(this.durationSelections.find(duration => duration.displayName === '1d'));
+  }
+
+  public getTimeDurationError(startTime?: string, endTime?: string): string {
+    let start, end: momentNs.Moment;
+    let returnValue: string = '';
+    if (startTime && endTime) {
+      start = moment.utc(startTime);
+      end = moment.utc(endTime);
+
+      let allowedDurationInDays: number = 0;
+      if (this.isInternalView) {
+        allowedDurationInDays = 1;
+      }
+      else {
+        allowedDurationInDays = 3;
+      }
+      if (start && end) {
+        let diff: momentNs.Duration = moment.duration(end.diff(start));
+        let dayDiff: number = diff.asDays();
+        if (dayDiff > -1) {
+          if (dayDiff > allowedDurationInDays) {
+            returnValue = `Difference between start and end date times should not be more than ${allowedDurationInDays * 24} hours.`;
+          }
+          else {
+            //Duration is fine. Just make sure that the start date is not more than the past 30 days
+            if (moment.duration(moment().diff(start)).asMonths() > 1) {
+              returnValue = `Start date time cannot be more than a month from now.`;
+            }
+            else {
+              if (diff.asSeconds() === 0) {
+                returnValue = 'Start and End date time cannot be equal.';
+              }
+              else {
+                returnValue = '';
+              }
+            }
+          }
+        }
+        else {
+          returnValue = 'Start date time should be greater than the End date time.';
+        }
+      }
+      return returnValue;
+    }
+    else {
+      if (startTime) {
+        returnValue = 'Empty End date time supplied.';
+      }
+      else {
+        returnValue = 'Empty Start date time supplied.';
+      }
+    }
+    return returnValue;
   }
 
   public setCustomStartEnd(start?: string, end?: string): void {
@@ -83,7 +137,6 @@ export class DetectorControlService {
 
     this._startTime = startTime;
     this._endTime = endTime;
-
     this._refreshData();
   }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -53,7 +53,7 @@ export class DetectorControlService {
 
   public DetectorQueryParams = this.detectorQueryParams.asObservable();
 
-  public timeRangeDefaulted : boolean = false;
+  public timeRangeDefaulted: boolean = false;
 
   constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
     this.internalClient = !config.isPublic;
@@ -72,24 +72,24 @@ export class DetectorControlService {
     let returnValue: string = '';
     if (startTime && endTime) {
       start = moment.utc(startTime);
-      if(!start.isValid()) {
+      if (!start.isValid()) {
         returnValue = 'Invalid Start date time specified. Expected format: YYYY-MM-DD hh:mm';
         return returnValue;
       }
       end = moment.utc(endTime);
-      if(!end.isValid()) {
+      if (!end.isValid()) {
         returnValue = 'Invalid End date time specified. Expected format: YYYY-MM-DD hh:mm';
         return returnValue;
       }
-      if(moment.duration(moment.utc(moment()).diff(start)).asMinutes() < 0) {
+      if (moment.duration(moment.utc(moment()).diff(start)).asMinutes() < 0) {
         returnValue = 'Start date time must be less than current date time';
         return returnValue;
       }
-      if(moment.duration(moment.utc(moment()).diff(end)).asMinutes() < 0) {
+      if (moment.duration(moment.utc(moment()).diff(end)).asMinutes() < 0) {
         returnValue = 'End date time must be less than current date time';
         return returnValue;
       }
-      
+
       let allowedDurationInDays: number = 0;
       if (this.isInternalView) {
         allowedDurationInDays = 1;
@@ -156,7 +156,7 @@ export class DetectorControlService {
       return;
     }
 
-    if(this.getTimeDurationError(start, end) === '') {      
+    if (this.getTimeDurationError(start, end) === '') {
       this._startTime = startTime;
       this._endTime = endTime;
       this._refreshData();
@@ -166,7 +166,7 @@ export class DetectorControlService {
       this._endTime = moment.utc(moment());
       this._startTime = this._endTime.clone().subtract(1, 'days');
       this._refreshData();
-    }    
+    }
   }
 
   public selectDuration(duration: DurationSelector) {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -120,8 +120,6 @@ export class DetectorControlService {
           }
         }
         else {
-          console.log(start);
-          console.log(end);
           returnValue = 'Start date time should be greater than the End date time.';
         }
       }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -81,6 +81,15 @@ export class DetectorControlService {
         returnValue = 'Invalid End date time specified. Expected format: YYYY-MM-DD hh:mm';
         return returnValue;
       }
+      if(moment.duration(moment.utc(moment()).diff(start)).asMinutes() < 0) {
+        returnValue = 'Start date time must be less than current date time';
+        return returnValue;
+      }
+      if(moment.duration(moment.utc(moment()).diff(end)).asMinutes() < 0) {
+        returnValue = 'End date time must be less than current date time';
+        return returnValue;
+      }
+      
       let allowedDurationInDays: number = 0;
       if (this.isInternalView) {
         allowedDurationInDays = 1;


### PR DESCRIPTION
Added a check in the date range selection control to check for invalid dates. Also defaulting to past 24 hours in case someone bypasses the UX and hits the applens URL directly. Error messages are displayed as follows.


I am aesthetically challenged, please suggest a better highlighting color for the error message :)

![image](https://user-images.githubusercontent.com/20996681/55039442-598a9100-4fe1-11e9-9c8d-8eac9a06d001.png)
