### PR TITLE
Changed DiagnosticClient request flow logic

### DIFF
--- a/ApplensBackend/Services/DiagnosticClientService/DiagnosticClient.cs
+++ b/ApplensBackend/Services/DiagnosticClientService/DiagnosticClient.cs
@@ -100,18 +100,9 @@ namespace AppLensV3.Services.DiagnosticClientService
             try
             {
                 HttpResponseMessage response;
-
-                if (!IsLocalDevelopment)
+                // Sends request to DiagRole.
+                if (!IsLocalDevelopment && !IsRunTimeHostEnabled)
                 {
-                    if (IsRunTimeHostEnabled)
-                    {
-                        path = path.TrimStart('/');
-                        if (new Regex("^v[0-9]+/").Matches(path).Any())
-                        {
-                            path = path.Substring(path.IndexOf('/'));
-                        }
-                    }
-
                     if (!HitPassThroughApi(path))
                     {
                         var requestMessage = new HttpRequestMessage(method == "POST" ? HttpMethod.Post : HttpMethod.Get, path);
@@ -158,6 +149,7 @@ namespace AppLensV3.Services.DiagnosticClientService
                 }
                 else
                 {
+                    // If running locally or using App Service for Runtimehost, we can send requests directly.
                     path = path.TrimStart('/');
                     if (new Regex("^v[0-9]+/").Matches(path).Any())
                     {


### PR DESCRIPTION
- If both IsLocalDevelopment and RuntimehostEnabled is false, requests will go the DiagRole. This is the current set up in Applens-prod and applens-staging.
- In Applens-dev slot, RuntimehostEnabled is true and LocalDevelopment is false, so requests will directly go to Runtimehost App Service.
- While running the project locally, RuntimehostEnabled can be set to false and LocalDevelopment is true, so requests will go to runtime host running locally.
- Once we have migrated applens to runtimehost completely, we can get rid of the flags and there will be only one flow.