### PR TITLE
Fix Wrap Text issue in Ngx-DataTable for FrebViewer tool

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.ts
@@ -21,7 +21,7 @@ export class DataTableComponent extends DataRenderBaseComponent implements After
     }
 
     if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
-      this.currentStyles = { 'height': this.renderingProperties.height };
+      this.currentStyles = { 'height': this.renderingProperties.height ,'overflow-y':'visible' };
     }
 
     if (this.renderingProperties.tableOptions != null) {


### PR DESCRIPTION
To able to wrap text in a DataTable, we have to set RowHeight to Auto but with the scrollbarV is breaking. The quick way to fix this is by setting a scrollbar on the component itself and set rowHeight to Auto in detector code.