### PR TITLE
Fixing the time selector error for Edge

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -212,23 +212,23 @@ export class DetectorControlService {
     }
   }
 
-  public selectDuration(duration: DurationSelector) {
+  public selectDuration(duration: DurationSelector) {    
     this._duration = duration;
     this._startTime = moment.utc().subtract(duration.duration);
     this._endTime = this._startTime.clone().add(duration.duration);
-    this.setCustomStartEnd(this._startTime.toString(), this.endTime.toString());
+    this.setCustomStartEnd(this._startTime.format(), this.endTime.format());
   }
 
   public moveForwardDuration(): void {
     this._startTime.add(this._duration.duration);
     this._endTime.add(this._duration.duration);
-    this.setCustomStartEnd(this._startTime.toString(), this.endTime.toString());
+    this.setCustomStartEnd(this._startTime.format(), this.endTime.format());
   }
 
   public moveBackwardDuration(): void {
     this._startTime.subtract(this._duration.duration);
     this._endTime.subtract(this._duration.duration);
-    this.setCustomStartEnd(this._startTime.toString(), this.endTime.toString());
+    this.setCustomStartEnd(this._startTime.format(), this.endTime.format());
   }
 
   public refresh() {


### PR DESCRIPTION
Fixing the time selector for Edge. momentJS was falling back on creating date via js Date which wasn't working on Edge and hence was creating an invalid moment object causing the issue. Replaced .toString() with .format() which converts the date to one of the ISO date formats and conversion back from string to moment object always works in all browsers. Tested with Edge, Chrome and IE 11. Assuming it works with the rest of the browsers :-)