### PR TITLE
Enabling CPU detector in case submission

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
@@ -13,8 +13,8 @@ export class SiteSupportTopicService extends SupportTopicService {
   private _hardCodedSupportTopicIdMapping = [
     {
       pesId: '14748',
-      supportTopicId: '32583701',
-      path: '/diagnostics/availability/detectors/sitecpuanalysis/focus',
+      supportTopicId: '32457411',
+      path: '/diagnostics/performance/analysis',
     },
     {
       pesId: '14748',
@@ -39,8 +39,8 @@ export class SiteSupportTopicService extends SupportTopicService {
     if (!VersioningHelper.isV2Subscription(_webSiteService.subscriptionId)) {
       this._hardCodedSupportTopicIdMapping.push({
         pesId: '14748',
-        supportTopicId: '32457411',
-        path: '/diagnostics/performance/analysis',
+        supportTopicId: '32583701',
+        path: '/diagnostics/availability/detectors/sitecpuanalysis/focus',
       });
     }
   }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/utilities/versioningHelper.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/utilities/versioningHelper.ts
@@ -8,9 +8,13 @@ export class VersioningHelper {
         let enableV2 = false;
 
         let isBetaSubscription = DemoSubscriptions.betaSubscriptions.findIndex(item => subscriptionId.toLowerCase() === item.toLowerCase()) > -1;
+        if (isBetaSubscription) {
+            return true;
+        }
+        
         let firstDigit = "0x" + subscriptionId.substr(0, 1);
 
         // doing a 70:30 split for now
-        return (parseInt(firstDigit, 16) >= 12 || isBetaSubscription) && enableV2;
+        return (parseInt(firstDigit, 16) >= 12) && enableV2;
     }
 }


### PR DESCRIPTION
Enabling CPU detector instead of web app down in case submission
And enabling this for beta subscriptions so we can test it before we start A/B testing.