### PR TITLE
Fixes to Analysis Layer after testing a few end to end scenarios

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
@@ -16,9 +16,9 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
   analysisId: string = "";
   detectorName: string = "";
 
-  constructor(private _activatedRouteLocal: ActivatedRoute, private _diagnosticService: DiagnosticService, _resourceService: ResourceService, _authServiceInstance: AuthService, _telemetryService: TelemetryService,
-    _navigator: FeatureNavigationService,private _routerLocal: Router) {
-    super(_activatedRouteLocal, _resourceService, _authServiceInstance, _telemetryService, _navigator, _routerLocal);
+  constructor(private _activatedRouteLocal: ActivatedRoute, private _diagnosticServiceLocal: DiagnosticService, _resourceService: ResourceService, _authServiceInstance: AuthService, _telemetryService: TelemetryService,
+    _navigator: FeatureNavigationService, private _routerLocal: Router) {
+    super(_activatedRouteLocal, _diagnosticServiceLocal, _resourceService, _authServiceInstance, _telemetryService, _navigator, _routerLocal);
   }
 
   ngOnInit() {
@@ -26,7 +26,7 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
       this.analysisId = params.get('analysisId');
       this.detectorId = params.get('detectorName') === null ? "" : params.get('detectorName');
 
-      this._diagnosticService.getDetectors().subscribe(detectorList => {
+      this._diagnosticServiceLocal.getDetectors().subscribe(detectorList => {
         if (detectorList) {
 
           if (this.detectorId !== "") {
@@ -38,7 +38,7 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
     });
   }
 
-  goBackToAnalysis(){
+  goBackToAnalysis() {
     this._routerLocal.navigate([`../../../${this.analysisId}`], { relativeTo: this._activatedRouteLocal, queryParamsHandling: 'merge' });
   }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-detector/generic-detector.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-detector/generic-detector.component.ts
@@ -1,7 +1,7 @@
 import { Router } from '@angular/router';
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { TelemetryService, FeatureNavigationService } from 'diagnostic-data';
+import { TelemetryService, FeatureNavigationService, DiagnosticService, DetectorMetaData, DetectorType } from 'diagnostic-data';
 import { AuthService } from '../../../startup/services/auth.service';
 import { Subscription } from 'rxjs';
 import { ResourceService } from '../../../shared-v2/services/resource.service';
@@ -18,9 +18,9 @@ export class GenericDetectorComponent implements OnDestroy {
   detector: string;
   analysisDetector: string;
   navigateSub: Subscription;
-  analysisMode:boolean = false;
+  analysisMode: boolean = false;
 
-  constructor(private _activatedRoute: ActivatedRoute, private _resourceService: ResourceService, private _authServiceInstance: AuthService, private _telemetryService: TelemetryService,
+  constructor(private _activatedRoute: ActivatedRoute, private _diagnosticService: DiagnosticService, private _resourceService: ResourceService, private _authServiceInstance: AuthService, private _telemetryService: TelemetryService,
     private _navigator: FeatureNavigationService, private _router: Router) {
 
     if (this._activatedRoute.snapshot.params['analysisId'] != null) {
@@ -40,7 +40,13 @@ export class GenericDetectorComponent implements OnDestroy {
 
     this.navigateSub = this._navigator.OnDetectorNavigate.subscribe((detector: string) => {
       if (detector) {
-        this._router.navigate([`../../detectors/${detector}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
+        let detectorMetaData: DetectorMetaData = this._diagnosticService.getDetectorById(detector);
+        if (detectorMetaData.type === DetectorType.Detector) {
+          this._router.navigate([`../../detectors/${detector}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
+        } else if (detectorMetaData.type === DetectorType.Analysis) {
+          this._router.navigate([`../../analysis/${detector}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
+        }
+
       }
     });
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tabs/tabs.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tabs/tabs.component.ts
@@ -61,7 +61,7 @@ export class TabsComponent implements OnInit {
   }
 
   getAnalysisTabIfAnalysisDetector(url: string) {
-    if (url.indexOf("/analysis/") && url.indexOf("/detectors/") >= 0) {
+    if (url.indexOf("/analysis/") >=0 && url.indexOf("/detectors/") >= 0 && url.indexOf("/legacy/") === -1) {
       let detectorWithAnalysisPath = url.split("/analysis/")[1];
       if (detectorWithAnalysisPath.indexOf("/detectors/") > 0) {
         if (detectorWithAnalysisPath.indexOf("/") > 0) {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
@@ -14,7 +14,7 @@
     <collapsible-menu theme="dark">
       <search-box [(searchValue)]="searchValue"></search-box>
       <menu-scroll>
-        <section-divider label="Analysis">
+        <section-divider label="Analysis" [hidden]="analysisTypes.length === 0">
           <collapsible-menu-item *ngFor="let item of analysisTypes" [menuItem]="item"></collapsible-menu-item>
         </section-divider>
         <section-divider label="Create">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
@@ -119,7 +119,11 @@ export class SideNavComponent implements OnInit {
               this.navigateTo(`analysis/${element.id}`);
             };
 
-            let analysisMenuItem = new CollapsibleMenuItem(element.name, onClickAnalysisParent, null, null, true);
+            let isSelectedAnalysis = () =>{
+              return this.currentRoutePath && this.currentRoutePath.join('/') === `analysis/${element.id}`;
+            }
+
+            let analysisMenuItem = new CollapsibleMenuItem(element.name, onClickAnalysisParent, isSelectedAnalysis, null, true);
             this.analysisTypes.push(analysisMenuItem);
 
           }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
@@ -15,5 +15,5 @@
         queryParamsHandling="preserve">Back to observations</a>
     </div>
   </div>
-  <router-outlet></router-outlet>
+  <router-outlet (activate)="onActivate($event)"></router-outlet>
 </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
@@ -10,9 +10,16 @@
     <div style="display: inline-block">
       <h4>{{ detectorName }}</h4>
     </div>
-    <div style="display: inline-block;margin-left: 10px">
-      <a *ngIf="detectorId !== ''" [routerLink]="['../../']" preserveFragment
-        queryParamsHandling="preserve">Back to observations</a>
+    <div class="pull-right">
+
+      <div style="display: inline-block">
+        <button class="btn btn-sm btn-primary" *ngIf="detectorId !== ''" [routerLink]="['../../../../detectors',detectorId]"
+          preserveFragment queryParamsHandling="preserve">Expand View</button>
+      </div>
+      <div style="display: inline-block;margin-left: 10px;margin-right:20px">
+        <button class="btn btn-sm btn-primary" *ngIf="detectorId !== ''" [routerLink]="['../../']" preserveFragment
+          queryParamsHandling="preserve">Back to Observations</button>
+      </div>
     </div>
   </div>
   <router-outlet (activate)="onActivate($event)"></router-outlet>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.html
@@ -13,11 +13,11 @@
     <div class="pull-right">
 
       <div style="display: inline-block">
-        <button class="btn btn-sm btn-primary" *ngIf="detectorId !== ''" [routerLink]="['../../../../detectors',detectorId]"
-          preserveFragment queryParamsHandling="preserve">Expand View</button>
+        <button class="btn btn-sm" *ngIf="detectorId !== ''" [routerLink]="['../../../../detectors',detectorId]"
+          preserveFragment queryParamsHandling="preserve">Go to Detector</button>
       </div>
       <div style="display: inline-block;margin-left: 10px;margin-right:20px">
-        <button class="btn btn-sm btn-primary" *ngIf="detectorId !== ''" [routerLink]="['../../']" preserveFragment
+        <button class="btn btn-sm" *ngIf="detectorId !== ''" [routerLink]="['../../']" preserveFragment
           queryParamsHandling="preserve">Back to Observations</button>
       </div>
     </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.ts
@@ -32,5 +32,7 @@ export class TabAnalysisComponent implements OnInit {
       }
     });
   }
-
+  onActivate(event) {
+    window.scroll(0, 0);
+  }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -8,7 +8,7 @@
             completed)</span>
     </div>
 
-    <div *ngIf="detectors.length> 0 && issueDetectedViewModels.length > 0 || (detectorsPending === 0 && loadingChildDetectors)"
+    <div *ngIf="detectors.length > 0 && (issueDetectedViewModels.length > 0 || successfulViewModels.length > 0) || (detectorsPending === 0 && loadingChildDetectors)"
         class="list-wrapper">
         <div class="red-line" [ngClass]="{'remove-padding':withinDiagnoseAndSolve}"></div>
         <div class="list-item-wrapper">
@@ -16,7 +16,12 @@
             <div class="list-item">
                 <div class="list-title">Observations</div>
                 <div>Events observed during this time period</div>
-                <div class="list-text" style="margin-top:10px;">
+                
+                <div *ngIf="detectorsPending > 0" style="margin-top:10px">
+                    <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                    <span style="margin-left:5px">Loading...</span>
+                </div>
+                <div class="list-text">
                     <div *ngIf="issueDetectedViewModels.length === 0 && detectorsPending === 0">
                         <div class="success-msg">We could not identify any issues that caused availability drops to your
                             app</div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -1,28 +1,28 @@
 <div [hidden]="detectorId !== ''">
 
-    <div *ngIf="detectorsPending > 0" style="margin-left:30px;margin-bottom: 30px">
+    <div *ngIf="getPendingDetectorCount() > 0" style="margin-left:30px;margin-bottom: 30px">
         <i class="fa fa-circle-o-notch fa-2x fa-spin spin-icon" aria-hidden="true"></i>
         <span [@loadingAnimation]="showLoadingMessage ? 'shown' : 'hidden'"
             class="loading-message">{{loadingMessages[loadingMessageIndex]}}</span>
-        <span style="margin-left:10px">({{ detectors.length - detectorsPending }} of {{ detectors.length }} checks
+        <span style="margin-left:10px">({{ detectors.length - getPendingDetectorCount() }} of {{ detectors.length }} checks
             completed)</span>
     </div>
 
-    <div *ngIf="detectors.length > 0 && (issueDetectedViewModels.length > 0 || successfulViewModels.length > 0) || (detectorsPending === 0 && loadingChildDetectors)"
+    <div *ngIf="detectors.length > 0 && (issueDetectedViewModels.length > 0 || successfulViewModels.length > 0) || (getPendingDetectorCount() === 0 && loadingChildDetectors)"
         class="list-wrapper">
         <div class="red-line" [ngClass]="{'remove-padding':withinDiagnoseAndSolve}"></div>
         <div class="list-item-wrapper">
-            <div class="stepper-circle"><i aria-hidden="true" class="fa fa-search dark"></i></div>
+            <div class="stepper-circle"><i aria-hidden="true" class="fa fa-search"></i></div>
             <div class="list-item">
                 <div class="list-title">Observations</div>
                 <div>Events observed during this time period</div>
-                
-                <div *ngIf="detectorsPending > 0" style="margin-top:10px">
+
+                <div *ngIf="getPendingDetectorCount() > 0" style="margin-top:10px">
                     <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
                     <span style="margin-left:5px">Loading...</span>
                 </div>
                 <div class="list-text">
-                    <div *ngIf="issueDetectedViewModels.length === 0 && detectorsPending === 0">
+                    <div *ngIf="issueDetectedViewModels.length === 0 && getPendingDetectorCount() === 0">
                         <div class="success-msg">We could not identify any issues that caused availability drops to your
                             app</div>
                     </div>
@@ -31,7 +31,8 @@
                             <thead>
                                 <tr>
                                     <th class="col-sm-2">Issues</th>
-                                    <th colspan="2" class="col-sm-8">Description</th>
+                                    <th class="col-sm-6">Description</th>
+                                    <th class="col-sm-1"></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -56,13 +57,11 @@
                                     </td>
                                     <td>
                                         <div style="margin-top: 5px;white-space: nowrap;">
-                                            <button
-                                                [ngClass]="{'btn btn-primary btn-sm':!withinDiagnoseAndSolve, 'custom-button':withinDiagnoseAndSolve}"
-                                                (click)="selectDetector(viewModel.model.metadata.id)">More
+                                            <a (click)="selectDetector(viewModel.model.metadata.id)">More
                                                 Info
                                                 <i class="fa fa-arrow-circle-o-right"
                                                     style="margin-left:5px; font-size: 15px"></i>
-                                            </button>
+                                            </a>
                                         </div>
                                     </td>
                                 </tr>
@@ -75,21 +74,21 @@
         </div>
 
         <div class="list-item-wrapper">
-            <div class="stepper-circle stepper-circle-brown"><i aria-hidden="true" class="fa fa-wrench dark"></i></div>
+            <div class="stepper-circle stepper-circle-brown"><i aria-hidden="true" class="fa fa-wrench"></i></div>
             <div class="list-item">
                 <div class="list-title">Troubleshooting and Next Steps</div>
                 <div>Next steps curated specifically for your app</div>
                 <div class="list-text">
-                    <div *ngIf="allSolutions.length === 0 && detectorsPending === 0">
+                    <div *ngIf="allSolutions.length === 0 && getPendingDetectorCount() === 0">
                         <div class="success-msg">We could not identify any futher troubleshooting steps or solutions
                         </div>
                     </div>
                     <div style="width:98%">
-                        <div *ngIf="detectorsPending === 0">
-                            <solutions *ngIf="allSolutions.length > 0" [solutions]="allSolutions">
+                        <div *ngIf="getPendingDetectorCount() === 0 && allSolutions.length > 0">
+                            <solutions [solutions]="allSolutions">
                             </solutions>
                         </div>
-                        <div *ngIf="detectorsPending > 0">
+                        <div *ngIf="getPendingDetectorCount() > 0">
                             <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
                             <span style="margin-left:5px">Loading...</span>
                         </div>
@@ -98,21 +97,48 @@
             </div>
         </div>
         <div class="list-item-wrapper">
-            <div class="stepper-circle stepper-circle-green"><i aria-hidden="true" class="fa fa-check dark"></i></div>
+            <div class="stepper-circle stepper-circle-green"><i aria-hidden="true" class="fa fa-check"></i></div>
             <div class="list-item">
                 <div class="list-title">Successful Checks</div>
                 <div>Tests that succeeded for your app</div>
-                <div class="list-text" style="margin-bottom: 20px;">
-                    <div class="row">
-                        <div class="col-sm-3" [ngClass]="{'nopadding':withinDiagnoseAndSolve}">
-                            <ul class="list-group special">
-                                <li *ngFor="let viewModel of successfulViewModels" class="list-group-item">
-                                    <a
-                                        (click)="selectDetector(viewModel.model.metadata.id)">{{ viewModel.model.title }}</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+                <div class="list-text">
+                    <table class="table detector-list">
+                        <thead>
+                            <tr>
+                                <th class="col-sm-2">Checks</th>
+                                <th class="col-sm-6">Description</th>
+                                <th class="col-sm-1"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr *ngFor="let viewModel of successfulViewModels">
+                                <td>
+                                    <div style="white-space: nowrap">
+                                        <div style="display: inline-block">
+                                            <status-icon [loading]="viewModel.model.loadingStatus"
+                                                [status]="viewModel.model.status" [size]="20">
+                                            </status-icon>
+                                        </div>
+                                        <div style="display: inline-block;margin-left: 10px;">
+                                            <strong>{{ viewModel.model.title }} </strong>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    {{ viewModel.insightTitle }}
+                                </td>
+                                <td>
+                                    <div style="margin-top: 5px;white-space: nowrap;">
+                                        <a (click)="selectDetector(viewModel.model.metadata.id)">More
+                                            Info
+                                            <i class="fa fa-arrow-circle-o-right"
+                                                style="margin-left:5px; font-size: 15px"></i>
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
                 <div class="white-line" [ngClass]="{'remove-padding':withinDiagnoseAndSolve}"></div>
             </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -71,7 +71,7 @@
         </div>
 
         <div class="list-item-wrapper">
-            <div class="stepper-circle stepper-circle-green"><i aria-hidden="true" class="fa fa-wrench dark"></i></div>
+            <div class="stepper-circle stepper-circle-brown"><i aria-hidden="true" class="fa fa-wrench dark"></i></div>
             <div class="list-item">
                 <div class="list-title">Troubleshooting and Next Steps</div>
                 <div>Next steps curated specifically for your app</div>
@@ -81,8 +81,30 @@
                         </div>
                     </div>
                     <div style="width:98%">
-                        <solutions *ngIf="allSolutions.length > 0" [solutions]="allSolutions">
-                        </solutions>
+                        <div *ngIf="detectorsPending === 0">
+                            <solutions *ngIf="allSolutions.length > 0" [solutions]="allSolutions">
+                            </solutions>
+                        </div>
+                        <div *ngIf="detectorsPending > 0">
+                            <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                            <span style="margin-left:5px">Loading...</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="list-item-wrapper">
+            <div class="stepper-circle stepper-circle-green"><i aria-hidden="true" class="fa fa-check dark"></i></div>
+            <div class="list-item">
+                <div class="list-title">Successful tests</div>
+                <div>Checks that succeeded for your app</div>
+                <div class="list-text" style="margin-bottom: 20px;">
+                    <div style="width:98%">
+                        <ng-container *ngFor="let viewModel of successfulViewModels">
+                            <button
+                                class ="btn btn-sm btn-success"
+                                (click)="selectDetector(viewModel.model.metadata.id)">{{ viewModel.model.title }} </button>
+                        </ng-container>
                     </div>
                 </div>
                 <div class="white-line" [ngClass]="{'remove-padding':withinDiagnoseAndSolve}"></div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -45,7 +45,6 @@
                                     </td>
                                     <td>
                                         {{ viewModel.insightTitle }}
-
                                         <div style="margin-top:10px">
                                             <markdown [data]="viewModel.insightDescription"></markdown>
                                         </div>
@@ -75,7 +74,7 @@
             <div class="list-item">
                 <div class="list-title">Troubleshooting and Next Steps</div>
                 <div>Next steps curated specifically for your app</div>
-                <div class="list-text" style="margin-bottom: 20px;">
+                <div class="list-text">
                     <div *ngIf="allSolutions.length === 0 && detectorsPending === 0">
                         <div class="success-msg">We could not identify any futher troubleshooting steps or solutions
                         </div>
@@ -96,15 +95,18 @@
         <div class="list-item-wrapper">
             <div class="stepper-circle stepper-circle-green"><i aria-hidden="true" class="fa fa-check dark"></i></div>
             <div class="list-item">
-                <div class="list-title">Successful tests</div>
-                <div>Checks that succeeded for your app</div>
+                <div class="list-title">Successful Checks</div>
+                <div>Tests that succeeded for your app</div>
                 <div class="list-text" style="margin-bottom: 20px;">
-                    <div style="width:98%">
-                        <ng-container *ngFor="let viewModel of successfulViewModels">
-                            <button
-                                class ="btn btn-sm btn-success"
-                                (click)="selectDetector(viewModel.model.metadata.id)">{{ viewModel.model.title }} </button>
-                        </ng-container>
+                    <div class="row">
+                        <div class="col-sm-3" [ngClass]="{'nopadding':withinDiagnoseAndSolve}">
+                            <ul class="list-group special">
+                                <li *ngFor="let viewModel of successfulViewModels" class="list-group-item">
+                                    <a
+                                        (click)="selectDetector(viewModel.model.metadata.id)">{{ viewModel.model.title }}</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 <div class="white-line" [ngClass]="{'remove-padding':withinDiagnoseAndSolve}"></div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
@@ -79,6 +79,11 @@
     color:black;
 }
 
+.list-text {
+    margin-top: 10px;
+    margin-bottom: 20px;
+}
+
 .detector-list {
     background: #f9f9f9;
     border: 1px solid #ebebeb;
@@ -107,3 +112,18 @@
     font-size: 20px;
     font-weight: lighter;
   }
+
+.special .list-group-item:first-child {
+    border-top-right-radius: 0px !important;
+    border-top-left-radius: 0px !important;
+ }
+ 
+.special .list-group-item:last-child {
+   border-bottom-right-radius: 0px !important;
+   border-bottom-left-radius: 0px !important;
+ }
+
+.nopadding {
+    padding: 0 !important;
+    margin: 5px !important;
+ }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
@@ -39,6 +39,12 @@
     z-index: 1;
 }
 
+.stepper-circle-brown {
+    background-color: rgb(249, 213, 180);
+    z-index: 1;
+}
+
+
 .list-item {
     // display: table-row;
     vertical-align: middle;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.scss
@@ -35,12 +35,12 @@
 }
 
 .stepper-circle-green {
-    background-color: #87d286;
+    background-color: #7fba00;
     z-index: 1;
 }
 
 .stepper-circle-brown {
-    background-color: rgb(249, 213, 180);
+    background-color: #ff9104;
     z-index: 1;
 }
 
@@ -73,10 +73,6 @@
     left: 15px;
     border: 0;
     z-index: 0;
-}
-
-.dark{
-    color:black;
 }
 
 .list-text {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
- import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
- import { LoadingStatus } from '../../models/loading';
+import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
+import { LoadingStatus } from '../../models/loading';
 import { StatusStyles } from '../../models/styles';
 import { DetectorControlService } from '../../services/detector-control.service';
 import { DiagnosticService } from '../../services/diagnostic.service';
@@ -43,15 +43,16 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
   LoadingStatus = LoadingStatus;
   detectorViewModels: any[];
   issueDetectedViewModels: any[] = [];
+  successfulViewModels: any[] = [];
   detectorMetaData: DetectorMetaData[];
   detectorsPending: number = 0;
   private childDetectorsEventProperties = {};
   loadingChildDetectors: boolean = false;
   allSolutions: Solution[] = [];
   loadingMessages: string[] = [];
-  loadingMessageIndex:number = 0;
+  loadingMessageIndex: number = 0;
   loadingMessageTimer: any;
-  showLoadingMessage:boolean = false;
+  showLoadingMessage: boolean = false;
 
   constructor(private _activatedRoute: ActivatedRoute, private _router: Router,
     private _diagnosticService: DiagnosticService, private _detectorControl: DetectorControlService, protected telemetryService: TelemetryService) {
@@ -118,6 +119,9 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                   let issueDetectedViewModel = { model: this.detectorViewModels[index], insightTitle: insight.title, insightDescription: insight.description };
                   this.issueDetectedViewModels.push(issueDetectedViewModel);
                   this.issueDetectedViewModels = this.issueDetectedViewModels.sort((n1, n2) => n1.model.status - n2.model.status);
+                } else {
+                  let successViewModel = { model: this.detectorViewModels[index] };
+                  this.successfulViewModels.push(successViewModel);
                 }
 
                 return {
@@ -153,6 +157,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     this.loadingChildDetectors = false;
     this.allSolutions = [];
     this.loadingMessages = [];
+    this.successfulViewModels = [];
 
   }
   getDetectorInsight(viewModel: any): any {
@@ -223,20 +228,20 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     this.showLoadingMessage = true;
 
     setTimeout(() => {
-        self.showLoadingMessage = false;
+      self.showLoadingMessage = false;
     }, 3000)
     this.loadingMessageTimer = setInterval(() => {
-        self.loadingMessageIndex++;
-        self.showLoadingMessage = true;
+      self.loadingMessageIndex++;
+      self.showLoadingMessage = true;
 
-        if (self.loadingMessageIndex === self.loadingMessages.length - 1) {
-            clearInterval(this.loadingMessageTimer);
-            return;
-        }
+      if (self.loadingMessageIndex === self.loadingMessages.length - 1) {
+        clearInterval(this.loadingMessageTimer);
+        return;
+      }
 
-        setTimeout(() => {
-            self.showLoadingMessage = false;
-        }, 3000)
+      setTimeout(() => {
+        self.showLoadingMessage = false;
+      }, 3000)
     }, 4000);
-}
+  }
 }


### PR DESCRIPTION
In this pull request, the following fixes have been done

1. Added successful detectors to the bottom of the analysis as successful checks
2. Highlighted the selected Analysis detector in AppLens
3. Fixed the Analysis tab to open a new detector for legacy analysis detectors
4. Added an Expand View when the detector is loaded under analysis (This is done in case someone needs to get the DataSources and KUSTO queries etc.)
5. Changed error handling in Analysis layer so that if a child detector fails, rest of the detectors still load
6. Scrolling to the top when a child detector is clicked under the Analysis list
7. Improved the card navigation to route to analysis route if the card added is of type DetectorType.Analysis
8. Fixed a bug in loading of Solutions when multiple detectors added solutions to analysis
