### PR TITLE
Remove Row Limit For DataTable

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.html
@@ -3,7 +3,6 @@
     *ngIf="!renderingProperties.groupByColumnName && !(renderingProperties.groupByColumnName === ''); else groupedTable">
     <ngx-datatable #myTable class="bootstrap with-shadow"
       [columnMode]="'force'"
-      [limit]="rowLimit"
       [rowHeight]="'auto'"
       [footerHeight]="0"
       [scrollbarH]="false"
@@ -25,7 +24,6 @@
       [rows]="rows"
       [columns]="columns"
       [columnMode]="'force'"
-      [limit]="rowLimit"
       [rowHeight]="'auto'"
       [footerHeight]="0"
       [scrollbarH]="false"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.scss
@@ -26,25 +26,27 @@
 }
 
 .description-text{
-    margin-top: 5px;
-    padding: 5px;
-    height: 150px;
-    max-height: 150px;
-    overflow-y: scroll;
-    border-radius: 0px;
-    white-space: pre-wrap;
+  margin-top: 5px;
+  padding: 5px;
+  height: 150px;
+  max-height: 150px;
+  overflow-y: scroll;
+  border-radius: 0px;
+  white-space: pre-wrap;
 }
 
 :host ::ng-deep .ngx-datatable {
-    .sortable .sort-btn:before {
-        font-family: data-table;
-        padding-left: 1em;
-        content: "c";
-    }
-    .sortable .sort-btn.datatable-icon-down:before {
-        content: "f";
-    }
-    .sortable .sort-btn.datatable-icon-up:before {
-        content: "e";
-    }
+  .sortable .sort-btn:before {
+    font-family: data-table;
+    padding-left: 1em;
+    content: "c";
+  }
+
+  .sortable .sort-btn.datatable-icon-down:before {
+    content: "f";
+  }
+
+  .sortable .sort-btn.datatable-icon-up:before {
+    content: "e";
+  }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table/data-table.component.ts
@@ -21,7 +21,7 @@ export class DataTableComponent extends DataRenderBaseComponent implements After
     }
 
     if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
-      this.currentStyles = { 'height': this.renderingProperties.height ,'overflow-y':'auto' };
+      this.currentStyles = { 'height': this.renderingProperties.height, 'overflow-y':'visible' };
     }
 
     if (this.renderingProperties.tableOptions != null) {


### PR DESCRIPTION
- Row limit was previously worked around with `TableOptions = new { scrollbarV = true}` in detector rendering properties
- Setting a height limit on the table and removing row limit automatically adds the vertical scroll bar, achieving the same effect