### PR TITLE
Adding null check

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -131,9 +131,11 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
     // TODO: Find a better way of updating angular UI
     private triggerChangeEvent(properties: any): void {
         let domelement = <HTMLInputElement>document.getElementById("changeSetId");
-        domelement.value = properties.items[0];
-        let event = new Event('change');
-        domelement.dispatchEvent(event);
+        if(properties.items.length > 0 && typeof properties.items[0] != 'undefined') {
+            domelement.value = properties.items[0];
+            let event = new Event('change');
+            domelement.dispatchEvent(event);
+        }
     }
 
      refreshChangesTable(): void {

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/changeanalysis-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/changeanalysis-utilities.ts
@@ -10,6 +10,12 @@ export class ChangeAnalysisUtilities {
       public static prepareValuesForDiffView(diffvalue: any): DiffEditorModel {
         try {
             let jsonObject: any;
+            if(diffvalue === null || typeof diffvalue === 'undefined') {
+                return {
+                    "code": "",
+                    "language": 'text/plain'
+                }
+            }
             if(isBoolean(diffvalue)) {
                 return {
                     "code": diffvalue.toString(),


### PR DESCRIPTION
This PR fixes the following issues:

- When Change Analysis api returns null for old value/new value, the monaco editor throws js error and does not show diff view. So adding null check to set empty string in those cases.

- Clicking anywhere on timeline (not a data point) triggers select event, and causes change set id set to be undefined. Adding check here to avoid setting change set id in those cases. 