### PR TITLE
Addressed Change Analysis UI feedback

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/assets/custom-timeline.css
+++ b/AngularApp/projects/app-service-diagnostics/src/assets/custom-timeline.css
@@ -7,3 +7,6 @@
     background-color: lightblue;
     border-color: blue;
 }
+.vis-item {
+    cursor: pointer;
+}

--- a/AngularApp/projects/applens/src/assets/custom-timeline.css
+++ b/AngularApp/projects/applens/src/assets/custom-timeline.css
@@ -8,3 +8,6 @@
     border-color: blue;
 }
 
+.vis-item {
+    cursor: pointer;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
@@ -96,6 +96,7 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
                 });
             });
             this.tableItems.sort((i1, i2) => i1.level - i2.level);
+            this.expandedElement = this.tableItems[0];
             this.dataSource = new MatTableDataSource(this.tableItems);
         }
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -133,8 +133,7 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
                 id: changeset[0],
                 content: ' ',
                 start: changeset[3],
-                group: ChangeAnalysisUtilities.findGroupBySource(changeset[2]),
-                className: ChangeAnalysisUtilities.findGroupBySource(changeset[2]) == 1 ? 'blue' : 'green'
+                group: ChangeAnalysisUtilities.findGroupBySource(changeset[2])
             })
         });
         this.timeLineDataSet.add(updatedTimelineItems);
@@ -490,8 +489,7 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
                     id: row[0],
                     content: ' ',
                     start: row[3],
-                    group: ChangeAnalysisUtilities.findGroupBySource(row[2]),
-                    className: ChangeAnalysisUtilities.findGroupBySource(row[2]) == 1 ? 'blue' : 'green'
+                    group: ChangeAnalysisUtilities.findGroupBySource(row[2])
                 });
                 }
             });

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -151,9 +151,8 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
             id: changeset[0],
             content: ' ',
             start: changeset[3],
-            group: ChangeAnalysisUtilities.findGroupBySource(changeset[2]),
-            className: ChangeAnalysisUtilities.findGroupBySource(changeset[2]) == 1 ? 'blue' : 'green'
-        })
+            group: ChangeAnalysisUtilities.findGroupBySource(changeset[2])
+        });
         });
         this.loadingChangesTimeline = false;
         // DOM element where the Timeline will be attached
@@ -171,6 +170,7 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
         // Create a Timeline
         this.changesTimeline = new Timeline(container, this.timeLineDataSet, this.sourceGroups, options);
         this.changesTimeline.on('select', this.triggerChangeEvent);
+        this.changesTimeline.setSelection(changeSets[0][0]);
     }
 
     private initializeChangesView(data: DataTableResponseObject) {


### PR DESCRIPTION
- Highlight the most recent change group in the default view to indicate that it’s been selected. 
- Change groups should be monotone in color unless selected. 
- Change the cursor to a pointer style when a user hovers over a change group. 
- Make the top row from the change chart expanded by default