### PR TITLE
A minor fix of error handling when add hidden tag to web app

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/diagnostics-settings/diagnostics-settings.component.ts
@@ -146,9 +146,10 @@ export class DiagnosticsSettingsComponent implements OnInit, OnDestroy {
         };
         this.loggingService.logEvent('UpdateScanTag', eventProps);
 
-        this.armService.patchResource(this.currentResource.id, this.currentResource).subscribe((response: any) => {
+        this.armService.patchResourceFullResponse(this.currentResource.id, this.currentResource, true).subscribe((response: HttpResponse<{}>) => {
             this.updatingTag = false;
-            if (response && response.tags && response.tags[scanTag] === 'true') {
+            let resource = <ArmResource>response.body;
+            if (resource && resource.tags && resource.tags[scanTag] === 'true') {
                 this.isHiddenTagAdded.next(true);
             } else {
                 this.isHiddenTagAdded.next(false);


### PR DESCRIPTION
The original call using patchResource() will not return full response of the error, which makes the error message always "Try again later" even if it's something like unauthorized.