### PR TITLE
Making gist version history scrollable

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/gist-changelist/gist-changelist.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/gist-changelist/gist-changelist.component.scss
@@ -68,6 +68,8 @@ a:active {
   width: 11%;
   padding-left: 0px;
   padding-right: 0px;
+  overflow: scroll;
+  height: calc(100vh - 200px);
 }
 
 .commit-editor {


### PR DESCRIPTION
Old experience in applens gist version history:
![image](https://user-images.githubusercontent.com/8492235/71385676-c4cbb880-259d-11ea-8aae-85e6c6137f2c.png)
![image](https://user-images.githubusercontent.com/8492235/71385681-cac19980-259d-11ea-8d59-cecbd236e929.png)

New experience:
![image](https://user-images.githubusercontent.com/8492235/71385690-d3b26b00-259d-11ea-9ba8-f3067da3b7d2.png)

