### PR TITLE
Add a check for storage length till ANT88

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
@@ -18,7 +18,7 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
   constructor(private _serverFarmService: ServerFarmDataService, private _siteService: SiteService, private _daasService: DaasService) {
   }
 
-  @ViewChild('daasValidatorRef', {static: true}) daasValidatorRef: DaasValidatorComponent;
+  @ViewChild('daasValidatorRef', { static: false }) daasValidatorRef: DaasValidatorComponent;
 
   @Input() siteToBeDiagnosed: SiteInfoMetaData;
   @Input() customAction: AutoHealCustomAction;

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -121,13 +121,19 @@
           </div>
 
           <div class="header2">4. Review and Save your Settings</div>
-          <div class="summary autohealtile-content">
-            <div *ngIf="originalSettings">
+          <div class="autohealtile-content">
+            <div class="summary" *ngIf="originalSettings">
               <strong>Current Settings</strong>
               <autohealing-config-summary [autohealSettings]="originalSettings">
               </autohealing-config-summary>
+              <div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word"
+                *ngIf="storageAccountLengthExceeding">
+                Due to a limitation in Autohealing module, the length of the chosen storage account should be less than
+                13 charachters. Please choose a different storage account or reduce the account length. This limitation
+                will be removed in the upcoming versions of Azure App Service.
+              </div>
             </div>
-            <div *ngIf="currentSettings && saveEnabled" style="margin-top:25px">
+            <div class="summary" *ngIf="currentSettings && saveEnabled" style="margin-top:25px">
               <strong>New Settings</strong>
               <autohealing-config-summary [autohealSettings]="currentSettings">
               </autohealing-config-summary>
@@ -137,18 +143,20 @@
       </div>
       <div *ngIf="!retrievingAutohealSettings  && !errorMessage && saveEnabled && validationWarning.length > 0">
         <table class="ml-4 mt-4 table table-bordered" style="width:90%">
-          <th>
+          <thead>
             <tr>
-              <td>
+              <th>
                 <div style="padding: 10px">
                   <i class="fa health-icon fa-exclamation-triangle warning-icon-color"></i> Warning
                 </div>
-              </td>
+              </th>
             </tr>
