### PR TITLE
Fix bug in parent rendering in search results

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
@@ -168,7 +168,11 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
             var childrenOfParent = results[2];
             if (detectorList) {
                 searchResults.forEach(result => {
-                    if ((result.id !== this.detector) && (childrenOfParent.findIndex((x: string) => x.toLowerCase() == result.id.toLowerCase()) < 0) && (result.type === DetectorType.Detector)) {
+                    if ((result.id === this.detector) || (childrenOfParent.findIndex((x: string) => x.toLowerCase() == result.id.toLowerCase()) >= 0))
+                    {
+                        return;
+                    }
+                    else if (result.type === DetectorType.Detector) {
                         this.insertInDetectorArray({ name: result.name, id: result.id, score: result.score });
                     }
                     else if (result.type === DetectorType.Analysis) {


### PR DESCRIPTION
Check 1: If the search result is either the parent or any child of the parent - skip
Check 2: If the search result is a detector - show it
Check 3: If the search result is an analysis -> get it's children -> show only those who fail the check 1.