### PR TITLE
Fixing bug when links not opened in new tab

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
@@ -28,7 +28,7 @@
         </h5>
       </div>
 
-      <div class="panel-body" *ngIf="insight.isExpanded && insight.hasData()">
+      <div class="panel-body" [hidden]="!(insight.isExpanded && insight.hasData())">
         <table>
           <tbody>
             <tr *ngFor="let key of insight.getKeys()">
@@ -36,8 +36,8 @@
                 <b>{{key}}</b>
               </td>
               <td class="table-value">
-                <div *ngIf="!isMarkdown(insight.data[key])" [innerHtml]="insight.data[key]"></div>
-                <markdown #markdownDiv [data]="getMarkdown(insight.data[key])" *ngIf="isMarkdown(insight.data[key])">
+                <div [hidden]="isMarkdown(insight.data[key])" [innerHtml]="insight.data[key]"></div>
+                <markdown #markdownDiv [data]="getMarkdown(insight.data[key])" [hidden]="!isMarkdown(insight.data[key])">
                 </markdown>
               </td>
             </tr>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, ViewChild, Renderer2 } from "@angular/core";
+import { Component, OnDestroy, Renderer2, ViewChildren, QueryList, AfterViewInit } from "@angular/core";
 import { Router } from "@angular/router";
 import { MarkdownComponent } from "ngx-markdown";
 import { DataRenderBaseComponent } from "../data-render-base/data-render-base.component";
@@ -9,21 +9,20 @@ import { LinkInterceptorService } from "../../services/link-interceptor.service"
 import { TelemetryEventNames } from "../../services/telemetry/telemetry.common";
 
 
-
-
-
 @Component({
   selector: 'insights-v4',
   templateUrl: './insights-v4.component.html',
   styleUrls: ['./insights-v4.component.scss']
 })
-export class InsightsV4Component extends DataRenderBaseComponent implements OnDestroy {
-  @ViewChild(MarkdownComponent, { static: false })
-  public set markdown(v: MarkdownComponent) {
-    this.markdownDiv = v;
-    if (this.markdownDiv) {
-      this.listenObj = this.renderer.listen(this.markdownDiv.element.nativeElement, 'click', (evt) => this._interceptorService.interceptLinkClick(evt, this.router, this.detector, this.telemetryService));
-    }
+export class InsightsV4Component extends DataRenderBaseComponent implements AfterViewInit, OnDestroy {
+ 
+  @ViewChildren('markdownDiv') markdownComponents: QueryList<MarkdownComponent>;
+
+  ngAfterViewInit() {
+    if (this.markdownComponents != null && this.markdownComponents.length > 0)
+    this.markdownComponents.toArray().forEach(markdownDiv => {
+      this.listenObj = this.renderer.listen(markdownDiv.element.nativeElement, 'click', (evt) => this._interceptorService.interceptLinkClick(evt, this.router, this.detector, this.telemetryService));
+    });
   }
 
   private listenObj: any;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.html
@@ -60,7 +60,7 @@
             </h5>
           </div>
     
-          <div class="panel-body" *ngIf="insight.isExpanded && insight.hasData()">
+          <div class="panel-body" [hidden]="!(insight.isExpanded && insight.hasData())">
             <table>
               <tbody>
                 <tr *ngFor="let key of insight.getKeys()">
@@ -68,8 +68,8 @@
                     <b>{{key}}</b>
                   </td>
                   <td class="table-value">
-                    <div *ngIf="!isMarkdown(insight.data[key])" [innerHtml]="insight.data[key]"></div>
-                    <markdown #markdownDiv [data]="getMarkdown(insight.data[key])" *ngIf="isMarkdown(insight.data[key])"></markdown>
+                    <div [hidden]="isMarkdown(insight.data[key])" [innerHtml]="insight.data[key]"></div>
+                    <markdown #markdownDiv [data]="getMarkdown(insight.data[key])" [hidden]="!isMarkdown(insight.data[key])"></markdown>
                   </td>
                 </tr>
     

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights/insights.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, Renderer2, OnDestroy } from '@angular/core';
+import { Component, OnInit, ViewChild, Renderer2, OnDestroy, ViewChildren, QueryList, AfterViewInit } from '@angular/core';
 import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
 import { Rendering, RenderingType, DiagnosticData, InsightsRendering, HealthStatus } from '../../models/detector';
 import { Insight, InsightUtils } from '../../models/insight';
@@ -14,25 +14,22 @@ import { LinkInterceptorService } from '../../services/link-interceptor.service'
   templateUrl: './insights.component.html',
   styleUrls: ['./insights.component.scss']
 })
-export class InsightsComponent extends DataRenderBaseComponent implements OnDestroy {
+export class InsightsComponent extends DataRenderBaseComponent implements AfterViewInit, OnDestroy {
 
-  @ViewChild(MarkdownComponent, { static: false })
-  public set markdown(v: MarkdownComponent) {
-    this.markdownDiv = v;
-    if (this.markdownDiv) {
-      this.listenObj = this.renderer.listen(this.markdownDiv.element.nativeElement, 'click', (evt) => this._interceptorService.interceptLinkClick(evt, this.router, this.detector, this.telemetryService));
-    }
+  @ViewChildren('markdownDiv') markdownComponents: QueryList<MarkdownComponent>;
+
+  ngAfterViewInit() {
+    if (this.markdownComponents != null && this.markdownComponents.length > 0)
+    this.markdownComponents.toArray().forEach(markdownDiv => {
+      this.listenObj = this.renderer.listen(markdownDiv.element.nativeElement, 'click', (evt) => this._interceptorService.interceptLinkClick(evt, this.router, this.detector, this.telemetryService));
+    });
   }
 
+
   private listenObj: any;
-  private markdownDiv: MarkdownComponent;
-
   DataRenderingType = RenderingType.Insights;
-
   renderingProperties: InsightsRendering;
-
   public insights: Insight[];
-
   InsightStatus = HealthStatus;
 
   constructor(protected telemetryService: TelemetryService, private renderer: Renderer2, private router: Router, private _interceptorService: LinkInterceptorService) {


### PR DESCRIPTION
There is currently an issue in which if an Insight has more than one item in the collection, then the hyperlinks only work in the first item of the insight and not the other one.

To explain more, for an insight like the below one, hyperlinks are opening in a new tab only for **Description** but not for **Learn More**.

![image](https://user-images.githubusercontent.com/5299838/77671800-1c6b2d00-6fae-11ea-99fc-d3cb47dd660a.png)


This PR fixes that issues and ensure that links are opened in a new tab for all insight list items.

The change from ngIf to hidden is required because otherwise the ngAfterViewInit is not having the reference to all the markdown components just because they are not even loaded in DOM.