### PR TITLE
SearchComponent: Cognitive search optimization and Detector search updates

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -23,7 +23,8 @@ export class ContentService {
 
   private ocpApimKeySubject: Subject<string> = new ReplaySubject<string>(1);
   private ocpApimKey: string = '';
-
+  private whitelistedStacks: string[] = ["net", "net core", "asp", "php", "python", "node", "docker", "java", "tomcat", "kube", "ruby", "dotnet", "static"];
+  
   constructor(private _http: HttpClient, private _resourceService: ResourceService, private _backendApi: BackendCtrlService) { 
 
     this._backendApi.get<string>(`api/appsettings/ContentSearch:Ocp-Apim-Subscription-Key`).subscribe((value: string) =>{
@@ -44,10 +45,17 @@ export class ContentService {
   searchWeb(questionString: string, resultsCount: string = '3'): Observable<any> {
 
     const searchSuffix = this._resourceService.searchSuffix;
+
+    //Decide the stack type to use with query
     var stackTypeSuffix = this._resourceService["appStack"]? ` ${this._resourceService["appStack"]}`: "";
-    if (stackTypeSuffix && stackTypeSuffix.length>0 && stackTypeSuffix.toLowerCase() == "static only"){
-      stackTypeSuffix = "Static content";
+    stackTypeSuffix = stackTypeSuffix.toLowerCase();
+    if (stackTypeSuffix && stackTypeSuffix.length>0 && stackTypeSuffix == "static only") {
+      stackTypeSuffix = "static content";
     }
+    if(!this.whitelistedStacks.some(stack => stackTypeSuffix.includes(stack))){
+      stackTypeSuffix = "";
+    }
+    
     const query = encodeURIComponent(`${questionString}${stackTypeSuffix} AND ${searchSuffix}`);
     const url = `https://api.cognitive.microsoft.com/bing/v7.0/search?q='${query}'&count=${resultsCount}`;
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -23,7 +23,7 @@ export class ContentService {
 
   private ocpApimKeySubject: Subject<string> = new ReplaySubject<string>(1);
   private ocpApimKey: string = '';
-  private whitelistedStacks: string[] = ["net", "net core", "asp", "php", "python", "node", "docker", "java", "tomcat", "kube", "ruby", "dotnet", "static"];
+  private allowedStacks: string[] = ["net", "net core", "asp", "php", "python", "node", "docker", "java", "tomcat", "kube", "ruby", "dotnet", "static"];
   
   constructor(private _http: HttpClient, private _resourceService: ResourceService, private _backendApi: BackendCtrlService) { 
 
@@ -52,7 +52,7 @@ export class ContentService {
     if (stackTypeSuffix && stackTypeSuffix.length>0 && stackTypeSuffix == "static only") {
       stackTypeSuffix = "static content";
     }
-    if(!this.whitelistedStacks.some(stack => stackTypeSuffix.includes(stack))){
+    if(!this.allowedStacks.some(stack => stackTypeSuffix.includes(stack))){
       stackTypeSuffix = "";
     }
     

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -241,7 +241,7 @@
     <div *ngIf="!isDynamicAnalysis && isSearchEmbedded && getPendingDetectorCount() === 0" style="margin-left:30px;">
         <detector-search [detector]="analysisId"></detector-search>
     </div>
-    <div *ngIf="isDynamicAnalysis && !showPreLoader && getPendingDetectorCount() === 0" style="margin-left:80px;margin-top:20px;">
+    <div *ngIf="isDynamicAnalysis && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch)" style="margin-left:80px;margin-top:20px;">
         <web-search [searchTerm]="searchTerm" [searchId]="searchId" [isChildComponent]="true" [maxResults]="5"></web-search>
     </div>
     <div class="list-wrapper" *ngIf="supportDocumentRendered">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -83,6 +83,8 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     showPreLoadingError: boolean = false;
     isSearchEmbedded: boolean = false;
     showSuccessfulChecks: boolean = true;
+    showWebSearch: boolean = false;
+    showWebSearchTimeout: any = null;
 
     constructor(private _activatedRoute: ActivatedRoute, private _router: Router,
         private _diagnosticService: DiagnosticService, private _detectorControl: DetectorControlService,
@@ -312,6 +314,10 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     }
 
     startDetectorRendering(detectorList) {
+        if (this.showWebSearchTimeout){
+            clearTimeout(this.showWebSearchTimeout);
+        }
+        this.showWebSearchTimeout = setTimeout(() => {this.showWebSearch = true;}, 10000);
         this.detectorMetaData = detectorList.filter(detector => this.detectors.findIndex(d => d.id === detector.id) >= 0);
         this.detectorViewModels = this.detectorMetaData.map(detector => this.getDetectorViewModel(detector));
         this.issueDetectedViewModels = [];
@@ -392,6 +398,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         this.allSolutions = [];
         this.loadingMessages = [];
         this.successfulViewModels = [];
+        this.showWebSearch = false;
 
     }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
@@ -150,7 +150,7 @@
                 </div>
             </div>
         </div>
-        <div style="margin-top: 20px;" *ngIf="showSearchTermPractices || showPreLoadingError || (detectors.length>0 && getPendingDetectorCount() == 0)">
+        <div style="margin-top: 20px;" *ngIf="(detectors.length>0 && getPendingDetectorCount() == 0) || showWebSearch">
             <web-search [searchTerm]="searchTerm" [searchId]="searchId" [isChildComponent]="true" [(searchResults)]="webSearchResults" [maxResults]="5"></web-search>
         </div>
     </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
@@ -69,6 +69,8 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
     firstLoad: boolean = true;
 
     webSearchResults: any[] = [];
+    showWebSearch: boolean = false;
+    webSearchShowTimeout: any = null;
 
     @Input()
     withinDiagnoseAndSolve: boolean = false;
@@ -109,6 +111,7 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
     handleRequestFailure() {
         this.showPreLoadingError = true;
         this.showSearchTermPractices = false;
+        this.showWebSearch = true;
     }
 
     triggerSearch() {
@@ -152,12 +155,19 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
                         var childList = this.getChildrenOfAnalysis(result.id, detectorList);
                         if (childList && childList.length > 0) {
                             childList.forEach((child: DetectorMetaData) => {
-                                this.insertInDetectorArray({ name: child.name, id: child.id, score: result.score });
+                                if ((child.id !== this.detector) && (childrenOfParent.findIndex((x: string) => x.toLowerCase() == child.id.toLowerCase()) < 0) && (child.type === DetectorType.Detector)){
+                                    this.insertInDetectorArray({ name: child.name, id: child.id, score: result.score });
+                                }
                             });
                         }
                         this.insertInDetectorArray({ name: result.name, id: result.id, score: result.score });
                     }
                 });
+                // Start the web search after 10 seconds if detectors take long to run
+                if(this.webSearchShowTimeout){
+                    clearTimeout(this.webSearchShowTimeout);
+                }
+                this.webSearchShowTimeout = setTimeout(() => {this.showWebSearch = true;}, 10000);
                 this.startDetectorRendering(detectorList);
             }
         },
@@ -169,8 +179,14 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
 
     startDetectorRendering(detectorList) {
         this.detectorMetaData = detectorList.filter(detector => this.detectors.findIndex(d => d.id === detector.id) >= 0);
-        if (this.detectorMetaData.length === 0) { this.showSearchTermPractices = true; this.searchTermDisplay = this.searchTerm.valueOf(); }
-        else { this.showSearchTermPractices = false; }
+        if (this.detectorMetaData.length === 0) {
+            this.searchTermDisplay = this.searchTerm.valueOf();
+            this.showSearchTermPractices = true;
+            this.showWebSearch = true;
+        }
+        else {
+            this.showSearchTermPractices = false;
+        }
         this.detectorViewModels = this.detectorMetaData.map(detector => this.getDetectorViewModel(detector));
         this.issueDetectedViewModels = [];
 
@@ -241,7 +257,7 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
         .pipe(flatMap((response: DetectorResponse) => {
             if (response.metadata.type == DetectorType.Analysis) {
                 return this._diagnosticService.getDetectors().pipe(map(detectorList => {
-                    return detectorList.filter(element => (element.analysisTypes != null && element.analysisTypes.length > 0 && element.analysisTypes.findIndex(x => x == parentDetectorId) >= 0)).map(element => { return { name: element.name, id: element.id }; });
+                    return detectorList.filter(element => (element.analysisTypes != null && element.analysisTypes.length > 0 && element.analysisTypes.findIndex(x => x == parentDetectorId) >= 0)).map(element => element.id);
                 }), catchError(e => of([])));
             }
             else{
@@ -288,6 +304,7 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
         this.showSuccessfulChecks = false;
         this.showSearchTermPractices = false;
         this.showPreLoadingError = false;
+        this.showWebSearch = false;
     }
 
     getDetectorInsight(viewModel: any): any {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
@@ -31,7 +31,7 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
         private _activatedRoute: ActivatedRoute, private _router: Router, private _contentService: GenericContentService) {
         super(telemetryService);
         this.isPublic = config && config.isPublic;
-        this._activatedRoute.queryParamMap.subscribe(qParams => {
+        this._activatedRoute.queryParamMap.pipe(take(1)).subscribe(qParams => {
             this.searchTerm = qParams.get('searchTerm') === null ? "" || this.searchTerm : qParams.get('searchTerm');
             this.refresh();
         });


### PR DESCRIPTION
Changes in cognitive search:
1. Use only particular types of stacks.
2. Show cognitive search at most 10 seconds into the rendering of the search component - and not wait for all detectors to execute.

Changes in detector search:
1. Do not run detectors that are already rendered in parent analysis.

No changes in the UI so no screenshots.