### PR TITLE
Render chart properly when there is only one data point

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
@@ -143,8 +143,8 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
             });
         });
 
-        // If there is only 1 or 0 points, fallback on no data defaults
-        if (data.table.rows.length <= 1) {
+        // If there is no point, fallback on no data defaults
+        if (data.table.rows.length < 1) {
             this.timeGrain = this._getNoDataTimegrain();
         }
 
@@ -229,17 +229,12 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
         if (rangeInMonths > 1 || this.customizeXAxis && rangeInMonths === 1) {
             return moment.duration(1, 'months');
         }
-        // 7 days -> 1 month: 1 day
-        if (rangeInHours >= 168) {
-            return moment.duration(7, 'days');
+         // 7 days -> 1 month: 1 day
+         if (rangeInHours >= 168) {
+            return moment.duration(1, 'days');
         }
 
-        // 1 days -> 7 days
-        if (rangeInHours > 24) {
-            return moment.duration(24, 'hours');
-        }
-
-        // else 1 hr
+        // Other scenarios we set the default as 60 minutes
         return moment.duration(60, 'minutes');
     }
 


### PR DESCRIPTION
When there is only one data point, we should not determine the timegrain only based on the starttime and endtime. Otherwise the data point won't show up in the bar chart.

The initial value should be 60 mins if the time difference between start time and end time is less than 7 days. 

For instance this example:
https://applens.azurewebsites.net/subscriptions/878ee15c-1efd-43de-b6ad-3f7e15338b1d/resourceGroups/rg-big-paceaissima-qa/providers/Microsoft.Web/sites/asfa-big-bib-qa-mapping/detectors/FunctionAppDeployed?startTime=2019-12-03T21:21&endTime=2019-12-05T21:05

This is after fix:
![image](https://user-images.githubusercontent.com/38216903/70366255-dc3f3d80-184a-11ea-961f-d953593ba1fd.png)

This kind of bug is not my favorite lol