### PR TITLE
Fixing the Caching issue of detectors

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -216,7 +216,7 @@ export class DetectorControlService {
     }
   }
 
-  public selectDuration(duration: DurationSelector) {    
+  public selectDuration(duration: DurationSelector) {
     this._duration = duration;
     this._startTime = moment.utc().subtract(duration.duration);
     this._endTime = this._startTime.clone().add(duration.duration);
@@ -257,9 +257,9 @@ export class DetectorControlService {
     return this._error;
   }
 
-  public get startTime(): momentNs.Moment { return this._startTime; }
+  public get startTime(): momentNs.Moment { return (this._startTime ? this._startTime.clone() : this._startTime); }
 
-  public get endTime(): momentNs.Moment { return this._endTime; }
+  public get endTime(): momentNs.Moment { return (this._endTime ? this._endTime.clone() : this._endTime); }
 
   public get duration(): DurationSelector { return this._duration; }
 


### PR DESCRIPTION
The caching issue was happening because the startTime was getting rounded to 5 minutes. This was happening only if a detector had a Chart and the Chart was actually rounding the startTime to 5 minute interval.

The fix is to return a clone of StartTime object so that the original startTime doesnt get changed when chart is rendered.

Thanks to @stevenernst131  for his quick guidance :-)