### PR TITLE
Fix keyboard navigation on tiles

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tile-list/tile-list.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tile-list/tile-list.component.html
@@ -1,5 +1,5 @@
 <div class="tile-container">
-  <a *ngFor="let tile of tiles" class="tile" (click)="tile.action()">
+  <a *ngFor="let tile of tiles" class="tile" (click)="tile.action()" (keyup.enter)="tile.action()" tabindex="0">
       {{tile.title}}
   </a>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/detector-summary/detector-summary.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/detector-summary/detector-summary.component.html
@@ -1,11 +1,11 @@
 <div class="detector-summary-container" [class.with-full-report]="showTopLevelFullReport" *ngIf="!loading else loadingMessage">
   <div class="full-report" *ngIf="showTopLevelFullReport">
     {{detector.name}}
-    <div class="full-report-link">
+    <div class="full-report-link" tabindex="0" (keyup.enter)="openFullReport()">
       <a (click)="openFullReport()">View Full Report <i class="fa fa-chevron-right"></i></a>
     </div>
   </div>
-  <div class="status-bar" *ngFor="let model of detectorSummaryViewModels" (click)="selectDetectorSummaryItem(model)">
+  <div class="status-bar" *ngFor="let model of detectorSummaryViewModels" (click)="selectDetectorSummaryItem(model)" (keyup.enter)="selectDetectorSummaryItem(model)"  tabindex="0">
     <div class="status-bar-icon align-content-center">
         <status-icon [loading]="model.loading" [status]="model.status" [size]="16"></status-icon>
     </div>

--- a/AngularApp/projects/app-service-diagnostics/src/styles/controls/_tiles.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/styles/controls/_tiles.scss
@@ -37,6 +37,10 @@
         background: $disabled-color;
         cursor: arrow;
     }
+
+    &:focus{
+        background-color: rgb(250, 242, 232);
+    }
 }
 
 .tile-container {


### PR DESCRIPTION
Tiles appearing under Diagnostics tools and Category chat window are not accessible through keyboard navigation.

- Made the tile navigation possible through Tab and Shift+Tab
- Pressing enter key on detector summary list takes to detector in genie chat window
- Pressing enter key on Diagnostic tool tile opens the tool window
- Tested in Chrome and Edge.

Screenshots from Keros showing tab stops
![image](https://user-images.githubusercontent.com/46545195/57887916-999e1100-77e5-11e9-801e-de3c032eeb39.png)

![image](https://user-images.githubusercontent.com/46545195/57887923-9dca2e80-77e5-11e9-997d-965368fed27d.png)

![image](https://user-images.githubusercontent.com/46545195/57887928-a15db580-77e5-11e9-845a-a5e7872e7073.png)
