### PR TITLE
Fix AppLens to load for sites with non-ascii chars

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -264,8 +264,8 @@ export class DiagnosticApiService {
       headers = headers.set('x-ms-method', HttpMethod[method]);
     }
 
-    if (this.Location) { 
-     headers = headers.set('x-ms-location', encodeURI(this.Location));
+    if (this.Location) {
+      headers = headers.set('x-ms-location', encodeURI(this.Location));
     }
 
     if (additionalHeaders) {

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -257,15 +257,15 @@ export class DiagnosticApiService {
       headers = headers.set("x-ms-geomaster-hostname", this.GeomasterServiceAddress);
 
     if (path) {
-      headers = headers.set('x-ms-path-query', path);
+      headers = headers.set('x-ms-path-query', encodeURI(path));
     }
 
     if (method) {
       headers = headers.set('x-ms-method', HttpMethod[method]);
     }
 
-    if (this.Location) {
-      headers = headers.set('x-ms-location', this.Location);
+    if (this.Location) { 
+     headers = headers.set('x-ms-location', encodeURI(this.Location));
     }
 
     if (additionalHeaders) {


### PR DESCRIPTION
The actual issue why it was failing was this exception

`Error while sending request: Failed to execute setRequestHeader on XMLHttpRequest: Value is not a valid ByteString.`