### PR TITLE
Enable v3 Memory Detector for case submission and Slow response Analysis for beta subs

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
@@ -20,11 +20,6 @@ export class SiteSupportTopicService extends SupportTopicService {
       pesId: '14748',
       supportTopicId: '32542218',
       path: '/diagnostics/availability/analysis',
-    },
-    {
-      pesId: '14748',
-      supportTopicId: '32581616',
-      path: '/diagnostics/availability/memoryanalysis',
     }
   ];
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
@@ -13,11 +13,6 @@ export class SiteSupportTopicService extends SupportTopicService {
   private _hardCodedSupportTopicIdMapping = [
     {
       pesId: '14748',
-      supportTopicId: '32457411',
-      path: '/diagnostics/performance/analysis',
-    },
-    {
-      pesId: '14748',
       supportTopicId: '32542218',
       path: '/diagnostics/availability/analysis',
     }
@@ -31,7 +26,7 @@ export class SiteSupportTopicService extends SupportTopicService {
       // To enable a/b testing, uncomment the below line with the right path and Support Topic Id
       // (the below is an example of how we did the testing for CPU detector)
       
-      //this._hardCodedSupportTopicIdMapping.push({pesId: '14748',supportTopicId: '32583701',path: '/diagnostics/availability/detectors/sitecpuanalysis/focus' });
+      this._hardCodedSupportTopicIdMapping.push({pesId: '14748',supportTopicId: '32457411',path: '/diagnostics/performance/analysis' });
     }
   }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/utilities/versioningHelper.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/utilities/versioningHelper.ts
@@ -5,7 +5,7 @@ export class VersioningHelper {
     static isV2Subscription(subscriptionId: string): boolean {
 
         // When we decide to enable the A/B testing for v2, change this to true
-        let enableV2 = true;
+        let enableV2 = false;
 
         let isBetaSubscription = DemoSubscriptions.betaSubscriptions.findIndex(item => subscriptionId.toLowerCase() === item.toLowerCase()) > -1;
         if (isBetaSubscription) {


### PR DESCRIPTION
With this PR, we are
1. Enabling v3 **High Memory Usage** detector in Case Submission for all subs
2. Enabling v3 **Web App Slow** Analysis for beta subscriptions to check if Analysis View loads properly in case submission. After testing this out fully, will send another PR to set `enableV2 =true`