### PR TITLE
Nmallick1/apim case submission fix

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -38,7 +38,7 @@ export class WebSitesService extends ResourceService {
                 return Observable.of("16072");
             }
             else{
-                return null;
+                return Observable.of(null);
             }
         }));
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/resource.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/resource.service.ts
@@ -38,7 +38,7 @@ export class ResourceService {
   }
 
   public getPesId(): Observable<string>{
-    return null;
+    return Observable.of(null);
   }
 
   public get searchSuffix(): string {


### PR DESCRIPTION
Returning an empty PesId in case of a generic resource. Does not impact the search flow and case submission works for other resource types.