### PR TITLE
Fix monitoring developing page

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -68,7 +68,7 @@ export class OnboardingFlowComponent implements OnInit {
   allUtterances: any[] = [];
   recommendedUtterances: RecommendedUtterance[] = [];
   utteranceInput: string = "";
-  
+
   modalPublishingButtonText: string;
   modalPublishingButtonDisabled: boolean;
 
@@ -267,7 +267,7 @@ export class OnboardingFlowComponent implements OnInit {
       })
       .subscribe((response: any) => {
         this.queryResponse = response.body;
-        if (this.queryResponse.invocationOutput && this.queryResponse.invocationOutput.metadata){
+        if (this.queryResponse.invocationOutput && this.queryResponse.invocationOutput.metadata && !isSystemInvoker){
           this.id = this.queryResponse.invocationOutput.metadata.id;
         }
         if (this.queryResponse.invocationOutput.suggestedUtterances && this.queryResponse.invocationOutput.suggestedUtterances.results) {
@@ -327,7 +327,7 @@ export class OnboardingFlowComponent implements OnInit {
       this.ngxSmartModalService.getModal('publishModal').open();
     }
   }
-  
+
   prepareMetadata() {
     this.publishingPackage.metadata = JSON.stringify({ "utterances": this.allUtterances });
   }
@@ -339,7 +339,7 @@ export class OnboardingFlowComponent implements OnInit {
       this.publishingPackage.dllBytes === '') {
       return;
     }
-    
+
     this.prepareMetadata();
     this.publishButtonDisabled = true;
     this.runButtonDisabled = true;


### PR DESCRIPTION
Detector Id gets override for monitoring developing page after we run monitoring dashboard code for the first time, which incorrectly set the detector id gets monitored to be the current system invoker id ("__monitoring" or "__analytics").

This was causing the second run of monitoring code failed previously.
