### PR TITLE
Support regional geomaster changes in applens

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid main-container">
   <div class="big-text" *ngIf="loading">Searching for site ...</div>
-  <div class="big-text" *ngIf="!loading && error">Site {{site}} not found</div>
+  <div class="big-text" *ngIf="!loading && error">{{error}}</div>
   <div class="big-text" *ngIf="!loading && !error && matchingSites.length == 1">Redirecting to {{site}}</div>
   <div *ngIf="!loading && !error && matchingSites.length > 0">
     <div class="multiple-sites">

--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
@@ -26,7 +26,7 @@ export class SiteFinderComponent implements OnInit {
     this.site = this._route.snapshot.params['site'];
 
     this._observerService.getSite(this.site).subscribe(observerSiteResponse => {
-      if (observerSiteResponse.details === "Unable to fetch data from Observer API : GetAdminSite"){
+      if ((observerSiteResponse.details instanceof String) && (observerSiteResponse.details.toString() == "Unable to fetch data from Observer API : GetAdminSite")){
         this.error = `There was an error trying to find app ${this.site}`;
         this.loading = false;  
       }

--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
@@ -26,7 +26,11 @@ export class SiteFinderComponent implements OnInit {
     this.site = this._route.snapshot.params['site'];
 
     this._observerService.getSite(this.site).subscribe(observerSiteResponse => {
-      if (observerSiteResponse.details.length === 1) {
+      if (observerSiteResponse.details === "Unable to fetch data from Observer API : GetAdminSite"){
+        this.error = `There was an error trying to find app ${this.site}`;
+        this.loading = false;  
+      }
+      else if (observerSiteResponse.details.length === 1) {
         let matchingSite = observerSiteResponse.details[0];
         this.navigateToSite(matchingSite);
       }

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -1,76 +1,75 @@
 namespace Observer {
-  export interface ObserverSiteResponse {
-      siteName: string;
-      details: ObserverSiteInfo[];
-      hostNames: string[];
+    export interface ObserverSiteResponse {
+        siteName: string;
+        details: ObserverSiteInfo[];
+    }
+  
+    export interface ObserverSiteInfo {
+        SiteName: string;
+        StampName: string;
+        InternalStampName: string;
+        Subscription: string;
+        WebSpace: string;
+        ResourceGroupName: string;
+        SlotName: string;
+    }
+  
+    export interface ObserverAseResponse {
+        details: ObserverAseInfo;
+    }
+  
+    export interface ObserverAseInfo {
+        ID: number;
+        Name: string;
+        LocationId: number;
+        PublicHost: string;
+        VNETName: string;
+        VNETId: string;
+        VNETSubnetName: string;
+        WebWorkerSize: string;
+        WebWorkerRoleCount: number;
+        MultiSize: string;
+        MultiRoleCount: number;
+        IPSSLAddressCount: number;
+        MonitoringDataAccountId: number;
+        SmallDedicatedWebWorkerSize: string;
+        SmallDedicatedWebWorkerRoleCount: number;
+        MediumDedicatedWebWorkerSize: string;
+        MediumDedicatedWebWorkerRoleCount: number;
+        LargeDedicatedWebWorkerSize: string;
+        LargeDedicatedWebWorkerRoleCount: number;
+        Allocated: boolean;
+        DatabaseEdition: string;
+        DatabaseServiceObjective: string;
+        MaximumNumberOfMachines: number;
+        UpgradeDomains: number;
+        VNETSubnetAddressRange: string;
+        DeploymentOrder: number;
+        AllowedMultiSizes?: null;
+        AllowedWorkerSizes?: null;
+        DefinitionsPath?: null;
+        SettingsPath?: null;
+        UserServiceEndpoint: string;
+        CustomerSubscriptionId: string;
+        VNETResourceGroup: string;
+        DeletedOn?: null;
+        DatabaseServerVersion: string;
+        Suspended: boolean;
+        ManualResumeOnly: boolean;
+        ExtraDefinitions: string;
+        InternalLoadBalancingMode: number;
+        ApiHubEnabled: boolean;
+        VNETSubscriptionId: string;
+        CustomBuild: boolean;
+        ClusterSettings?: null;
+        DnsSuffix?: null;
+        VNETResourceType: string;
+        DynamicCacheEnabled: boolean;
+        FileServerRoleCount: number;
+        EnvironmentType: number;
+        InternalStampName: string;
+        Subscription: string;
+        ResourceGroupName: string;
+    }
   }
-
-  export interface ObserverSiteInfo {
-      SiteName: string;
-      StampName: string;
-      InternalStampName: string;
-      Subscription: string;
-      WebSpace: string;
-      ResourceGroupName: string;
-      SlotName: string;
-      Hostnames: string[];
-  }
-
-  export interface ObserverAseResponse {
-      details: ObserverAseInfo;
-  }
-
-  export interface ObserverAseInfo {
-      ID: number;
-      Name: string;
-      LocationId: number;
-      PublicHost: string;
-      VNETName: string;
-      VNETId: string;
-      VNETSubnetName: string;
-      WebWorkerSize: string;
-      WebWorkerRoleCount: number;
-      MultiSize: string;
-      MultiRoleCount: number;
-      IPSSLAddressCount: number;
-      MonitoringDataAccountId: number;
-      SmallDedicatedWebWorkerSize: string;
-      SmallDedicatedWebWorkerRoleCount: number;
-      MediumDedicatedWebWorkerSize: string;
-      MediumDedicatedWebWorkerRoleCount: number;
-      LargeDedicatedWebWorkerSize: string;
-      LargeDedicatedWebWorkerRoleCount: number;
-      Allocated: boolean;
-      DatabaseEdition: string;
-      DatabaseServiceObjective: string;
-      MaximumNumberOfMachines: number;
-      UpgradeDomains: number;
-      VNETSubnetAddressRange: string;
-      DeploymentOrder: number;
-      AllowedMultiSizes?: null;
-      AllowedWorkerSizes?: null;
-      DefinitionsPath?: null;
-      SettingsPath?: null;
-      UserServiceEndpoint: string;
-      CustomerSubscriptionId: string;
-      VNETResourceGroup: string;
-      DeletedOn?: null;
-      DatabaseServerVersion: string;
-      Suspended: boolean;
-      ManualResumeOnly: boolean;
-      ExtraDefinitions: string;
-      InternalLoadBalancingMode: number;
-      ApiHubEnabled: boolean;
-      VNETSubscriptionId: string;
-      CustomBuild: boolean;
-      ClusterSettings?: null;
-      DnsSuffix?: null;
-      VNETResourceType: string;
-      DynamicCacheEnabled: boolean;
-      FileServerRoleCount: number;
-      EnvironmentType: number;
-      InternalStampName: string;
-      Subscription: string;
-      ResourceGroupName: string;
-  }
-}
+  

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -16,7 +16,7 @@ export class ObserverService {
     return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/sites/${site}`).pipe(
       map((siteRes: Observer.ObserverSiteResponse) => {
         if (siteRes && siteRes.details && isArray(siteRes.details)) {
-          siteRes.details.map(info => this.getSiteInfoWithSlotAndHostnames(info, siteRes.hostNames));
+          siteRes.details.map(info => this.getSiteInfoWithSlot(info));
         }
 
         return siteRes;
@@ -35,7 +35,7 @@ export class ObserverService {
     return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/hostingEnvironments/${name}/postBody`);
   }
 
-  private getSiteInfoWithSlotAndHostnames(site: Observer.ObserverSiteInfo, hostnames: string[]): Observer.ObserverSiteInfo {
+  private getSiteInfoWithSlot(site: Observer.ObserverSiteInfo): Observer.ObserverSiteInfo {
     const siteName = site.SiteName;
     let slot = '';
 
@@ -45,8 +45,6 @@ export class ObserverService {
     }
 
     site.SlotName = slot;
-    site.Hostnames = hostnames;
-
     return site;
   }
 

--- a/AngularApp/projects/applens/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/site.service.ts
@@ -24,12 +24,6 @@ export class SiteService extends ResourceService {
                 this._currentResource.next(this._siteObject);
                 return this._observerApiService.getSiteRequestBody(this._siteObject.SiteName, this._siteObject.InternalStampName);
             }), map((requestBody: any) => {
-                if (!requestBody.details.HostNames) {
-                    requestBody.details.HostNames = this._siteObject.Hostnames.map(hostname => <any>{
-                        name: hostname,
-                        type: 0
-                    });
-                }
                 this._requestBody = requestBody.details;
                 this.updatePesIdAndImgSrc();
                 return true;

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -64,17 +64,14 @@ namespace AppLensV3
 
         private async Task<IActionResult> GetSiteInternal(string stamp, string siteName)
         {
-            var hostnamesTask = _observerService.GetHostnames(siteName);
             var siteDetailsTask = stamp == null ? _observerService.GetSite(siteName) : _observerService.GetSite(stamp, siteName);
 
-            var hostNameResponse = await hostnamesTask;
             var siteDetailsResponse = await siteDetailsTask;
 
             var details = new
             {
                 SiteName = siteName,
-                Details = siteDetailsResponse.Content,
-                HostNames = hostNameResponse.Content
+                Details = siteDetailsResponse.Content
             };
 
             if (siteDetailsResponse.StatusCode == HttpStatusCode.NotFound)

--- a/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
@@ -12,8 +12,6 @@ namespace AppLensV3
 
         Task<ObserverResponse> GetStamp(string siteName);
 
-        Task<ObserverResponse> GetHostnames(string siteName);
-
         Task<ObserverResponse> GetHostingEnvironmentDetails(string hostingEnvironmentName);
 
         Task<ObserverResponse> GetHostingEnvironmentPostBody(string name);

--- a/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
@@ -46,11 +46,11 @@ namespace AppLensV3
                 //Add condition for Debugger.IsAttached so that we never mistakenly target Support Api test slot in production
                 if (Debugger.IsAttached && targetSupportApiTestSlot)
                 {
-                    return "https://support-bay-api-test.azurewebsites.net/observer/";
+                    return "https://wawsobserver-prod-staging.azurewebsites.net/api/";
                 }
                 else
                 {
-                    return "https://support-bay-api.azurewebsites.net/observer/";
+                    return "https://wawsobserver-prod.azurewebsites.net/api/";
                 }
             }
         }
@@ -126,7 +126,7 @@ namespace AppLensV3
         /// <param name="siteName">Site Name</param>
         public async Task<ObserverResponse> GetSite(string siteName)
         {
-            return await GetSiteInternal(SupportObserverApiEndpoint + "sites/" + siteName + "/adminsites?api-version=2.0");
+            return await GetSiteInternal(SupportObserverApiEndpoint + "sites/" + siteName + "/adminsites");
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace AppLensV3
         /// <param name="siteName">Site Name</param>
         public async Task<ObserverResponse> GetSite(string stamp, string siteName)
         {
-            return await GetSiteInternal(SupportObserverApiEndpoint + "stamps/" + stamp + "/sites/" + siteName + "/adminsites?api-version=2.0");
+            return await GetSiteInternal(SupportObserverApiEndpoint + "stamps/" + stamp + "/sites/" + siteName + "/adminsites");
         }
 
         private async Task<ObserverResponse> GetSiteInternal(string endpoint)
@@ -163,7 +163,7 @@ namespace AppLensV3
         {
             var request = new HttpRequestMessage()
             {
-                RequestUri = new Uri(SupportObserverApiEndpoint + "sites/" + site + "/resourcegroupname?api-version=2"),
+                RequestUri = new Uri(SupportObserverApiEndpoint + "sites/" + site + "/resourcegroupname"),
                 Method = HttpMethod.Get
             };
           
@@ -196,32 +196,11 @@ namespace AppLensV3
             return res;
         }
 
-        /// <summary>
-        /// Get Hostnames for a site
-        /// </summary>
-        /// <param name="siteName">SiteName</param>
-        /// <returns>Hostnames</returns>
-        public async Task<ObserverResponse> GetHostnames(string siteName)
-        {
-            var request = new HttpRequestMessage()
-            {
-                RequestUri = new Uri(SupportObserverApiEndpoint + "sites/" + siteName + "/hostnames?api-version=2.0"),
-                Method = HttpMethod.Get
-            };
-
-            var serializedParameters = JsonConvert.SerializeObject(new Dictionary<string, string>() { { "site", siteName } });
-            request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
-            var response = await _httpClient.SendAsync(request);
-
-            ObserverResponse res = await CreateObserverResponse(response, "GetHostnames(2.0)");
-            return res;
-        }
-
         public async Task<ObserverResponse> GetHostingEnvironmentDetails(string hostingEnvironmentName)
         {
             var request = new HttpRequestMessage()
             {
-                RequestUri = new Uri(SupportObserverApiEndpoint + "hostingEnvironments/" + hostingEnvironmentName + "?api-version=2.0"),
+                RequestUri = new Uri(SupportObserverApiEndpoint + "hostingEnvironments/" + hostingEnvironmentName),
                 Method = HttpMethod.Get
             };
 


### PR DESCRIPTION
--Point applens backend from support bay api to wawsobserver
--Deprecate /hostnames api in applens backend as wawsobserver does not support it and the data does not seem to be being used anywhere in frontend.
--Display correct error on request failure.