### PR TITLE
Fix search suffix for windows web app

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/app.module.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/app.module.ts
@@ -27,8 +27,6 @@ import { GenericSolutionService } from './shared/services/generic-solution.servi
 import { LocalBackendService } from './shared/services/local-backend.service';
 import { PortalKustoTelemetryService } from './shared/services/portal-kusto-telemetry.service';
 import { SharedModule } from './shared/shared.module';
-import { ResourceService } from './shared-v2/services/resource.service';
-import { WebSitesService } from './resources/web-sites/services/web-sites.service';
 import { ContentService } from './shared-v2/services/content.service';
 import { CategoryChatStateService } from './shared-v2/services/category-chat-state.service';
 import { StartupModule } from './startup/startup.module';
@@ -103,7 +101,6 @@ import { GenieModule } from './genie/genie.module';
     { provide: SolutionService, useExisting: GenericSolutionService },
     { provide: SettingsService, useExisting: PortalSettingsService },
     { provide: GenieGlobals, useExisting: Globals },
-    { provide: ResourceService, useExisting: WebSitesService },
     CategoryChatStateService,
     ContentService,
     CategoryService,

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -42,11 +42,6 @@ export class SiteFeatureService extends FeatureService {
     }];
 
     this._authService.getStartupInfo().subscribe(startupInfo => {
-
-      // removing v2 detectors for Availability and Perf
-      // if (this._resourceService.appType == AppType.WebApp && this._resourceService.platform == OperatingSystem.windows) {
-      //   this.getLegacyAvailabilityAndPerformanceFeatures(startupInfo.resourceId).forEach(feature => this._features.push(feature));
-      // }
       this.addDiagnosticTools(startupInfo.resourceId);
       this.addProactiveTools(startupInfo.resourceId);
       this.addPremiumTools();

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/web-sites.module.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/web-sites.module.ts
@@ -56,7 +56,6 @@ const ResourceRoutes = RouterModule.forChild([
   ],
   providers: [
     ContentService,
-    WebSitesService,
     SiteFeatureService,
     LoggingV2Service,
     LiveChatService,


### PR DESCRIPTION
Websites service is already defined as an injectable to be provided in "Root". To make sure the service is a singleton, it should not be provide in a lazy loaded module in websitesmodule again.