### PR TITLE
Change Analysis onboarding UI tweaks

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.html
@@ -10,9 +10,9 @@
     Change Analysis Resource Provider is {{resourceProviderRegState}}. This will take a few mins. Please check again later.
   </div>
   <div *ngIf="!pollingResourceProviderRegProgress && !updatingProvider && !updatingTag">
-    <div class="row form-group">
+    <div class="row form-group option-group">
       <label class="control-label col-sm-2 settings-label">Change Analysis</label>
-      <div class="col-sm-2">
+      <div class="col-sm-2 toggle-button">
         <toggle-button [selected]="isEnabled"
           (selectedChange)="$event ? enableButtonSelectedValue = true : enableButtonSelectedValue = false">
         </toggle-button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.scss
@@ -1,4 +1,12 @@
+.option-group {
+    display: flex;
+}
+
 .settings-label {
-color: black;
-font-size: 13px;
+    color: black;
+    font-size: 13px;
+}
+
+.toggle-button {
+    min-width: 180px;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -65,12 +65,12 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
                 this.initializeChangesView(data);
             }
             // Convert UTC timestamp to user readable date
-            this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : 'No recent scans were performed on this web app. Make sure scan for code changes has been enabled in settings.';
+            this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : 'No recent scans were performed on this web app. Please enable Change Analysis using Change Analysis Settings.';
             if(this.isPublic) {
                 this.checkInitialScanState();
              }
         } else {
-             this.scanDate = 'No recent scans were performed on this web app. Make sure scan for code changes has been enabled in settings.';
+             this.scanDate = 'No recent scans were performed on this web app. Please enable Change Analysis using Change Analysis Settings.';
              this.changeSetText = `No change groups have been detected`;
              this.setDefaultScanStatus();
         }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -43,6 +43,9 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
     changesTimeline: Timeline;
     changeSetsLocalCopy: {};
     initiatedBy: string = '';
+
+    private readonly noScanMsg: string = 'No recent scans were performed on this web app.';
+
     constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig, protected telemetryService: TelemetryService,
     protected changeDetectorRef: ChangeDetectorRef, protected diagnosticService: DiagnosticService,
     private detectorControlService: DetectorControlService, private settingsService: SettingsService,
@@ -65,12 +68,12 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
                 this.initializeChangesView(data);
             }
             // Convert UTC timestamp to user readable date
-            this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : 'No recent scans were performed on this web app. Please enable Change Analysis using Change Analysis Settings.';
+            this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : this.noScanMsg + ' Please enable Change Analysis using Change Analysis Settings.';
             if(this.isPublic) {
                 this.checkInitialScanState();
              }
         } else {
-             this.scanDate = 'No recent scans were performed on this web app. Please enable Change Analysis using Change Analysis Settings.';
+             this.scanDate = this.noScanMsg + ' Please enable Change Analysis using Change Analysis Settings.';
              this.changeSetText = `No change groups have been detected`;
              this.setDefaultScanStatus();
         }
@@ -221,48 +224,52 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
 
     private checkInitialScanState() {
         this.settingsService.getScanEnabled().subscribe(isEnabled => {
-        if(isEnabled) {
-            this.scanStatusMessage = "Checking recent scan status...";
-            this.scanState = "Polling";
-            this.allowScanAction = false;
-            let queryParams = `&scanAction=checkscan`;
-            this.diagnosticService.getDetector(this.detector, this.detectorControlService.startTimeString, this.detectorControlService.endTimeString,
-                this.detectorControlService.shouldRefresh, this.detectorControlService.isInternalView, queryParams).subscribe((response: DetectorResponse) => {
-                    let dataset = response.dataset;
-                    let table = dataset[0].table;
-                    let rows = table.rows;
-                    let submissionState = rows[0][1];
-                    this.scanState = submissionState;
-                    if (submissionState == "Completed") {
-                        this.setScanState(submissionState);
-                        let completedTime = rows[0][3];
-                        let currentMoment = moment();
-                        let completedMoment = moment(completedTime);
-                        let diff = currentMoment.diff(completedMoment, 'seconds');
-                        // If scan has been completed more than a minute ago, display default message
-                        if (diff >= 60) {
+            if (isEnabled) {
+                if (this.scanDate.startsWith(this.noScanMsg)) {
+                    this.scanDate = this.noScanMsg;
+                }
+
+                this.scanStatusMessage = "Checking recent scan status...";
+                this.scanState = "Polling";
+                this.allowScanAction = false;
+                let queryParams = `&scanAction=checkscan`;
+                this.diagnosticService.getDetector(this.detector, this.detectorControlService.startTimeString, this.detectorControlService.endTimeString,
+                    this.detectorControlService.shouldRefresh, this.detectorControlService.isInternalView, queryParams).subscribe((response: DetectorResponse) => {
+                        let dataset = response.dataset;
+                        let table = dataset[0].table;
+                        let rows = table.rows;
+                        let submissionState = rows[0][1];
+                        this.scanState = submissionState;
+                        if (submissionState == "Completed") {
+                            this.setScanState(submissionState);
+                            let completedTime = rows[0][3];
+                            let currentMoment = moment();
+                            let completedMoment = moment(completedTime);
+                            let diff = currentMoment.diff(completedMoment, 'seconds');
+                            // If scan has been completed more than a minute ago, display default message
+                            if (diff >= 60) {
+                                this.setDefaultScanStatus();
+                            } else {
+                                this.scanStatusMessage = "Scanning is complete. Click the below button to view the latest changes now.";
+                                this.allowScanAction = true;
+                                this.showViewChanges = true;
+                            }
+                        } else if (submissionState == "No active requests") {
+                            this.setScanState("");
                             this.setDefaultScanStatus();
                         } else {
-                            this.scanStatusMessage = "Scanning is complete. Click the below button to view the latest changes now.";
-                            this.allowScanAction = true;
-                            this.showViewChanges = true;
+                            this.subscription = interval(5000).subscribe(res => {
+                                this.pollForScanStatus();
+                            });
                         }
-                     } else if (submissionState == "No active requests") {
+                    }, (error: any) => {
+                        // Stop timer in case of any error
+                        if (this.subscription) {
+                            this.subscription.unsubscribe();
+                        }
+                        this.scanState = "";
                         this.setScanState("");
-                        this.setDefaultScanStatus();
-                     }  else {
-                        this.subscription = interval(5000).subscribe(res => {
-                            this.pollForScanStatus();
-                        });
-                     }
-                }, (error: any) => {
-                    // Stop timer in case of any error
-                    if(this.subscription) {
-                        this.subscription.unsubscribe();
-                    }
-                    this.scanState = "";
-                    this.setScanState("");
-                });
+                    });
             } else {
                 this.scanStatusMessage = '';
                 this.allowScanAction = false;


### PR DESCRIPTION
1. Tweak the enablement button group so it works better on narrow sized screen
2. Update the last scan message so we don't confuse user with the concept of code scan
3. Update the last scan message so if code scan is enabled and there is no last scan yet, we don't ask user to enable Change Analysis