### PR TITLE
Configure Detector Link in Internal Solution Text

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
@@ -31,7 +31,7 @@
 <ng-template #internal_solution>
     <ng-template #header>
         Instructions for the Customer
-        <button class="btn btn-default copy-text" (click)="copyInstructions(solution.InternalMarkdown)">
+        <button class="btn btn-default copy-text" (click)="copyInstructions(renderedInternalMarkdown)">
             <span class="fa fa-copy"></span>
             {{copyText}}
         </button>
@@ -39,7 +39,7 @@
 
     <div class="mt-5">
       <data-container [headerTemplate]="header">
-          <markdown [data]="solution.InternalMarkdown"></markdown>
+          <markdown [data]="renderedInternalMarkdown"></markdown>
       </data-container>
     </div>
 </ng-template>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
@@ -20,6 +20,7 @@ export class SolutionComponent extends DataRenderBaseComponent {
   defaultCopyText = 'Copy to Email';
   copyText = this.defaultCopyText;
   appName: string;
+  renderedInternalMarkdown = '';
 
   constructor(telemetryService: TelemetryService, private _siteService: SolutionService) {
     super(telemetryService);
@@ -29,16 +30,26 @@ export class SolutionComponent extends DataRenderBaseComponent {
     let uriParts = this.solution.ResourceUri.split('/');
     this.appName = uriParts[uriParts.length - 1];
 
-    this.buildSolutionText();
+    if (this.renderedInternalMarkdown === '') {
+        this.buildInternalText();
+    }
   }
 
-  buildSolutionText() {
-    let detectorLink = UriUtilities.BuildDetectorLink(this.solution.ResourceUri, this.solution.DetectorId);
-    let detectorLinkMarkdown = `Go to [Diagnose and Solve Problems](${detectorLink})`;
+  buildInternalText() {
+    let markdownBuilder = this.solution.InternalMarkdown;
 
-    if (!this.solution.InternalMarkdown.includes(detectorLinkMarkdown)) {
-      this.solution.InternalMarkdown = this.solution.InternalMarkdown + "\n\n" + detectorLinkMarkdown;
+    let detectorLink = UriUtilities.BuildDetectorLink(this.solution.ResourceUri, this.solution.DetectorId);
+    let detectorLinkMarkdown = `Go to [App Service Diagnostics](${detectorLink})`;
+
+    if (markdownBuilder.toLowerCase().includes("{detectorlink}")) {
+        console.log(markdownBuilder);
+        markdownBuilder = markdownBuilder.replace(/{detectorlink}/gi, detectorLink);
+        console.log(markdownBuilder);
+    } else if (!markdownBuilder.includes(detectorLinkMarkdown)) {
+        markdownBuilder = markdownBuilder + "\n\n" + detectorLinkMarkdown;
     }
+
+    this.renderedInternalMarkdown = markdownBuilder;
   }
 
   performAction() {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
@@ -42,9 +42,7 @@ export class SolutionComponent extends DataRenderBaseComponent {
     let detectorLinkMarkdown = `Go to [App Service Diagnostics](${detectorLink})`;
 
     if (markdownBuilder.toLowerCase().includes("{detectorlink}")) {
-        console.log(markdownBuilder);
         markdownBuilder = markdownBuilder.replace(/{detectorlink}/gi, detectorLink);
-        console.log(markdownBuilder);
     } else if (!markdownBuilder.includes(detectorLinkMarkdown)) {
         markdownBuilder = markdownBuilder + "\n\n" + detectorLinkMarkdown;
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/string-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/string-utilities.ts
@@ -1,0 +1,29 @@
+export class StringUtilities {
+    static TrimStart(target: string, trimSubstring: string): string {
+        let result = target;
+
+        while (result.length >= trimSubstring.length && result.startsWith(trimSubstring)) {
+            result = result.slice(trimSubstring.length);
+        }
+
+        return result;
+    }
+
+    static TrimEnd(target: string, trimSubstring: string): string {
+        let result = target;
+
+        while (result.length >= trimSubstring.length && result.endsWith(trimSubstring)) {
+            result = result.slice(0, -1 * trimSubstring.length);
+        }
+
+        return result;
+    }
+
+    static TrimBoth(target: string, trimSubstring?: string): string {
+        if (trimSubstring == undefined) {
+            return target.trim();
+        }
+
+        return this.TrimStart(this.TrimEnd(target, trimSubstring), trimSubstring);
+    }
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/string-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/string-utilities.ts
@@ -1,5 +1,9 @@
 export class StringUtilities {
-    static TrimStart(target: string, trimSubstring: string): string {
+    static TrimStart(target: string, trimSubstring?: string): string {
+        if (trimSubstring == undefined) {
+            return target.replace(/^\s+/m, '');
+        }
+
         let result = target;
 
         while (result.length >= trimSubstring.length && result.startsWith(trimSubstring)) {
@@ -9,7 +13,11 @@ export class StringUtilities {
         return result;
     }
 
-    static TrimEnd(target: string, trimSubstring: string): string {
+    static TrimEnd(target: string, trimSubstring?: string): string {
+        if (trimSubstring == undefined) {
+            return target.replace(/\s+$/m, '');
+        }
+
         let result = target;
 
         while (result.length >= trimSubstring.length && result.endsWith(trimSubstring)) {

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
@@ -1,7 +1,9 @@
+import { StringUtilities } from './string-utilities';
+
 export class UriUtilities {
-  static BuildDetectorLink(resourceUri: string, detectorId: string): string {
-    return "https://portal.azure.com" +
-      `/?websitesextension_ext=asd.featurePath%3Ddetectors%2F${detectorId}#@microsoft.onmicrosoft.com` +
-      `/resource/${resourceUri}/customtroubleshoot`
-  }
+    static BuildDetectorLink(resourceUri: string, detectorId: string): string {
+        return 'https://portal.azure.com' +
+            `/?websitesextension_ext=asd.featurePath%3Ddetectors%2F${detectorId}#@microsoft.onmicrosoft.com` +
+            `/resource/${StringUtilities.TrimBoth(resourceUri, '/')}/troubleshoot`
+    }
 }


### PR DESCRIPTION
- Detector link can be placed anywhere in internal solution text
- If the format string {detectorlink} is not present, end the internal text with the default detector link markdown;
- Fixed detector link builder