### PR TITLE
Temporary access provision for AppLens

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
@@ -1,7 +1,8 @@
 <div class="unauthorized-container">
     <div class="unauthorized-div">
         <img src="assets/img/unauthorized.svg" class="unauthorized-icon"/>
-        <p class="unauthorized-header">Unauthorized - You do not have valid permissions to access AppLens. Please follow these steps in order to gain access:</p>
+        <p class="unauthorized-header">Unauthorized - You do not have valid permissions to access AppLens. Please request for <a href="https://myaccess/identityiq/ui/rest/redirect?rp1=/accessRequest/accessRequest.jsf&rp2=accessRequest/review?role=AppLens+Access&autoSubmit=true" target="_blank" rel="noopener noreferrer">AppLens Access here</a>.</p>
+        <p><u>If the above direct link does not work</u>, please follow the below steps to apply for access.</p>
         <ol>
             <li>Go to <a href="https://myaccess" target="_blank" rel="noopener noreferrer">MyAccess</a></li>
             <li>Click on <strong>Request Access</strong></li>
@@ -11,9 +12,10 @@
         </ol>
         <div style="border-bottom: 3px solid black;"></div>
         <div style="margin-top:20px;">
-            <div *ngIf="!temporaryAccessFailed && !temporaryAccessSucceeded" class="temporary-access-link" (click)="requestTemporaryAccess()">Click here to request <strong>one time</strong> temporary access for 7 days</div>
+            Need Urgent Access?&nbsp;&nbsp;<div *ngIf="!temporaryAccessFailed && !temporaryAccessSucceeded" class="temporary-access-link" (click)="requestTemporaryAccess()">Click here to request <strong>one time</strong> temporary access for 7 days</div>
             <div *ngIf="temporaryAccessFailed">{{accessFailedReason}}</div>
             <div *ngIf="temporaryAccessSucceeded">{{temporaryAccessSuccessMessage}} Redirecting to home....</div>
+            <div *ngIf="!temporaryAccessFailed"><strong>Disclaimer:</strong> This is temporary access only. <u>Please make sure to apply for AppLens Access</u> as mentioned above.</div>
         </div>
     </div>
 </div>

--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
@@ -9,5 +9,11 @@
             <li>Click <strong>Next</strong> and move to Review and Submit</li>
             <li>Make sure <strong>AppLens Access</strong> is selected and click <strong>Submit</strong></li>
         </ol>
+        <div style="border-bottom: 3px solid black;"></div>
+        <div style="margin-top:20px;">
+            <div *ngIf="!temporaryAccessFailed && !temporaryAccessSucceeded" class="temporary-access-link" (click)="requestTemporaryAccess()">Click here to request <strong>one time</strong> temporary access for 7 days</div>
+            <div *ngIf="temporaryAccessFailed">{{accessFailedReason}}</div>
+            <div *ngIf="temporaryAccessSucceeded">{{temporaryAccessSuccessMessage}} Redirecting to home....</div>
+        </div>
     </div>
 </div>

--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.scss
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.scss
@@ -20,3 +20,9 @@
     width: 120px;
     padding-bottom: 20px;
 }
+
+.temporary-access-link{
+    text-decoration: underline;
+    cursor: pointer;
+    color: #72afd2;
+}

--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.ts
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.ts
@@ -1,4 +1,6 @@
 import {Component, OnInit} from '@angular/core';
+import { DiagnosticApiService } from '../../services/diagnostic-api.service';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'app-unauthorized',
@@ -6,6 +8,28 @@ import {Component, OnInit} from '@angular/core';
     styleUrls: ['./unauthorized.component.scss']
   })
 export class UnauthorizedComponent implements OnInit {
+    temporaryAccessFailed: boolean = false;
+    accessFailedReason: string = "";
+    temporaryAccessSucceeded: boolean = false;
+    temporaryAccessSuccessMessage: string = "";
+
+    public constructor(private _router: Router, private _diagnosticApiService: DiagnosticApiService){
+      
+    }
     ngOnInit(){
+    }
+
+    requestTemporaryAccess(){
+      this._diagnosticApiService.requestTemporaryAccess().subscribe(res => {
+        this.temporaryAccessSuccessMessage = res;
+        this.temporaryAccessSucceeded = true;
+        setTimeout(() => {
+          this._router.navigateByUrl('/');
+        }, 2000);
+      },
+      (err) => {
+        this.temporaryAccessFailed = true;
+        this.accessFailedReason = err.error;
+      });
     }
 }

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -90,6 +90,14 @@ export class DiagnosticApiService {
     return useCache ? this._cacheService.get(this.getCacheKey(HttpMethod.POST, url), request, invalidateCache) : request;
   }
 
