### PR TITLE
Fix x-ms-path editing

### DIFF
--- a/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
+++ b/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
@@ -128,7 +128,7 @@ namespace AppLensV3
                 }
                 else
                 {
-                    path = path.Replace("/v4", string.Empty).Replace("v4", string.Empty).Replace("v2", string.Empty);
+                    path = path.Substring(path.IndexOf("/"));
                     
                     var requestMessage = new HttpRequestMessage(method.Trim().ToUpper() == "POST" ? HttpMethod.Post : HttpMethod.Get, path)
                     {


### PR DESCRIPTION
If the resource name has "v2" or "v4" in it then it will be replaced with string.empty thus sending wrong resource name to backend during local development.