### PR TITLE
Rely only on stack from diagnosticProperties call

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-main/daas-main.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-main/daas-main.component.ts
@@ -49,7 +49,8 @@ export class DaasMainComponent implements OnInit {
 
     this._siteService.currentSite.subscribe(site => {
       if (site) {
-        this.appType = site.appType;
+        this.appType = site.kind.toLowerCase().indexOf('functionapp') >= 0 ? AppType.FunctionApp : AppType.WebApp;
+        this.platform = site.kind.toLowerCase().indexOf('linux') >= 0 ? OperatingSystem.linux : OperatingSystem.windows;
         this.sku = site.sku;
         this.sku.toLowerCase();
 
@@ -58,7 +59,6 @@ export class DaasMainComponent implements OnInit {
           const resourceUriParts = this._siteService.parseResourceUri(startupInfo.resourceId);
           this._appAnalysisService.getDiagnosticProperties(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName).subscribe((data: IDiagnosticProperties) => {
             this.AppStack = data && data.appStack && data.appStack != '' ? data.appStack : 'ASP.Net';
-            this.platform = data && data.isLinux ? OperatingSystem.linux : OperatingSystem.windows;
             this._categoryService.Categories.subscribe(categories => {
               const toolsCategories = categories.filter(x => x.Name === 'Diagnostic Tools');
               if (toolsCategories.length > 0 && (this.sku.toLowerCase() === 'standard' || this.sku.toLowerCase().indexOf('premium') > -1 || this.sku.toLowerCase() === 'isolated')) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/main-menu/main-menu.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/main-menu/main-menu.component.ts
@@ -39,7 +39,6 @@ export class MainMenuComponent implements OnInit, AfterViewInit, IChatMessageCom
     }
 
     ngOnInit(): void {
-        console.log("Inside main component ngoninit");
         if (this._authService.resourceType == ResourceType.Site) {
             this._siteService.currentSite.subscribe(site => {
                 if (site) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/main-menu/main-menu.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/supportbot/message-flow/main-menu/main-menu.component.ts
@@ -39,16 +39,17 @@ export class MainMenuComponent implements OnInit, AfterViewInit, IChatMessageCom
     }
 
     ngOnInit(): void {
+        console.log("Inside main component ngoninit");
         if (this._authService.resourceType == ResourceType.Site) {
             this._siteService.currentSite.subscribe(site => {
                 if (site) {
-                    this.appType = site.appType;
+                    this.appType = site.kind.toLowerCase().indexOf('functionapp') >= 0 ? AppType.FunctionApp : AppType.WebApp;
+                    this.platform = site.kind.toLowerCase().indexOf('linux') >= 0 ? OperatingSystem.linux : OperatingSystem.windows;
                     this.sku = Sku[site.sku];
                     this._authService.getStartupInfo().subscribe((startupInfo: StartupInfo) => {
                         const resourceUriParts = this._siteService.parseResourceUri(startupInfo.resourceId);
                         this._appAnalysisService.getDiagnosticProperties(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName).subscribe((data: IDiagnosticProperties) => {
                             this.AppStack = data && data.appStack && data.appStack != '' ? data.appStack : 'ASP.Net';
-                            this.platform = data && data.isLinux ? OperatingSystem.linux : OperatingSystem.windows;
                             this.categoryService.Categories.subscribe(categories => {
                                 this.allProblemCategories = categories;
                             });


### PR DESCRIPTION
Even though I am sending this PR, this is basically **dead code.**None of the below components are currently used. They were used at some point but not any more. 

So we should be totally ok with making the backend change for properties call.