+  public requestTemporaryAccess(): Observable<any> {
+    let url: string = `${this.diagnosticApi}temporaryAccess/requestAccess`;
+    let request = this._httpClient.get(url, {
+      headers: this._getHeaders()
+    });
+    return request;
+  }
+
   public getSupportTopics(pesId: any, useCache: boolean = true, invalidateCache: boolean = false): Observable<any> {
     let url: string = `${this.diagnosticApi}api/supporttopics/${pesId}`;
     let request = this._httpClient.get(url, {

--- a/ApplensBackend/.gitignore
+++ b/ApplensBackend/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 # local app settings
 appsettings.Development.json
 appsettings.Local.json
+appsettings.*.json
 
 # Nuget
 /packages

--- a/ApplensBackend/AppLensV3.csproj
+++ b/ApplensBackend/AppLensV3.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="Sendgrid" Version="9.10.0" />

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Authorization;
 using AppLensV3.Authorization;
 using System.Collections.Generic;
+using AppLensV3.Services.CosmosDBHandler;
+using AppLensV3.Models;
 
 namespace AppLensV3
 {
@@ -53,6 +55,7 @@ namespace AppLensV3
             services.AddSingleton<ISupportTopicService, SupportTopicService>();
             services.AddSingleton<ISelfHelpContentService, SelfHelpContentService>();
             services.AddSingleton<IFreshChatClientService, FreshChatClientService>();
+            services.AddSingleton<ICosmosDBHandler<TemporaryAccessUser>, CosmosDBHandler<TemporaryAccessUser>>();
 
             services.AddMemoryCache();
             services.AddMvc();
@@ -84,6 +87,9 @@ namespace AppLensV3
                 Configuration.Bind("ApplensAccess", applensAccess);
                 Configuration.Bind("ApplensTesters", applensTesters);
 
+                options.AddPolicy("DefaultAccess", policy => {
+                    policy.Requirements.Add(new DefaultAuthorizationRequirement());
+                });
                 options.AddPolicy(applensAccess.GroupName, policy => {
                    policy.Requirements.Add(new SecurityGroupRequirement(applensAccess.GroupName, applensAccess.GroupId));
                 });
@@ -93,6 +99,7 @@ namespace AppLensV3
             });
 
             services.AddSingleton<IAuthorizationHandler, SecurityGroupHandler>();
+            services.AddSingleton<IAuthorizationHandler, DefaultAuthorizationHandler>();
 
             if (Configuration["ServerMode"] == "internal")
             {

--- a/ApplensBackend/Configuration/StartupNationalCloud.cs
+++ b/ApplensBackend/Configuration/StartupNationalCloud.cs
@@ -54,8 +54,11 @@ namespace AppLensV3.Configuration
             services.AddMemoryCache();
             // Add auth policies as they are applied on controllers
             services.AddAuthorization(options => {
+                options.AddPolicy("DefaultAccess", policy => {
+                    policy.Requirements.Add(new DefaultAuthorizationRequirement());
+                });
                 options.AddPolicy("ApplensAccess", policy => {
-                policy.Requirements.Add(new SecurityGroupRequirement("ApplensAccess", string.Empty));
+                    policy.Requirements.Add(new SecurityGroupRequirement("ApplensAccess", string.Empty));
                 });
                 options.AddPolicy("ApplensTesters", policy => {
                     policy.Requirements.Add(new SecurityGroupRequirement("ApplensTesters", string.Empty));

--- a/ApplensBackend/Controllers/TemporaryAccessController.cs
+++ b/ApplensBackend/Controllers/TemporaryAccessController.cs
@@ -14,13 +14,15 @@ namespace AppLensV3.Controllers
     public class TemporaryAccessController : Controller
     {
         ICosmosDBHandler<TemporaryAccessUser> _cosmosDBHandler;
-        int temporaryAccessDays = 7;
+        long temporaryAccessDurationInSeconds = 7 * 24 * 60 * 60;
 
         public TemporaryAccessController(ICosmosDBHandler<TemporaryAccessUser> cosmosDBHandler, IConfiguration configuration)
         {
             _cosmosDBHandler = cosmosDBHandler;
             var accessDurationInDays = configuration["ApplensTemporaryAccess:AccessDurationInDays"];
+            int temporaryAccessDays = 7;
             int.TryParse(accessDurationInDays.ToString(), out temporaryAccessDays);
+            temporaryAccessDurationInSeconds = temporaryAccessDays * 24 * 60 * 60;
         }
 
         [HttpGet("requestAccess")]
@@ -50,7 +52,7 @@ namespace AppLensV3.Controllers
                     }
                     else
                     {
-                        if ((long)DateTime.UtcNow.Subtract(result.AccessStartDate).TotalSeconds >= temporaryAccessDays * 24 * 60 * 60)
+                        if ((long)DateTime.UtcNow.Subtract(result.AccessStartDate).TotalSeconds >= temporaryAccessDurationInSeconds)
                         {
                             return BadRequest("One-time temporary access already used! Please request for AppLens Access on MyAccess.");
                         }

--- a/ApplensBackend/Controllers/TemporaryAccessController.cs
+++ b/ApplensBackend/Controllers/TemporaryAccessController.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using AppLensV3.Services.CosmosDBHandler;
+using AppLensV3.Models;
+using Microsoft.AspNetCore.Authorization;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Extensions.Configuration;
+
+namespace AppLensV3.Controllers
+{
+    [Route("temporaryAccess")]
+    [Authorize(Policy = "DefaultAccess")]
+    public class TemporaryAccessController : Controller
+    {
+        ICosmosDBHandler<TemporaryAccessUser> _cosmosDBHandler;
+        int temporaryAccessDays = 7;
+
+        public TemporaryAccessController(ICosmosDBHandler<TemporaryAccessUser> cosmosDBHandler, IConfiguration configuration)
+        {
+            _cosmosDBHandler = cosmosDBHandler;
+            var accessDurationInDays = configuration["ApplensTemporaryAccess:AccessDurationInDays"];
+            int.TryParse(accessDurationInDays.ToString(), out temporaryAccessDays);
+        }
+
+        [HttpGet("requestAccess")]
+        public async Task<IActionResult> RequestAccess()
+        {
+            string userId = null;
+            var authorization = Request.Headers["Authorization"].ToString();
+            string accessToken = authorization.Split(" ")[1];
+            var token = new JwtSecurityToken(accessToken);
+            object upn;
+            if (token.Payload.TryGetValue("upn", out upn))
+            {
+                userId = upn.ToString();
+                if (userId != null)
+                {
+                    var result = await _cosmosDBHandler.GetItemAsync(userId);
+                    if (result == null)
+                    {
+                        TemporaryAccessUser newUser = new TemporaryAccessUser()
+                        {
+                            Id = userId,
+                            AccessStartDate = DateTime.UtcNow,
+                            UserPrincipalName = userId
+                        };
+                        await _cosmosDBHandler.CreateItemAsync(newUser);
+                        return Ok("Temporary access approved!");
+                    }
+                    else
+                    {
+                        if ((long)DateTime.UtcNow.Subtract(result.AccessStartDate).TotalSeconds >= temporaryAccessDays * 24 * 60 * 60)
+                        {
+                            return BadRequest("One-time temporary access already used! Please request for AppLens Access on MyAccess.");
+                        }
+                        else
+                        {
+                            return Ok("User already has temporary access to AppLens.");
+                        }
+                    }
+                }
+            }
+
+            return BadRequest("Access token is missing user principal name.");
+        }
+    }
+}

--- a/ApplensBackend/Controllers/TemporaryAccessController.cs
+++ b/ApplensBackend/Controllers/TemporaryAccessController.cs
@@ -45,7 +45,7 @@ namespace AppLensV3.Controllers
                         {
                             Id = userId,
                             AccessStartDate = DateTime.UtcNow,
-                            UserPrincipalName = userId
+                            PartitionKey = "TemporaryAccessUser"
                         };
                         await _cosmosDBHandler.CreateItemAsync(newUser);
                         return Ok("Temporary access approved!");

--- a/ApplensBackend/Models/TemporaryAccessUser.cs
+++ b/ApplensBackend/Models/TemporaryAccessUser.cs
@@ -11,7 +11,7 @@ namespace AppLensV3.Models
         [JsonProperty(PropertyName = "accessStartDate")]
         public DateTime AccessStartDate { get; set; }
 
-        [JsonProperty(PropertyName = "UserPrincipalName")]
-        public string UserPrincipalName { get; set; }
+        [JsonProperty(PropertyName = "PartitionKey")]
+        public string PartitionKey { get; set; }
     }
 }

--- a/ApplensBackend/Models/TemporaryAccessUser.cs
+++ b/ApplensBackend/Models/TemporaryAccessUser.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace AppLensV3.Models
+{
+    public class TemporaryAccessUser
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "accessStartDate")]
+        public DateTime AccessStartDate { get; set; }
+
+        [JsonProperty(PropertyName = "UserPrincipalName")]
+        public string UserPrincipalName { get; set; }
+    }
+}

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
@@ -16,7 +16,7 @@ namespace AppLensV3.Services.CosmosDBHandler
         private string Key;
         private string DatabaseId;
         private string CollectionId;
-        private string PartitionKey = "/UserPrincipalName";
+        private string PartitionKey = "/PartitionKey";
         private DocumentClient client;
 
         public CosmosDBHandler(IConfiguration configuration)
@@ -36,7 +36,7 @@ namespace AppLensV3.Services.CosmosDBHandler
             {
                 Document document = await client.ReadDocumentAsync(
                     UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id),
-                    new RequestOptions {PartitionKey = new PartitionKey(id)});
+                    new RequestOptions {PartitionKey = new PartitionKey("TemporaryAccessUser")});
                 return (T)(dynamic)document;
             }
             catch (DocumentClientException e)

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace AppLensV3.Services.CosmosDBHandler
+{
+    public class CosmosDBHandler<T> : ICosmosDBHandler<T> where T : class
+    {
+        private string Endpoint;
+        private string Key;
+        private string DatabaseId;
+        private string CollectionId;
+        private string PartitionKey = "/UserPrincipalName";
+        private DocumentClient client;
+
+        public CosmosDBHandler(IConfiguration configuration)
+        {
+            Endpoint = configuration["ApplensTemporaryAccess:Endpoint"];
+            Key = configuration["ApplensTemporaryAccess:Key"];
+            DatabaseId = configuration["ApplensTemporaryAccess:DatabaseId"];
+            CollectionId = configuration["ApplensTemporaryAccess:CollectionId"];
+            this.client = new DocumentClient(new Uri(Endpoint), Key);
+            CreateDatabaseIfNotExistsAsync().Wait();
+            CreateCollectionIfNotExistsAsync().Wait();
+        }
+
+        public async Task<T> GetItemAsync(string id)
+        {
+            try
+            {
+                Document document = await client.ReadDocumentAsync(
+                    UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id),
+                    new RequestOptions {PartitionKey = new PartitionKey(id)});
+                return (T)(dynamic)document;
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        public async Task<Document> CreateItemAsync(T item)
+        {
+            return await client.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri(DatabaseId, CollectionId), item);
+        }
+
+        private async Task CreateDatabaseIfNotExistsAsync()
+        {
+            try
+            {
+                await client.ReadDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseId));
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    await client.CreateDatabaseAsync(new Database { Id = DatabaseId });
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private async Task CreateCollectionIfNotExistsAsync()
+        {
+            try
+            {
+                await client.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(DatabaseId, CollectionId));
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    DocumentCollection myCollection = new DocumentCollection();
+                    myCollection.Id = CollectionId;
+                    myCollection.PartitionKey.Paths.Add(PartitionKey);
+                    await client.CreateDocumentCollectionAsync(
+                        UriFactory.CreateDatabaseUri(DatabaseId),
+                        myCollection,
+                        new RequestOptions { OfferThroughput = 400 }
+                        );
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBHandler.cs
@@ -43,6 +43,12 @@ namespace AppLensV3.Services.CosmosDBHandler
             {
                 if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
+                    if (e.Message.Contains("Resource Not Found"))
+                    {
+                        CreateDatabaseIfNotExistsAsync().Wait();
+                        CreateCollectionIfNotExistsAsync().Wait();
+                        return await GetItemAsync(id);
+                    }
                     return null;
                 }
                 else

--- a/ApplensBackend/Services/CosmosDBHandler/ICosmosDBHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/ICosmosDBHandler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+
+namespace AppLensV3.Services.CosmosDBHandler
+{
+    public interface ICosmosDBHandler<T> where T : class
+    {
+        Task<Document> CreateItemAsync(T item);
+        Task<T> GetItemAsync(string id);
+    }
+}

--- a/ApplensBackend/appsettings.json
+++ b/ApplensBackend/appsettings.json
@@ -96,5 +96,12 @@
   },
   "ContentSearch": {
     "Ocp-Apim-Subscription-Key": ""
+  },
+  "ApplensTemporaryAccess": {
+    "Endpoint": "",
+    "Key": "",
+    "DatabaseId": "",
+    "CollectionId": "",
+    "AccessDurationInDays": "7"
   }
 }


### PR DESCRIPTION
Temporary Access Provision for AppLens. It defaults to 7 days and can be availed one time only.
Screenshots:
When user does not have access to applens
![image](https://user-images.githubusercontent.com/8492235/73206399-b1a98c80-40f7-11ea-8b27-a52033cfb2f4.png)


When temporary access is approved
![image](https://user-images.githubusercontent.com/8492235/73206442-c6862000-40f7-11ea-95eb-7eecbde61294.png)

And user is redirected to home page
![image](https://user-images.githubusercontent.com/8492235/73142369-83b64080-4042-11ea-8f26-acd3e82cd4b3.png)

When user has already used one-time temporary access
![image](https://user-images.githubusercontent.com/8492235/73206496-e0276780-40f7-11ea-83a5-210a62825ae9.png)

