### PR TITLE
Restrict only last 60 commits to be shown in Gist Version Management

### DIFF
--- a/ApplensBackend/Services/GithubClientService/GithubClientService.cs
+++ b/ApplensBackend/Services/GithubClientService/GithubClientService.cs
@@ -109,7 +109,7 @@ namespace AppLensV3
 
             return await GetRawFile(gistFileUrl);
         }
-        
+
         /// <summary>
         /// Get metadata file.
         /// </summary>
@@ -133,16 +133,17 @@ namespace AppLensV3
         }
 
         /// <summary>
-        /// Get Resource configuration for search
+        /// Get Resource configuration for search.
         /// </summary>
-        /// <returns>Resource Configuration JSON for search api</returns>
-        public async Task<string> GetResourceConfigFile(){
+        /// <returns>Resource Configuration JSON for search api.</returns>
+        public async Task<string> GetResourceConfigFile()
+        {
             var resourceConfigFileUrl = string.Format(
                 GithubConstants.ResourceConfigFormat,
                 UserName,
                 RepoName,
                 Branch);
-            
+
             return await GetRawFile(resourceConfigFileUrl);
         }
 
@@ -215,7 +216,13 @@ namespace AppLensV3
                 Sha = Branch
             };
 
-            var allCommits = await OctokitClient.Repository.Commit.GetAll(UserName, RepoName, request);
+            var options = new ApiOptions()
+            {
+                PageSize = 2,
+                PageCount = 30
+            };
+
+            var allCommits = await OctokitClient.Repository.Commit.GetAll(UserName, RepoName, request, options);
             var res = new List<Models.Commit>();
 
             var commits = allCommits


### PR DESCRIPTION
When I click on Manage Package for WebAppDownWindows gist, the list is just not loading because there are more than 150 commits to this file. 

After this change, we will restrict the UI to show last 60 commits only thereby allowing the call to succeed.

This is a temporary fix and the long time fix is to allow pagination in the gist version list. I am submitting this PR to unblock myself so I can easily use the latest version of the Gist in few detectors.