### PR TITLE
Add back child detector event logging data

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
@@ -57,17 +57,19 @@ export class DetectorListComponent extends DataRenderBaseComponent {
       this.detectorViewModels.forEach((metaData, index) => {
         requests.push((<Observable<DetectorResponse>>metaData.request).pipe(
           map((response: DetectorResponse) => {
-            this.detectorViewModels[index] = this.updateDetectorViewModelSuccess(metaData, response);
+            this.detectorViewModels[index] = this.updateDetectorViewModelSuccess(metaData, response);            
+            return {
+              'ChildDetectorName': this.detectorViewModels[index].title,
+              'ChildDetectorId': this.detectorViewModels[index].metadata.id,
+              'ChildDetectorStatus': this.detectorViewModels[index].status,
+              'ChildDetectorLoadingStatus': this.detectorViewModels[index].loadingStatus
+            };
           })
           , catchError(err => {
             this.detectorViewModels[index].loadingStatus = LoadingStatus.Failed;
             return throwError(err);
           })
         ));
-      });
-
-      requests.forEach(request => {
-        request.subscribe();
       });
 
       // Log all the children detectors


### PR DESCRIPTION
I think this part was removed by accident while we migrate our projects...
That's why we don't get any child detector summary data anymore