### PR TITLE
Allow markdown to have links to Detectors, Analysis and Tools

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -14,7 +14,7 @@ import { DropdownComponent } from '../dropdown/dropdown.component';
 import { DynamicInsightComponent } from '../dynamic-insight/dynamic-insight.component';
 import { EmailComponent } from '../email/email.component';
 import { InsightsComponent } from '../insights/insights.component';
-import { MarkdownComponent } from '../markdown/markdown.component';
+import { MarkdownViewComponent } from '../markdown-view/markdown-view.component';
 import { SolutionComponent } from '../solution/solution.component';
 import { GuageControlComponent } from '../guage-control/guage-control.component';
 import { TimeSeriesGraphComponent } from '../time-series-graph/time-series-graph.component';
@@ -32,7 +32,7 @@ import {AppDependenciesComponent} from '../app-dependencies/app-dependencies.com
   styleUrls: ['./dynamic-data.component.scss'],
   entryComponents: [
     TimeSeriesGraphComponent, DataTableComponent, DataSummaryComponent, EmailComponent,
-    InsightsComponent, TimeSeriesInstanceGraphComponent, DynamicInsightComponent, MarkdownComponent,
+    InsightsComponent, TimeSeriesInstanceGraphComponent, DynamicInsightComponent, MarkdownViewComponent,
     DetectorListComponent, DropdownComponent, CardSelectionComponent, SolutionComponent, GuageControlComponent, FormComponent,
     ChangeAnalysisOnboardingComponent, ChangesetsViewComponent, AppDependenciesComponent, AppInsightsMarkdownComponent
   ]
@@ -96,7 +96,7 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.DynamicInsight:
         return DynamicInsightComponent;
       case RenderingType.Markdown:
-        return MarkdownComponent;
+        return MarkdownViewComponent;
       case RenderingType.DetectorList:
         return DetectorListComponent;
       case RenderingType.DropDown:

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.html
@@ -69,7 +69,7 @@
               </td>
               <td class="table-value">
                 <div *ngIf="!isMarkdown(insight.data[key])" [innerHtml]="insight.data[key]"></div>
-                <markdown [data]="getMarkdown(insight.data[key])" *ngIf="isMarkdown(insight.data[key])"></markdown>
+                <markdown #markdownDiv [data]="getMarkdown(insight.data[key])" *ngIf="isMarkdown(insight.data[key])"></markdown>
               </td>
             </tr>
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.ts
@@ -1,16 +1,31 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, Renderer2, OnDestroy } from '@angular/core';
 import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
 import { Rendering, RenderingType, DiagnosticData, InsightsRendering, HealthStatus } from '../../models/detector';
 import { Insight, InsightUtils } from '../../models/insight';
 import { DiagnosticService } from '../../services/diagnostic.service';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { TelemetryEventNames } from '../../services/telemetry/telemetry.common';
+import { MarkdownComponent } from 'ngx-markdown'
+import { Router } from '@angular/router';
+import { LinkInterceptorService } from '../../services/link-interceptor.service';
+
 
 @Component({
   templateUrl: './insights.component.html',
   styleUrls: ['./insights.component.scss']
 })
