### PR TITLE
Render search component in detector/analysis view of analysis type detector

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -101,10 +101,12 @@ export class DetectorViewComponent implements OnInit {
   protected loadDetector() {
     this.detectorResponseSubject.subscribe((data: DetectorResponse) => {
       let metadata: DetectorMetaData = data? data.metadata: null;
-      if (metadata && (metadata.type == DetectorType.Analysis)){
-        data.dataset = data.dataset.filter((ds: DiagnosticData) => (ds.renderingProperties.type !== RenderingType.SearchComponent));
-      }
       this.detectorDataLocalCopy = data;
+      if (metadata && (metadata.type == DetectorType.Analysis) && this.isAnalysisView){
+        // Create a copy of the cached response because we are modifying it
+        this.detectorDataLocalCopy = JSON.parse(JSON.stringify(data));
+        this.detectorDataLocalCopy.dataset = this.detectorDataLocalCopy.dataset.filter((ds: DiagnosticData) => (ds.renderingProperties.type !== RenderingType.SearchComponent));
+      }
       if (data) {
         this.detectorEventProperties = {
           'StartTime': String(this.startTime),


### PR DESCRIPTION
We observed a bug in search component rendering where search component would show up only the first time an analysis is opened in a session. This was happening because we are filtering out search component from detector result dataset to skip it from rendering in the "detector part" of analysis view and show it at the very end. As it seems the detector response is cached and is copied by reference, so when we filter out search component we actually modify the cached detector response which results in search component not being there when the cached response is referenced the second time.

To overcome this, we needed an actual copy of the detector response. So **only when it is an "Analysis Type" detector and is rendered as an "Analysis View"** we create a deep copy of detector response and filter out the search component from the copied response. Since our detector response does not contain any non-stringifiable objects and no methods, this way of deep copying should work in all scenarios without loss of data.