### PR TITLE
Fix row expansion not working in edge

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
@@ -14,8 +14,8 @@ const moment = momentNs;
     styleUrls: ['./changes-view.component.scss'],
     animations: [
         trigger('changeRowExpand', [
-          state('collapsed', style({height: '0px', minHeight: '0', display: 'none'})),
-          state('expanded', style({height: '*'})),
+          state('collapsed', style({height: '0px', minHeight: '0', visibility: 'hidden'})),
+          state('expanded', style({height: '*', visibility: 'visible'})),
           transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
         ]),
       ],


### PR DESCRIPTION
This was a known issue in Angular material table expand row not working with `display: none `https://github.com/angular/components/issues/15596

- Tested Applens Edge & Chrome
- Tested App Service Diagnostics Edge & Chrome

Edge:
![image](https://user-images.githubusercontent.com/46545195/58192276-37c22900-7c75-11e9-8087-37cd3ffe34ad.png)

![image](https://user-images.githubusercontent.com/46545195/58192284-41e42780-7c75-11e9-8c8a-6c55053b4bd2.png)


Chrome:

![image](https://user-images.githubusercontent.com/46545195/58192323-57f1e800-7c75-11e9-9488-c037824939c7.png)

![image](https://user-images.githubusercontent.com/46545195/58192394-7952d400-7c75-11e9-8ba0-63d3a3c46dc5.png)
