### PR TITLE
Monitor SCM process in proactive cpu monitoring

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.html
@@ -170,7 +170,7 @@
             </div>
             <div class="media-body">
               <div class="media-heading label-header">Monitor Web job processes</div>
-              Enable this to monitor the process for Kudu site and all webjobs
+              Enable this to monitor the process for Kudu site and webjobs
             </div>
           </div>
         </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.html
@@ -162,6 +162,26 @@
         </div>
       </div>
 
+      <div class="row input-row">
+        <div class="col-sm-6">
+          <div class="media">
+            <div class="media-left media-middle">
+              <i class="media-object fa fa-cogs tile-icon"></i>
+            </div>
+            <div class="media-body">
+              <div class="media-heading label-header">Monitor Web job processes</div>
+              Enable this to monitor the process for Kudu site and all webjobs
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-5">
+          <div *ngIf="editMode" class="custom-slider">
+            <toggle-button ToggleText="" [(selected)]="monitoringSession.MonitorScmProcesses" (selectedChange)="updateRuleSummary()"></toggle-button>
+          </div>
+          <div *ngIf="!editMode" class="readonly-mode">{{ monitoringSession.MonitorScmProcesses }}</div>
+        </div>
+      </div>
+
       <div class="row">
         <div class="summary-title">Rule Configuration</div>
         <div class="col-sm-9 summary-box" [innerHTML]="ruleSummary">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
@@ -125,7 +125,7 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
     monitoringSession.Mode = SessionMode.CollectAndKill;
     monitoringSession.MaxActions = 2;
     monitoringSession.ThresholdSeconds = 30;
-    monitoringSession.MaximumNumberOfHours = 24 * 7;
+    monitoringSession.MaximumNumberOfHours = 24 * 14;
     this.mode = monitoringSession.Mode;
     this.modeDescription = this.modeDescriptions.find(x => x.Mode == this.mode).Description;
     this.selectMode(this.mode);
@@ -164,6 +164,10 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
     }
 
     this.ruleSummary += ` Monitoring will stop automatically after <b>${this.monitoringSession.MaximumNumberOfHours > 24 ? (this.getValueRounded(this.monitoringSession.MaximumNumberOfHours / 24)) + " days" : this.monitoringSession.MaximumNumberOfHours + " hours"}</b>.`;
+
+    if (this.monitoringSession.MonitorScmProcesses){
+      this.ruleSummary += " The worker process for the kudu site and all the webjobs under this app will also be monitored."
+    }
   }
 
   saveCpuMonitoring() {
@@ -177,6 +181,7 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
       newSession.ThresholdSeconds = this.monitoringSession.ThresholdSeconds;
       newSession.CpuThreshold = this.monitoringSession.CpuThreshold;
       newSession.MaximumNumberOfHours = this.monitoringSession.MaximumNumberOfHours;
+      newSession.MonitorScmProcesses = this.monitoringSession.MonitorScmProcesses;
 
       this._daasService.submitMonitoringSession(this.siteToBeDiagnosed, newSession).subscribe(
         result => {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
@@ -166,7 +166,7 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
     this.ruleSummary += ` Monitoring will stop automatically after <b>${this.monitoringSession.MaximumNumberOfHours > 24 ? (this.getValueRounded(this.monitoringSession.MaximumNumberOfHours / 24)) + " days" : this.monitoringSession.MaximumNumberOfHours + " hours"}</b>.`;
 
     if (this.monitoringSession.MonitorScmProcesses){
-      this.ruleSummary += " The worker process for the kudu site and all the webjobs under this app will also be monitored."
+      this.ruleSummary += " The worker process for the kudu site and the webjobs under this app will also be monitored."
     }
   }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -131,7 +131,7 @@ export class MonitoringSession {
     StartDate: string;
     EndDate: string;
     ProcessesToMonitor: string;
-    MonitorScmProcess: boolean;
+    MonitorScmProcesses: boolean;
     CpuThreshold: number;
     ThresholdSeconds: number;
     MonitorDuration: number;


### PR DESCRIPTION
- Adding support to monitor Scm processes and
- increasing the default time to 2 weeks instead of one.

![image](https://user-images.githubusercontent.com/5299838/73048690-f935db80-3e9f-11ea-932d-d67ca7751767.png)
