### PR TITLE
Make gist modal scrollable

### DIFF
--- a/AngularApp/projects/applens/src/styles.scss
+++ b/AngularApp/projects/applens/src/styles.scss
@@ -82,6 +82,7 @@ body {
 .package-modal {
   max-width: 100% !important;
   max-height: 90%;
+  overflow-y: scroll !important;
 }
 
 .panel.with-nav-tabs .panel-heading.app-nav-bar {


### PR DESCRIPTION
Currently, when there are many versions of gist, the confirm button goes all the way to the bottom and its not seen. Made Gist modal scrollable if the content is overflowing.

