### PR TITLE
Fix graph when number is int

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
@@ -101,7 +101,7 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
         if (row[columnIndex]) {
           const point: TablePoint = <TablePoint>{
             timestamp: timestamp,
-            value: parseFloat(row[columnIndex]),
+            value: Number(row[columnIndex]),
             column: column.columnName,
             counterName: counterNameColumnIndex >= 0 ? row[counterNameColumnIndex] : null
           };

--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-instance-graph/time-series-instance-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-instance-graph/time-series-instance-graph.component.ts
@@ -105,7 +105,7 @@ export class TimeSeriesInstanceGraphComponent extends DataRenderBaseComponent im
 
           const point: InstanceTablePoint = <InstanceTablePoint>{
             timestamp: timestamp,
-            value: parseFloat(row[columnIndex]),
+            value: Number(row[columnIndex]),
             counterName: column.columnName,
             instance: instance
           };


### PR DESCRIPTION
I was getting a NaN for 0, discovered it is any integer. 

parseFloat returns 'NaN' for an integer, Number() constructor handles either float or int. 