### PR TITLE
Updated Change Analysis insight title, removed caching for getDetector API call

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/changes-view/changes-view.component.ts
@@ -89,7 +89,7 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
                     'jsonPath': jsonPath,
                     'originalModel': ChangeAnalysisUtilities.prepareValuesForDiffView(oldValue),
                     'modifiedModel': ChangeAnalysisUtilities.prepareValuesForDiffView(newValue),
-                    'initiatedByList' : row['initiatedByList'] ? row['initiatedByList'] : this.initiatedByList
+                    'initiatedByList' : row['initiatedByList'] ? this.getInitiatedByUsers(row) : this.initiatedByList
                 });
             });
             this.tableItems.sort((i1, i2) => i1.level - i2.level);
@@ -176,6 +176,10 @@ export class ChangesViewComponent extends DataRenderBaseComponent implements OnI
         };
 
         return eventProps;
+    }
+
+    getInitiatedByUsers(row: any[]): any[] {
+        return row['initiatedByList'].length > 0 ? row['initiatedByList'] : ['Unable to Determine'];
     }
 }
 


### PR DESCRIPTION
- Updated Change Analysis insight title to reflect number of changes instead of change groups.
  Current UI:
![image](https://user-images.githubusercontent.com/46545195/67242253-fdb6a800-f409-11e9-8f0e-9b25fd9721a1.png)

 New UI:
![image](https://user-images.githubusercontent.com/46545195/67242211-e2e43380-f409-11e9-8658-9280c17ed0b1.png)


- Removed caching call for getDetector API call by passing `shouldRefresh` parameter as `true`