### PR TITLE
UI improvements for Change Analysis batch API

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.html
@@ -101,7 +101,7 @@
 
 <div class="table-top text-center">
   <em *ngIf="tableItems.length <= 0" >
-      No distinct changes were found in the selected change group.
+      No distinct changes were found.
   </em>
   <em>To view other changes, select a change group in the timeline. To zoom in and out, scroll the timeline up and down</em>
 </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
@@ -50,9 +50,6 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
     }, {
         "imgSrc": "../../../assets/img/importanticon.png",
         "displayValue": "Important"
-    }, {
-        "imgSrc": "../../../assets/img/noiseicon.png",
-        "displayValue": "Noise"
     }];
 
     private _changeFeedbacks: Map<Change, boolean> = new Map<Change, boolean>();
@@ -81,7 +78,7 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
                 let jsonPath    = this.getChangeProperty(row, "jsonPath", changesTable);
                 let initiatedBy = this.initiatedByList;
                 this.tableItems.push({
-                    "time":  moment(timestamp).format("MMM D YYYY, h:mm:ss a"),
+                    "time":  moment.utc(timestamp).format("YYYY-MM-DD HH:mm"),
                     "level": level,
                     "levelIcon": this.getIconForLevel(level),
                     "displayName":ChangeAnalysisUtilities.prepareDisplayValueForTable(displayName),
@@ -92,7 +89,7 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
                     'jsonPath': jsonPath,
                     'originalModel': ChangeAnalysisUtilities.prepareValuesForDiffView(oldValue),
                     'modifiedModel': ChangeAnalysisUtilities.prepareValuesForDiffView(newValue),
-                    'initiatedByList' : this.initiatedByList
+                    'initiatedByList' : row['initiatedByList'] ? row['initiatedByList'] : this.initiatedByList
                 });
             });
             this.tableItems.sort((i1, i2) => i1.level - i2.level);

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -569,9 +569,6 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
     }
 
     getBatchChanges(data: DataTableResponseObject): any[][] {
-        if(data.rows.length < 1) {
-            return [];
-        }
         let changeDetails = [];
         let columnIndex = DataTableUtilities.getColumnIndexByName(data, "Inputs");
         data.rows.forEach(row => {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changesets-view/changesets-view.component.ts
@@ -87,9 +87,9 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
             }
             if(isAppService) {
                 // Convert UTC timestamp to user readable date
-                this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : this.noScanMsg + ' Please enable Change Analysis using Change Analysis Settings.';
+                this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment.utc(rows[0][6]).format("YYYY-MM-DD HH:mm") : this.noScanMsg + ' Please enable Change Analysis using Change Analysis Settings.';
             } else {
-                this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment(rows[0][6]).format("ddd, MMM D YYYY, h:mm:ss a") : 'No recent scans were performed on this resource.';
+                this.scanDate = rows[0][6] != '' ? 'Changes were last scanned on ' + moment.utc(rows[0][6]).format("YYYY-MM-DD HH:mm") : 'No recent scans were performed on this resource.';
             }
 
             if(this.isPublic) {
@@ -137,7 +137,6 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
             })
         });
         this.timeLineDataSet.add(updatedTimelineItems);
-        this.changesTimeline.setSelection(changeSets[0][0]);
     }
 
     private constructTimeline(data: DataTableResponseObject) {
@@ -164,13 +163,16 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
         let options = {
             maxHeight: 400,
             horizontalScroll: true,
-            verticalScroll: true
+            verticalScroll: true,
+            // Set the timeline to show dates in UTC.
+            moment: function (date) {
+                return moment.utc(date);
+              }
             };
 
         // Create a Timeline
         this.changesTimeline = new Timeline(container, this.timeLineDataSet, this.sourceGroups, options);
         this.changesTimeline.on('select', this.triggerChangeEvent);
-        this.changesTimeline.setSelection(changeSets[0][0]);
     }
 
     private initializeChangesView(data: DataTableResponseObject) {
@@ -184,14 +186,14 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
         let latestChangeSetId = data.rows[0][changeSetIdColumnIndex];
         let latestChangeSet = data.rows[0][inputsColumnIndex];
         this.selectedChangeSetId = latestChangeSetId;
-
+        // Send all changes row instead of latest row.
         if(latestChangeSet != null) {
             this.loadingChangesTable = true;
             this.changesTableError = '';
             this.changesDataSet = [{
                table:{
                     columns:[],
-                    rows: data.rows[0][7]
+                    rows: this.getBatchChanges(data)
                     },
                 renderingProperties: {
                     type: RenderingType.ChangesView,
@@ -564,5 +566,19 @@ export class ChangesetsViewComponent extends DataRenderBaseComponent implements 
             return ["N/A"];
         }
         return [changeSet[initiatedByIndex]];
+    }
+
+    getBatchChanges(data: DataTableResponseObject): any[][] {
+        if(data.rows.length < 1) {
+            return [];
+        }
+        let changeDetails = [];
+        let columnIndex = DataTableUtilities.getColumnIndexByName(data, "Inputs");
+        data.rows.forEach(row => {
+            if (row[columnIndex] != null || row[columnIndex].length > 0) {
+                changeDetails = changeDetails.concat(row[columnIndex]);
+            }
+        });
+        return changeDetails;
     }
 }


### PR DESCRIPTION
- Display last 24h changes by default
- Noisy changes filtered out by default
- Last Scan timestamp, timestamp on each change, timeline displayed in UTC
- Removed noise icon from table legend