-export class InsightsComponent extends DataRenderBaseComponent {
+export class InsightsComponent extends DataRenderBaseComponent implements OnDestroy {
+
+  @ViewChild(MarkdownComponent)
+  public set markdown(v: MarkdownComponent) {
+    this.markdownDiv = v;
+    if (this.markdownDiv) {
+      this.listenObj = this.renderer.listen(this.markdownDiv.element.nativeElement, 'click', (evt) => this._interceptorService.interceptLinkClick(evt, this.router, this.detector, this.telemetryService));
+    }
+  }
+
+  private listenObj: any;
+  private markdownDiv: MarkdownComponent;
 
   DataRenderingType = RenderingType.Insights;
 
@@ -20,7 +35,7 @@ export class InsightsComponent extends DataRenderBaseComponent {
 
   InsightStatus = HealthStatus;
 
-  constructor(protected telemetryService: TelemetryService) {
+  constructor(protected telemetryService: TelemetryService, private renderer: Renderer2, private router: Router, private _interceptorService: LinkInterceptorService) {
     super(telemetryService);
   }
 
@@ -71,6 +86,12 @@ export class InsightsComponent extends DataRenderBaseComponent {
       insight.isRated = true;
       insight.isHelpful = isHelpful;
       this.logEvent(TelemetryEventNames.InsightRated, eventProps);
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.listenObj) {
+      this.listenObj();
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/markdown-view/markdown-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/markdown-view/markdown-view.component.html
@@ -11,7 +11,7 @@
 </ng-template>
 
 <data-container *ngIf="renderingProperties.isContainerNeeded else noContainerMarkdown" [headerTemplate]="header" [title]="renderingProperties.title">
-    <markdown [data]="markdown"></markdown>
+    <markdown #markdownDiv [data]="markdownData"></markdown>
 </data-container>
 
 <!-- If there is no title, do not use container. Note this is called from the else statement in the *ngIf above -->
@@ -19,6 +19,6 @@
     <div *ngIf="renderingProperties.title">
         <h1>{{renderingProperties.title}}</h1>
     </div>
-    <markdown [data]="markdown"></markdown>
+    <markdown #markdownDiv [data]="markdownData"></markdown>
 </ng-template>
   

--- a/AngularApp/projects/diagnostic-data/src/lib/components/markdown-view/markdown-view.component.spec.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/markdown-view/markdown-view.component.spec.ts
@@ -1,20 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { MarkdownComponent } from './markdown.component';
+import { MarkdownViewComponent } from './markdown-view.component';
 
-describe('MarkdownComponent', () => {
-  let component: MarkdownComponent;
-  let fixture: ComponentFixture<MarkdownComponent>;
+describe('MarkdownViewComponent', () => {
+  let component: MarkdownViewComponent;
+  let fixture: ComponentFixture<MarkdownViewComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MarkdownComponent ]
+      declarations: [ MarkdownViewComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(MarkdownComponent);
+    fixture = TestBed.createComponent(MarkdownViewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
@@ -37,7 +37,7 @@ import { FeedbackComponent } from './components/feedback/feedback.component';
 import { InsightsComponent } from './components/insights/insights.component';
 import { LoaderViewComponent } from './components/loader-view/loader-view.component';
 import { MarkdownEditorComponent } from './components/markdown-editor/markdown-editor.component';
-import { MarkdownComponent } from './components/markdown/markdown.component';
+import { MarkdownViewComponent } from './components/markdown-view/markdown-view.component';
 import { Nvd3GraphComponent } from './components/nvd3-graph/nvd3-graph.component';
 import {
   StarRatingFeedbackComponent
@@ -94,7 +94,7 @@ import { AppDependenciesComponent } from './components/app-dependencies/app-depe
     Nvd3GraphComponent, TimeSeriesGraphComponent, DataTableComponent, DynamicDataComponent,
     DataRenderBaseComponent, DataContainerComponent, TimeSeriesInstanceGraphComponent, DetectorViewComponent,
     DataSummaryComponent, EmailComponent, InsightsComponent, LoaderViewComponent, DynamicInsightComponent,
-    MarkdownComponent, DetectorListComponent, DetectorOrderPipe, StarRatingComponent, StarRatingFeedbackComponent,
+    MarkdownViewComponent, DetectorListComponent, DetectorOrderPipe, StarRatingComponent, StarRatingFeedbackComponent,
     DropdownComponent, StatusIconComponent, DetectorControlComponent, DetectorContainerComponent, InternalPipe,
     CommAlertComponent, FeedbackComponent, CopyInsightDetailsComponent, MarkdownEditorComponent, CardSelectionComponent,
     GuageGraphicComponent, GuageControlComponent, SolutionComponent, SolutionsComponent, FormComponent,

--- a/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.spec.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LinkInterceptorService } from './link-interceptor.service';
+
+describe('LinkInterceptorService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: LinkInterceptorService = TestBed.get(LinkInterceptorService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { TelemetryService } from './telemetry/telemetry.service';
+import { Router } from '@angular/router';
+import { TelemetryEventNames } from './telemetry/telemetry.common';
+
+const isAbsolute = new RegExp('(?:^[a-z][a-z0-9+.-]*:|\/\/)', 'i');
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LinkInterceptorService {
+
+  constructor() { }
+
+  interceptLinkClick(e: Event, router: Router, detector: string, telemetryService: TelemetryService) {
+    if (e.target && (e.target as any).tagName === 'A') {
+
+      const el = (e.target as HTMLElement);
+      const linkURL = el.getAttribute && el.getAttribute('href');
+      const linkText = el && el.innerText;
+
+      // Send telemetry event for clicking hyerlink
+      const linkClickedProps: { [name: string]: string } = {
+        'Title': linkText,
+        'Href': linkURL,
+        'Detector': detector
+      };
+
+      telemetryService.logEvent(TelemetryEventNames.LinkClicked, linkClickedProps);
+
+      if (linkURL && !isAbsolute.test(linkURL)) {
+        e.preventDefault();
+        router.navigate([linkURL]);
+      }
+    }
+  }
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/link-interceptor.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TelemetryService } from './telemetry/telemetry.service';
-import { Router } from '@angular/router';
+import { Router, NavigationExtras } from '@angular/router';
 import { TelemetryEventNames } from './telemetry/telemetry.common';
 
 const isAbsolute = new RegExp('(?:^[a-z][a-z0-9+.-]*:|\/\/)', 'i');
@@ -27,10 +27,14 @@ export class LinkInterceptorService {
       };
 
       telemetryService.logEvent(TelemetryEventNames.LinkClicked, linkClickedProps);
+      let navigationExtras: NavigationExtras = {
+        queryParamsHandling: 'preserve',
+        preserveFragment: true
+      };
 
       if (linkURL && !isAbsolute.test(linkURL)) {
         e.preventDefault();
-        router.navigate([linkURL]);
+        router.navigate([linkURL], navigationExtras);
       }
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -16,6 +16,7 @@ export const TelemetryEventNames = {
     InsightsSummary: 'InsightsSummary',
     ChildDetectorsSummary: 'ChildDetectorsSummary',
     MarkdownClicked: 'MarkdownClicked',
+    LinkClicked: 'LinkClicked',
     StarRatingSubmitted: 'StarRatingSubmitted',
     CardClicked: 'CardClicked',
     FormButtonClicked: 'FormButtonClicked',


### PR DESCRIPTION
With this PR, a detector can now have a hyperlink to another Detector, tool or analysis.

On the detector side, you have to do something like this

```
 res.AddMarkdownView($@"Open <a href='{GetLinkToDetector(cxt, "detectors/http4xx")}'>HTTP 4XX Detector</a>","Markdown Title");

static string GetLinkToDetector(OperationContext<App> cxt, string routePath)
{
    if (cxt.IsInternalCall)
        return $"{cxt.Resource.ResourceUri}/{routePath}";
    else
        return $"./resource{cxt.Resource.ResourceUri}/{routePath}".ToLower();
}
```

The `GetLinkToDetector `method can be worded more appropriately and put in a Gist so all detector authors can leverage this.