### PR TITLE
Fix issue: Applens editor hangs on empty code

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/configuration/configuration.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/configuration/configuration.component.html
@@ -18,8 +18,8 @@
   {{alertMessage}}
 </div>
 
-<loader-view *ngIf="!code" message="Loading Kusto Mapping.."></loader-view>
-<div class="flow-container" *ngIf="code">
+<loader-view *ngIf="!codeLoaded" message="Loading Kusto Mapping.."></loader-view>
+<div class="flow-container" *ngIf="codeLoaded">
   <div class="onboarding-container">
     <split direction="vertical" gutterSize="8">
     <split-area size="85">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/configuration/configuration.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/configuration/configuration.component.ts
@@ -14,6 +14,7 @@ export class ConfigurationComponent implements OnInit {
     showAlert:boolean;
     alertClass: string;
     alertMessage: string;
+    codeLoaded: boolean = false;
 
   constructor(public ngxSmartModalService: NgxSmartModalService, private _diagnosticService: ApplensDiagnosticService, private githubService: GithubApiService) {
     this.editorOptions = {
@@ -32,6 +33,7 @@ export class ConfigurationComponent implements OnInit {
 
   ngOnInit() {
       this._diagnosticService.getKustoMappings().subscribe(resp => {
+        this.codeLoaded = true;
         this.code = JSON.stringify(resp, null, 2);
       }, (error: any) => {
         console.log(error);

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
@@ -97,9 +97,9 @@
   <div *ngIf="showAlert" class="alert alert-container" [ngClass]="alertClass" role="alert">
     {{alertMessage}}
   </div>
-  <loader-view *ngIf="!code" message="Starting onboarding flow ..."></loader-view>
+  <loader-view *ngIf="!codeLoaded" message="Starting onboarding flow ..."></loader-view>
 
-  <div *ngIf="code" class="onboarding-container">
+  <div *ngIf="codeLoaded" class="onboarding-container">
     <split [direction]="horizontal" gutterSize="8" gutterColor="#dff0ff">
       <split-area size="60">
         <split direction="vertical" gutterSize="8" gutterColor="rgb(249, 233, 212)">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -79,6 +79,7 @@ export class OnboardingFlowComponent implements OnInit {
   compilationPackage: CompilationProperties;
 
   initialized = false;
+  codeLoaded: boolean = false;
 
   private publishingPackage: Package;
   private userName: string;
@@ -215,6 +216,7 @@ export class OnboardingFlowComponent implements OnInit {
     this.diagnosticApiService.prepareLocalDevelopment(body, this.id, this._detectorControlService.startTimeString,
       this._detectorControlService.endTimeString, this.dataSource, this.timeRange)
       .subscribe((response: string) => {
+        this.codeLoaded = true;
         this.localDevButtonDisabled = false;
         this.localDevUrl = response;
         this.localDevText = "Download Local Development Package";


### PR DESCRIPTION
Applens editor hangs when the code is emptied. This happens for detectors/gists/configuration files.
Repro steps:
Open applens and open any detector for editing or go to create new detector
![image](https://user-images.githubusercontent.com/8492235/74381383-293a1580-4da0-11ea-9d82-c7d6cb093e00.png)

Then empty the editor, the editor screen hangs indefinitely
![image](https://user-images.githubusercontent.com/8492235/74381408-39ea8b80-4da0-11ea-82da-2e15c2f2308d.png)



The fix:
We use a boolean for rendering the monaco code editor instead of binding it directly to "code" variable. We set the boolean once the pre-development requests are complete.
After the fix, upon emptying the editor one can have the view
![image](https://user-images.githubusercontent.com/8492235/74381502-6e5e4780-4da0-11ea-8a66-52267a59672f.png)
