### PR TITLE
Hard refresh for refreshing request

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Globals } from '../../../globals';
 import { DetectorControlService } from 'projects/diagnostic-data/src/lib/services/detector-control.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'detector-command-bar',
@@ -10,7 +11,7 @@ import { DetectorControlService } from 'projects/diagnostic-data/src/lib/service
 export class DetectorCommandBarComponent {
   time: string;
 
-  constructor(private globals: Globals, private detectorControlService: DetectorControlService) { }
+  constructor(private globals: Globals, private detectorControlService: DetectorControlService, private _route: ActivatedRoute) { }
 
   toggleOpenState() {
     this.globals.openGeniePanel = !this.globals.openGeniePanel;
@@ -21,7 +22,11 @@ export class DetectorCommandBarComponent {
   }
 
   refreshPage() {
-    this.detectorControlService.refresh();
+    let instanceId = this._route.firstChild.snapshot.url[0].toString() === "overview" ? this._route.snapshot.params["category"] : this._route.firstChild.snapshot.params["detectorName"];
+    if (instanceId)
+    {
+      this.detectorControlService.refresh(instanceId);
+    }
   }
 
   toggleOpenTimePicker() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
@@ -22,7 +22,9 @@ export class DetectorCommandBarComponent {
   }
 
   refreshPage() {
-    let instanceId = this._route.firstChild.snapshot.url[0].toString() === "overview" ? this._route.snapshot.params["category"] : this._route.firstChild.snapshot.params["detectorName"];
+    let childRouteSnapshot = this._route.firstChild.snapshot;
+    let childRouteType = childRouteSnapshot.url[0].toString();
+    let instanceId = childRouteType === "overview" ? this._route.snapshot.params["category"] : childRouteType === "detectors" ? childRouteSnapshot.params["detectorName"] : childRouteSnapshot.params["analysisId"] ;
     if (instanceId)
     {
       this.detectorControlService.refresh(instanceId);

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -20,6 +20,7 @@ export class DetectorContainerComponent implements OnInit {
 
    detectorName: string;
    detectorRefreshSubscription: any;
+   refreshInstanceIdSubscription: any;
 
   @Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
@@ -45,7 +46,12 @@ export class DetectorContainerComponent implements OnInit {
     
     this.detectorRefreshSubscription = this.detectorControlService.update.subscribe(isValidUpdate => {
       if (isValidUpdate && this.detectorName) {
-          this.refresh(true);
+        this.refreshInstanceIdSubscription = this.detectorControlService._refreshInstanceId.subscribe((instanceId) => {
+            if (instanceId.toLowerCase() === this.detectorName.toLowerCase())
+            {
+              this.refresh(true);
+            }
+        });
       }
     });
 
@@ -106,6 +112,10 @@ export class DetectorContainerComponent implements OnInit {
   ngOnDestroy(): void {
     if (this.detectorRefreshSubscription) {
         this.detectorRefreshSubscription.unsubscribe();
+    }
+    if (this.refreshInstanceIdSubscription)
+    {
+      this.refreshInstanceIdSubscription.unsubscribe();
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -54,6 +54,8 @@ export class DetectorControlService {
 
   private detectorQueryParams: BehaviorSubject<string> = new BehaviorSubject<string>("");
 
+  public _refreshInstanceId: BehaviorSubject<string> = new BehaviorSubject<string>("");
+
   public DetectorQueryParams = this.detectorQueryParams.asObservable();
 
   public timeRangeDefaulted: boolean = false;
@@ -260,8 +262,8 @@ export class DetectorControlService {
     this.setCustomStartEnd(this._startTime.format(this.stringFormat), this.endTime.format(this.stringFormat));
   }
 
-  public refresh() {
-    this._duration ? this.selectDuration(this._duration) : this._refreshData();
+  public refresh(instanceId: string="") {
+    this._duration ? this.selectDuration(this._duration) : this._refreshData(instanceId);
   }
 
   public toggleInternalExternal() {
@@ -273,9 +275,10 @@ export class DetectorControlService {
     this.detectorQueryParams.next(detectorQueryParams);
   }
 
-  private _refreshData() {
+  private _refreshData(instanceId: string="") {
     this._shouldRefresh = true;
     this._refresh.next(true);
+    this._refreshInstanceId.next(instanceId);
   }
 
   public get error(): string {


### PR DESCRIPTION
This seems like the only solution I can find so far to make this refreshing completely working. 
https://ms.portal.azure.com/?websitesextension_ext=asd.env%3Dstaging#home

In this solution, I only unsubscribe the observer in ngDestroy function. Meaning as long as the component instance is still in the routing cache and getting reused, it will be still listening to the refresh signal from detector control service. I am thinking if this is the right way to do, but since we are already maintain those cached component instances, then maybe we should also maintain their subscribing states to make it a complete story.

The side effect is that it's making all the get detector response calls for the cached components whenever we refresh a detector. Need to find a way to minimize the calls.

