### PR TITLE
Hide gists section if empty and collapase left hand detector list by default

### DIFF
--- a/AngularApp/projects/applens/src/app/collapsible-menu/components/collapsible-menu-item/collapsible-menu-item.component.ts
+++ b/AngularApp/projects/applens/src/app/collapsible-menu/components/collapsible-menu-item/collapsible-menu-item.component.ts
@@ -34,12 +34,12 @@ export class CollapsibleMenuItemComponent {
   constructor(private _searchPipe: SearchPipe) { }
 
   ngOnInit() {
-
     this.children = this.menuItem.subItems;
     this.hasChildren = this.menuItem.subItems && this.menuItem.subItems.length > 0;
 
     this._searchValueSubject.subscribe(searchValue => {
       this.searchValueLocal = searchValue;
+      this.menuItem.expanded = searchValue != undefined;
       this.hasChildren = this.menuItem.subItems ? this._searchPipe.transform(this.menuItem.subItems, searchValue).length > 0 : false;
       this.matchesSearchTerm = !this.searchValueLocal || this.menuItem.label.toLowerCase().indexOf(this.searchValueLocal.toLowerCase()) >= 0 || this.hasChildren;
     });

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
@@ -11,7 +11,7 @@
           <i class="fa fa-book fa-fw menu-icon menu-icon-documentation" aria-hidden="true"></i>
           <collapsible-menu-item *ngFor="let doc of documentation" [menuItem]="doc"></collapsible-menu-item>
         </section-divider>
-        <section-divider [label]="'Analysis'" *ngIf="analysisTypes.length > 0" >
+        <section-divider  *ngIf="analysisTypes.length > 0" [label]="'Analysis'">
           <i class="fa fa-heartbeat fa-fw menu-icon menu-icon-analysis" aria-hidden="true"></i>
           <collapsible-menu-item *ngFor="let item of analysisTypes" [menuItem]="item"></collapsible-menu-item>
           <i *ngIf="!categories || categories.length === 0" class="fa fa-spinner fa-spin fa-3x fa-fw loading-menu"></i>
@@ -21,7 +21,7 @@
           <collapsible-menu-item *ngFor="let category of categories" [searchValue]="searchValue" [menuItem]="category"></collapsible-menu-item>
           <i *ngIf="!categories || categories.length === 0" class="fa fa-spinner fa-spin fa-3x fa-fw loading-menu"></i>
         </section-divider>
-        <section-divider [label]="'Gists'" [initiallyExpanded]="false">
+        <section-divider *ngIf="gists.length > 0" [label]="'Gists'" [initiallyExpanded]="false">
           <i class="fa fa-file-code-o fa-fw menu-icon menu-icon-gists" aria-hidden="true"></i>
           <collapsible-menu-item *ngFor="let gist of gists" [searchValue]="searchValue" [menuItem]="gist"></collapsible-menu-item>
           <i *ngIf="!gists || gists.length === 0" class="fa fa-spinner fa-spin fa-3x fa-fw loading-menu"></i>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
@@ -127,7 +127,7 @@ export class SideNavComponent implements OnInit {
 
           let categoryMenuItem = this.categories.find((cat: CollapsibleMenuItem) => cat.label === category);
           if (!categoryMenuItem) {
-            categoryMenuItem = new CollapsibleMenuItem(category, null, null, null, true);
+            categoryMenuItem = new CollapsibleMenuItem(category, null, null, null, false);
             this.categories.push(categoryMenuItem);
           }
 


### PR DESCRIPTION
1. Hide gists section if empty
2. Collapase left hand detector list by default, and expand automatically if search happens