### PR TITLE
Fixing Chat typo that is prevent chat to come up

### DIFF
--- a/Backend/appsettings.json
+++ b/Backend/appsettings.json
@@ -47,7 +47,7 @@
         "Hours": []
       }
     ],
-    "PublicHolidays": [
+    "PublicHolidayRegions": [
       {
         "Name": "USPublicHolidays",
         "Holidays": [


### PR DESCRIPTION
Chat Controller calls are failing because the code is looking for PublicHolidayRegions where as configuration has PublicHoliday. Fixing the typo