### PR TITLE
Use diagnostic role for basic site stamp information

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
@@ -37,7 +37,7 @@ export class AseFinderComponent implements OnInit {
 
   navigateToAse(matchingAse: Observer.ObserverAseInfo) {
     let resourceArray: string[] = [
-      'subscriptions', matchingAse.Subscription,
+      'subscriptions', matchingAse.CustomerSubscriptionId,
       'resourceGroups', matchingAse.ResourceGroupName,
       'providers','Microsoft.Web',
       'hostingEnvironments', matchingAse.Name];

--- a/AngularApp/projects/applens/src/app/shared/services/ase.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/ase.service.ts
@@ -17,15 +17,13 @@ export class AseService extends ResourceService {
   }
 
   public startInitializationObservable() {
-    this._initialized = this._observerApiService.getAse(this._armResource.resourceName).pipe(
-      mergeMap((observerResponse: Observer.ObserverAseResponse) => {
+    this._initialized = this._observerApiService.getAse(this._armResource.resourceName)
+      .pipe(
+        map((observerResponse: Observer.ObserverAseResponse) => {
         this._hostingEnvironmentResource = observerResponse.details;
         this._currentResource.next(observerResponse.details);
-        return this._observerApiService.getAseRequestBody(this._hostingEnvironmentResource.Name);
-      }),map((requestBody: any) => {
-        this._requestBody = requestBody.details;
         return true;
-      }),);
+      }));
   }
 
   public getCurrentResource(): Observable<Observer.ObserverAseInfo> {

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -27,14 +27,6 @@ export class ObserverService {
     return this._diagnosticApiService.get<Observer.ObserverAseResponse>(`api/hostingEnvironments/${ase}`);
   }
 
-  public getSiteRequestBody(site: string, stamp: string) {
-    return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/stamps/${stamp}/sites/${site}/postBody`);
-  }
-
-  public getAseRequestBody(name: string) {
-    return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/hostingEnvironments/${name}/postBody`);
-  }
-
   private getSiteInfoWithSlotAndHostnames(site: Observer.ObserverSiteInfo, hostnames: string[]): Observer.ObserverSiteInfo {
     const siteName = site.SiteName;
     let slot = '';

--- a/AngularApp/projects/applens/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/site.service.ts
@@ -18,21 +18,12 @@ export class SiteService extends ResourceService {
   }
 
   public startInitializationObservable() {
-    this._initialized = this._observerApiService.getSite(this._armResource.resourceName).pipe(
-      mergeMap((observerResponse: Observer.ObserverSiteResponse) => {
+    this._initialized = this._observerApiService.getSite(this._armResource.resourceName)
+      .pipe(map((observerResponse: Observer.ObserverSiteResponse) => {
         this._siteObject = this.getSiteFromObserverResponse(observerResponse);
         this._currentResource.next(this._siteObject);
-        return this._observerApiService.getSiteRequestBody(this._siteObject.SiteName, this._siteObject.InternalStampName);
-      }),map((requestBody: any) => {
-        if (!requestBody.details.HostNames) {
-          requestBody.details.HostNames = this._siteObject.Hostnames.map(hostname => <any>{
-            name: hostname,
-            type: 0
-          });
-        }
-        this._requestBody = requestBody.details;
         return true;
-      }),);
+      }))
   }
 
   public getCurrentResource(): Observable<any> {


### PR DESCRIPTION
Today, when the end user requests for a site in applens, the backend makes a call to SupportBayApi to get basic site information. Instead of making that call to SupportBayApi we will make the call to diagnostic backend instead to get this site info. The same will go as for stamp/ase.