### PR TITLE
Add missing config value to appsettings

### DIFF
--- a/ApplensBackend/appsettings.json
+++ b/ApplensBackend/appsettings.json
@@ -50,5 +50,6 @@
     "ApiKey": "",
     "PublishingEmailTemplateId": "",
     "ReportingEmailTemplateId": ""
-  }
+  },
+  "ServerMode": ""
 }


### PR DESCRIPTION
To run the project locally, we need this value to bypass the authentication part of the backend. This configuration value was missing from appsettings.