-          </th>
-          <tr *ngFor="let warning of validationWarning">
-            <td>{{ warning }}</td>
-          </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let warning of validationWarning">
+              <td>{{ warning }}</td>
+            </tr>
+          </tbody>
         </table>
       </div>
       <div *ngIf="!retrievingAutohealSettings  && !errorMessage" class="saveSection autohealtile-content">

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
@@ -74,7 +74,6 @@
 }
 
 .summary {
-    background-color: #efefef;
     border-bottom-left-radius: 0;
     border: 1px solid #e6e6e6;
     font-size: 12px;

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -39,6 +39,7 @@ export class AutohealingComponent implements OnInit {
   detectorHasData: boolean = false;
   validationWarning: string[];
   selectedTab: string = 'autoHealing';
+  storageAccountLengthExceeding: boolean = false;
 
   constructor(private _siteService: SiteService, private _autohealingService: AutohealingService, private _logger: AvailabilityLoggingService, protected _route: ActivatedRoute) {
   }
@@ -66,6 +67,39 @@ export class AutohealingComponent implements OnInit {
     this.originalAutoHealSettings = JSON.parse(this.originalSettings);
     this.updateConditionsAndActions();
     this.updateSummaryText();
+    this.checkStorageLength(this.originalAutoHealSettings);
+  }
+
+  checkStorageLength(autoHealSettings: AutoHealSettings) {
+    if (autoHealSettings.autoHealEnabled &&
+      autoHealSettings.autoHealRules != null &&
+      autoHealSettings.autoHealRules.actions != null &&
+      autoHealSettings.autoHealRules.actions.actionType === AutoHealActionType.CustomAction &&
+      autoHealSettings.autoHealRules.actions.customAction != null &&
+      autoHealSettings.autoHealRules.actions.customAction.parameters != null) {
+      let storageAccountName = this.getStorageAccountNameFromActionParams(autoHealSettings.autoHealRules.actions.customAction.parameters);
+      if (storageAccountName.length > 12) {
+        this.storageAccountLengthExceeding = true;
+      } else {
+        this.storageAccountLengthExceeding = false;
+      }
+
+    }
+  }
+
+  getStorageAccountNameFromActionParams(customActionParams: string): string {
+    let storageAccountName = "";
+    let searchString = "blobsasuri:\"https://";
+    let startIndex = customActionParams.toLowerCase().indexOf(searchString);
+    if (startIndex > 0) {
+      startIndex = startIndex + searchString.length;
+      let endIndex = customActionParams.indexOf(".", startIndex);
+      if (endIndex > 0) {
+        storageAccountName = customActionParams.substring(startIndex, endIndex);
+        console.log(storageAccountName);
+      }
+    }
+    return storageAccountName;
   }
 
   updateConditionsAndActions() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -96,7 +96,6 @@ export class AutohealingComponent implements OnInit {
       let endIndex = customActionParams.indexOf(".", startIndex);
       if (endIndex > 0) {
         storageAccountName = customActionParams.substring(startIndex, endIndex);
-        console.log(storageAccountName);
       }
     }
     return storageAccountName;

--- a/AngularApp/projects/app-service-diagnostics/src/app/betaSubscriptions.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/betaSubscriptions.ts
@@ -10,26 +10,26 @@ export class DemoSubscriptions {
         'ef90e930-9d7f-4a60-8a99-748e0eea69de', // AntaresDemo
         'fb2c25dc-6bab-45c4-8cc9-cece7c42a95a', // antps14
         'edcc99a4-b7f9-4b5e-a9a1-3034c51db496', // OtherDemo?
-        'ce678eba-8ab3-4a0c-9610-97fee4ee6b34',  //Ranjith linux test sub
-        '88c8fe3d-1993-4fac-8e44-0f3232cc60ce',   // antps29,
-        'da511dea-6e00-4728-93ff-6302ad7fe284',   // Nazeef's Sub
-        '15c0f6ba-acb7-4f9a-aed0-7249c140b4f3', //Finbar' sub
+        'ce678eba-8ab3-4a0c-9610-97fee4ee6b34', // Ranjith linux test sub
+        '88c8fe3d-1993-4fac-8e44-0f3232cc60ce', // antps29,
+        'da511dea-6e00-4728-93ff-6302ad7fe284', // Nazeef's Sub
+        '15c0f6ba-acb7-4f9a-aed0-7249c140b4f3', // Finbar' sub
         'c1972e9d-b3c7-4de4-acb3-681773b28ced', // Cindy's sub: Private Test Sub Xipeng,
         'caae90fd-95a3-4641-a523-b66894f4654c', // Xiaoxu's sub
         'c258f9c0-3d64-4761-8697-cab631f28422', // Private Test Sub KHZAYED (Khaled's subscription)
         'db8a84f3-059b-4491-9441-fb430ed8a187', // Private Test Sub YUNJCHOI (Yun Jung's subscription)
-        '00b9f3f9-5558-4bd8-9c4e-9ed47b92070e', //AppService-Marketplace-Subscription SUMUTH (Sunitha Subscription)
+        '00b9f3f9-5558-4bd8-9c4e-9ed47b92070e', // AppService-Marketplace-Subscription SUMUTH (Sunitha Subscription)
         '72383ac7-d6f4-4a5e-bf56-b172f2fdafb2', // Private Test Sub RESWAMIN (Rekha's subscription)
         '076fbf3e-ef06-46f2-af7e-76aa9f600612', // Private Test Sub DAGROOMS (Daniel's subscription)
-        'da511dea-6e00-4728-93ff-6302ad7fe284', //Microsoft Azure Internal Consumption (Nazeef's subscription)
-        '931906d8-00b9-481b-aba2-f227b237cada', //Private Test Sub NMALLICK (Nazeef's subscription)
+        'da511dea-6e00-4728-93ff-6302ad7fe284', // Microsoft Azure Internal Consumption (Nazeef's subscription)
+        '931906d8-00b9-481b-aba2-f227b237cada', // Private Test Sub NMALLICK (Nazeef's subscription)
         '1402be24-4f35-4ab7-a212-2cd496ebdf14', // Antps05
         '5abde51d-cc72-4bcc-b0d7-3c86b4db2a7c', // Shekhar's subscription
-        '6a205b0a-6b5a-4346-8468-f4b6367f7efa', //Private Test Sub HAWFOR (Hawk's subscription)
-        '6b6db65f-680e-4650-b97d-e82ed6a0f583', //Private Test Sub PUNEETG (Puneet's subscription)
+        '6a205b0a-6b5a-4346-8468-f4b6367f7efa', // Private Test Sub HAWFOR (Hawk's subscription)
+        '6b6db65f-680e-4650-b97d-e82ed6a0f583', // Private Test Sub PUNEETG (Puneet's subscription)
         '76679aa7-6638-4d84-b1c6-97dafcd8ebeb', // Juntao Zhu's Subscription
         '1c685347-a4a8-4cbc-8362-7a7b3c18d654', // Anik Shen's Subscription
-        '05c54750-4e91-4d98-981c-8c3e3356e9fa', //Ji Young Lee Susbscription
+        '05c54750-4e91-4d98-981c-8c3e3356e9fa', // Ji Young Lee Susbscription
         '8eeeb512-e3d7-4732-b40c-36df9ff628d0', // Nikhil Vetteth's Susbscription
     ];
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
@@ -29,7 +29,8 @@
       </div>
 
       <div *ngIf="chosenOption.option === 'ChooseExisting'">
-        <select class="mt-2 fixed-width" id="storageAccountsList" [(ngModel)]="chosenStorageAccount">
+        <select class="mt-2 fixed-width" id="storageAccountsList" [ngModel]="chosenStorageAccount"
+          (ngModelChange)="onStorageAccountChange($event)">
           <optgroup *ngFor="let location of getLocations()" [label]="location">
             <option *ngFor="let account of getStorageAccountsForLocation(location)" [ngValue]="account"
               [selected]="account === chosenStorageAccount">{{account.name}}
@@ -38,8 +39,15 @@
         </select>
       </div>
 
+      <div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word"
+        *ngIf="storageAccountLengthExceeding">
+        Due to a limitation in Autohealing module, the length of the chosen storage account should be less than 13
+        charachters. Please choose a different storage account or reduce the account length. This limitation will be 
+        removed in the upcoming versions of Azure App Service.
+      </div>
       <button type="button" class="btn btn-primary mt-3 mb-2"
-        [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount" (click)="saveChanges()">Save</button>
+        [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount || storageAccountLengthExceeding"
+        (click)="saveChanges()">Save</button>
       <button type="button" class="btn btn-primary mt-3 mb-2"
         [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount || !editMode"
         (click)="cancel()">Cancel</button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -35,6 +35,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
   editMode: boolean = false;
   validationResult: DaasValidationResult = new DaasValidationResult();
   error: any;
+  storageAccountLengthExceeding: boolean = false;
 
   ngOnInit() {
     this._storageService.getStorageAccounts(this.siteToBeDiagnosed.subscriptionId).subscribe(resp => {
@@ -73,6 +74,8 @@ export class ConfigureStorageAccountComponent implements OnInit {
 
   chooseOption(option: any) {
     this.chosenOption = option;
+    let accountName: string = this.chosenOption.option === 'CreateNew' ? this.newStorageAccountName : this.chosenStorageAccount.name;
+    this.checkAccountLength(accountName)
   }
 
   updateStorageAccount(storageAccount: string) {
@@ -82,6 +85,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
     } else {
       this.saveEnabled = true;
     }
+    this.checkAccountLength(this.newStorageAccountName);
   }
 
   saveChanges() {
@@ -178,6 +182,19 @@ export class ConfigureStorageAccountComponent implements OnInit {
     this.editMode = false;
     this.validationResult.Validated = true;
     this.StorageAccountValidated.emit(this.validationResult);
+  }
+
+  onStorageAccountChange(selectedStorageAccount: StorageAccount) {
+    this.chosenStorageAccount = selectedStorageAccount;
+    this.checkAccountLength(this.chosenStorageAccount.name);
+  }
+
+  checkAccountLength(storageAccountName: string) {
+    if (storageAccountName.length > 12) {
+      this.storageAccountLengthExceeding = true;
+    } else {
+      this.storageAccountLengthExceeding = false;
+    }
   }
 
 }


### PR DESCRIPTION
Auto-healing server side code is encountering a buffer overrun if the storage account number is longer than 18 characters. The server side fix is applied but will go with ANT 88 which might take more than a month. Adding a check in UI code for Storage name length so that customers dont end up configuring a storage account which may then cause Autohealing to fail silently.

![image](https://user-images.githubusercontent.com/5299838/77647416-63e0c180-6f8c-11ea-8491-9fdf4b9cc183.png)

For pre-configured Storage accounts that are already exceeding in length, Auto-Heal UI will show this warning.

![image](https://user-images.githubusercontent.com/5299838/77647613-b9b56980-6f8c-11ea-80a8-60bf0ddd4cf3.png)

