### PR TITLE
Fix the 0 values not rendered properly in timeseries

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
@@ -130,7 +130,7 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
 
                 lastTimeStamp = timestamp;
 
-                if (row[columnIndex]) {
+                if (columnIndex > -1) {
                     const point: TablePoint = <TablePoint>{
                         timestamp: timestamp,
                         value: parseFloat(row[columnIndex]),
@@ -230,7 +230,7 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
             return moment.duration(1, 'months');
         }
          // 7 days -> 1 month: 1 day
-         if (rangeInHours >= 168) {
+         if (rangeInHours > 168) {
             return moment.duration(1, 'days');
         }
 


### PR DESCRIPTION
In the timeseries logic, first we determine which column of the input table we want to render as y axis values. (This is determined by iterating all the columns and return the column index which has datatype of double or int.) Once we get the counter column index, we push the datapoint and reformat it as “TablePoint” format for timeseries rendering.

    data.table.rows.forEach(row => {
            numberValueColumns.forEach(column => {
                const columnIndex: number = data.table.columns.indexOf(column);
                const timestamp = moment.utc(row[timestampColumn]);

                lastTimeStamp = timestamp;
                if (row[columnIndex]) {
                    const point: TablePoint = <TablePoint>{
                        timestamp: timestamp,
                        value: parseFloat(row[columnIndex]),
                        column: column.columnName,
                        counterName: counterNameColumnIndex >= 0 ? row[counterNameColumnIndex] : null
                    };

                    tablePoints.push(point);
                }
            });

In the above logic,  we are using if(row[columnIndex]) to determine if the counter column exists for that row. For most of the cases it will work because the counter column doesn’t exist for this row. But this logic will also fail if the row[columIndex] has 0 values.