### PR TITLE
Change tooltip opacity and reflow behavior

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -156,7 +156,7 @@ export class HighchartsGraphComponent implements OnInit {
             },
             chart: {
                 reflow: true,
-                height: 200,
+                height: 300,
                 display: 'block!important',
                 type: 'line',
                 zoomType: 'x',
@@ -202,6 +202,8 @@ export class HighchartsGraphComponent implements OnInit {
                 enabled: true,
                 valueDecimals: 2,
                 useHTML: true,
+                outside: true,
+                backgroundColor: "white",
             },
             navigation: {
                 buttonOptions: {
@@ -239,7 +241,7 @@ export class HighchartsGraphComponent implements OnInit {
                         onclick: function () {
                             var series = this.series;
                             for (var i = 0; i < series.length; i++) {
-                                series[i].hide();
+                                series[i].setVisible(false, false);
                             }
                         }
                     },
@@ -248,7 +250,7 @@ export class HighchartsGraphComponent implements OnInit {
                         onclick: function () {
                             var series = this.series;
                             for (var i = 0; i < series.length; i++) {
-                                series[i].show();
+                                series[i].setVisible(true, false);
                             }
                         }
                     }
@@ -276,7 +278,6 @@ export class HighchartsGraphComponent implements OnInit {
                     year: '%Y'
                 },
                 labels: {
-                    useHTML: true,
                     style: {
                         whiteSpace: 'nowrap'
                     }


### PR DESCRIPTION
1. In highcharts, texts and labels are given in HTML but rendered as SVG. When useHTML both set to be true, tooltip will be laid below XAxis labels. Remove Xaxis "useHTML=true" and set "tooltip.outside" to prevent this behavior in Highcharts 6.1.1. 

![image](https://user-images.githubusercontent.com/38216903/70289604-1dbbe400-178a-11ea-8612-04fc54e643ff.png)

2. Change select "All" and "None" behavior.
series.hide() and series.show() will try to reflow the chart. If there are too many series, UI will freeze.
However setVisible is only set the visible status, which works instantaneously.

3. Change the default height of linechart from "200px" to "300px".
![image](https://user-images.githubusercontent.com/38216903/70289738-96bb3b80-178a-11ea-91d5-eb63461f424a.png)

