### PR TITLE
Fix issue in local dev where header value gets passed twice

### DIFF
--- a/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
+++ b/ApplensBackend/Services/DiagnosticRoleClientService/DiagnosticRoleClient.cs
@@ -140,13 +140,13 @@ namespace AppLensV3
                         Content = new StringContent(body ?? string.Empty, Encoding.UTF8, "application/json")
                     };
 
+                    requestMessage.Headers.Add("x-ms-internal-client", internalClient.ToString());
+                    requestMessage.Headers.Add("x-ms-internal-view", internalView.ToString());
+
                     if (additionalHeaders != null)
                     {
                         AddAdditionalHeaders(additionalHeaders, ref requestMessage);
                     }
-
-                    requestMessage.Headers.Add("x-ms-internal-client", internalClient.ToString());
-                    requestMessage.Headers.Add("x-ms-internal-view", internalView.ToString());
 
                     response = await _client.SendAsync(requestMessage);
                 }


### PR DESCRIPTION
While running applens locally, x-ms-internal-client header values gets received as "true, True" in Runtime host side because of the order in which headers were added. Fixing that in this PR 