### PR TITLE
Performance improvement of the change list view

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.html
@@ -76,6 +76,7 @@
   <ng-container matColumnDef="expandedDetail">
     <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length" class="detail-cell">
       <div [@changeRowExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+        <div *ngIf="element == expandedElement">
           <ngx-monaco-diff-editor class="diff-view" [options]="options" [(originalModel)]="element.originalModel"
             [(modifiedModel)]="element.modifiedModel"></ngx-monaco-diff-editor>
           <div class="feedback-view">
@@ -83,6 +84,7 @@
             <div [ngClass]="getFeedbackButtonClass(element, true)" (click)="sendFeedback(element, true)">Yes</div>
             <div [ngClass]="getFeedbackButtonClass(element, false)" (click)="sendFeedback(element, false)">No</div>
           </div>
+        </div>
       </div>
     </td>
   </ng-container>


### PR DESCRIPTION
The existing implementation will blindly load the monaco editors for all changes, which will make the UI unresponsive when there is a huge list of changes (100 changes for example).
The fix is to load the editor only when it's expanded.