### PR TITLE
Render search component in detector/analysis view of analysis type detector

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -43,7 +43,7 @@
     <hr>
   </div>
 
-  <div *ngFor="let data of detectorDataLocalCopy.dataset" class="dynamic-data-container">
+  <div *ngFor="let data of detectorDataLocalCopy.dataset | renderfilter:isAnalysisView" class="dynamic-data-container">
     <dynamic-data [isAnalysisView]="isAnalysisView" [diagnosticData]="data" [startTime]="startTime" [endTime]="endTime" [detectorEventProperties]="detectorEventProperties"
     [developmentMode]="developmentMode" [executionScript]="script" [detector]="detector" [compilationPackage]="compilationPackage"></dynamic-data>
   </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -1,7 +1,7 @@
 import { Moment } from 'moment';
 import { BehaviorSubject } from 'rxjs';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnInit, Pipe, PipeTransform } from '@angular/core';
 import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagnostic-data-config';
 import { DetectorResponse, Rendering, RenderingType, DetectorMetaData, DetectorType, DiagnosticData } from '../../models/detector';
 import { DetectorControlService } from '../../services/detector-control.service';
@@ -102,11 +102,6 @@ export class DetectorViewComponent implements OnInit {
     this.detectorResponseSubject.subscribe((data: DetectorResponse) => {
       let metadata: DetectorMetaData = data? data.metadata: null;
       this.detectorDataLocalCopy = data;
-      if (metadata && (metadata.type == DetectorType.Analysis) && this.isAnalysisView){
-        // Create a copy of the cached response because we are modifying it
-        this.detectorDataLocalCopy = JSON.parse(JSON.stringify(data));
-        this.detectorDataLocalCopy.dataset = this.detectorDataLocalCopy.dataset.filter((ds: DiagnosticData) => (ds.renderingProperties.type !== RenderingType.SearchComponent));
-      }
       if (data) {
         this.detectorEventProperties = {
           'StartTime': String(this.startTime),
@@ -336,4 +331,17 @@ export class DetectorViewComponent implements OnInit {
     }
   }
 
+}
+
+@Pipe({
+  name: 'renderfilter',
+  pure: false
+})
+export class RenderFilterPipe implements PipeTransform {
+  transform(items: DiagnosticData[], isAnalysisView: any): any {
+      if (!items || !isAnalysisView) {
+          return items;
+      }
+      return items.filter(item => !((item.renderingProperties.type === RenderingType.SearchComponent) && isAnalysisView));
+  }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -342,6 +342,9 @@ export class RenderFilterPipe implements PipeTransform {
       if (!items || !isAnalysisView) {
           return items;
       }
-      return items.filter(item => !((item.renderingProperties.type === RenderingType.SearchComponent) && isAnalysisView));
+      if (isAnalysisView)
+      return items.filter(item => item.renderingProperties.type !== RenderingType.SearchComponent);
+      else
+      return items;
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -101,10 +101,12 @@ export class DetectorViewComponent implements OnInit {
   protected loadDetector() {
     this.detectorResponseSubject.subscribe((data: DetectorResponse) => {
       let metadata: DetectorMetaData = data? data.metadata: null;
-      if (metadata && (metadata.type == DetectorType.Analysis)){
-        data.dataset = data.dataset.filter((ds: DiagnosticData) => (ds.renderingProperties.type !== RenderingType.SearchComponent));
-      }
       this.detectorDataLocalCopy = data;
+      if (metadata && (metadata.type == DetectorType.Analysis) && this.isAnalysisView){
+        // Create a copy of the cached response because we are modifying it
+        this.detectorDataLocalCopy = JSON.parse(JSON.stringify(data));
+        this.detectorDataLocalCopy.dataset = this.detectorDataLocalCopy.dataset.filter((ds: DiagnosticData) => (ds.renderingProperties.type !== RenderingType.SearchComponent));
+      }
       if (data) {
         this.detectorEventProperties = {
           'StartTime': String(this.startTime),

--- a/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
@@ -86,6 +86,7 @@ import { AppInsightsEnablementComponent } from './components/app-insights-enable
 import { ConnectAppInsightsComponent } from './components/connect-app-insights/connect-app-insights.component';
 import {DetectorSearchComponent} from './components/detector-search/detector-search.component';
 import {WebSearchComponent} from './components/web-search/web-search.component';
+import {RenderFilterPipe} from './components/detector-view/detector-view.component';
 
 @NgModule({
   imports: [
@@ -121,7 +122,8 @@ import {WebSearchComponent} from './components/web-search/web-search.component';
     CxpChatLauncherComponent,
     AppInsightsEnablementComponent,
     ConnectAppInsightsComponent,
-    WebSearchComponent
+    WebSearchComponent,
+    RenderFilterPipe
   ],
   exports: [
     FormsModule, TimeSeriesGraphComponent, DataTableComponent, DynamicDataComponent, DetectorViewComponent, DetectorSearchComponent,


### PR DESCRIPTION
We observed a bug in search component rendering where search component would show up only the first time an analysis is opened in a session. This was happening because we are filtering out search component from detector result dataset to skip it from rendering in the "detector part" of analysis view and show it at the very end. As it seems the detector response is cached and is copied by reference, so when we filter out search component we actually modify the cached detector response which results in search component not being there when the cached response is referenced the second time.

To overcome this, we **added a pipe filter while rendering dynamic components and avoid the search component** only in analysis view.