### PR TITLE
Fix timer picker in Applens and D&S

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-time-picker/detector-time-picker.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-time-picker/detector-time-picker.component.ts
@@ -183,7 +183,6 @@ export class DetectorTimePickerComponent implements OnInit {
     this.timeDiffError = this.detectorControlService.getTimeDurationError(startDateWithTime, endDateWithTime);
     if (this.timeDiffError === '') {
       this.detectorControlService.setCustomStartEnd(startDateWithTime, endDateWithTime);
-
       this.globals.updateTimePickerInfo(timePickerInfo);
     }
     this.globals.openTimePicker = this.timeDiffError !== "";

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -18,9 +18,9 @@ export class DetectorContainerComponent implements OnInit {
   @Input() hideDetectorControl: boolean = false;
   hideTimerPicker: boolean = false;
 
-   detectorName: string;
-   detectorRefreshSubscription: any;
-   refreshInstanceIdSubscription: any;
+  detectorName: string;
+  detectorRefreshSubscription: any;
+  refreshInstanceIdSubscription: any;
 
   @Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
@@ -28,12 +28,13 @@ export class DetectorContainerComponent implements OnInit {
     this.detectorSubject.next(detector);
   }
 
-  @Input() analysisMode:boolean = false;
-  @Input() isAnalysisView:boolean = false;
-  isCategoryOverview:boolean = false;
-  private isLegacy:boolean
+  @Input() analysisMode: boolean = false;
+  @Input() isAnalysisView: boolean = false;
+  isCategoryOverview: boolean = false;
+  private isLegacy: boolean
   constructor(private _route: ActivatedRoute, private _diagnosticService: DiagnosticService,
-    public detectorControlService: DetectorControlService, private versionService:VersionService) { }
+    public detectorControlService: DetectorControlService, private versionService: VersionService) {
+  }
 
   ngOnInit() {
     this.versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
@@ -41,16 +42,15 @@ export class DetectorContainerComponent implements OnInit {
     if (this.isLegacy) {
       this.hideTimerPicker = false;
     } else {
-      this.hideTimerPicker= this.hideDetectorControl || this._route.snapshot.parent.url.findIndex((x: UrlSegment) => x.path === "categories") > -1;
+      this.hideTimerPicker = this.hideDetectorControl || this._route.snapshot.parent.url.findIndex((x: UrlSegment) => x.path === "categories") > -1;
     }
-    
+
     this.detectorRefreshSubscription = this.detectorControlService.update.subscribe(isValidUpdate => {
       if (isValidUpdate && this.detectorName) {
         this.refreshInstanceIdSubscription = this.detectorControlService._refreshInstanceId.subscribe((instanceId) => {
-            if (instanceId.toLowerCase() === this.detectorName.toLowerCase())
-            {
-              this.refresh(true);
-            }
+          if (instanceId.toLowerCase() === this.detectorName.toLowerCase() || instanceId === "V3ControlRefresh") {
+            this.refresh(true);
+          }
         });
       }
     });
@@ -59,10 +59,10 @@ export class DetectorContainerComponent implements OnInit {
       if (detector && detector !== "searchResultsAnalysis") {
         this.detectorName = detector;
         this.refresh(false);
-     }
+      }
     });
 
-    const component:any = this._route.component; 
+    const component: any = this._route.component;
     if (component && component.name) {
       this.isCategoryOverview = component.name === "CategoryOverviewComponent";
     }
@@ -75,17 +75,17 @@ export class DetectorContainerComponent implements OnInit {
   }
 
   getDetectorResponse(hardRefresh: boolean) {
-      let invalidateCache = hardRefresh ? hardRefresh : this.detectorControlService.shouldRefresh;
-      let allRouteQueryParams = this._route.snapshot.queryParams;
-      let additionalQueryString = '';
-      let knownQueryParams = ['startTime', 'endTime'];
-      Object.keys(allRouteQueryParams).forEach(key => {
-        if(knownQueryParams.indexOf(key) < 0) {
-            additionalQueryString += `&${key}=${encodeURIComponent(allRouteQueryParams[key])}`;
-        }
-      });
-     this._diagnosticService.getDetector(this.detectorName, this.detectorControlService.startTimeString, this.detectorControlService.endTimeString,
-      invalidateCache,  this.detectorControlService.isInternalView, additionalQueryString)
+    let invalidateCache = hardRefresh ? hardRefresh : this.detectorControlService.shouldRefresh;
+    let allRouteQueryParams = this._route.snapshot.queryParams;
+    let additionalQueryString = '';
+    let knownQueryParams = ['startTime', 'endTime'];
+    Object.keys(allRouteQueryParams).forEach(key => {
+      if (knownQueryParams.indexOf(key) < 0) {
+        additionalQueryString += `&${key}=${encodeURIComponent(allRouteQueryParams[key])}`;
+      }
+    });
+    this._diagnosticService.getDetector(this.detectorName, this.detectorControlService.startTimeString, this.detectorControlService.endTimeString,
+      invalidateCache, this.detectorControlService.isInternalView, additionalQueryString)
       .subscribe((response: DetectorResponse) => {
         this.shouldHideTimePicker(response);
         this.detectorResponse = response;
@@ -105,16 +105,15 @@ export class DetectorContainerComponent implements OnInit {
       } else {
         this.hideDetectorControl = cardRenderingIndex >= 0 || this.hideDetectorControl;
       }
-      
+
     }
   }
 
   ngOnDestroy(): void {
     if (this.detectorRefreshSubscription) {
-        this.detectorRefreshSubscription.unsubscribe();
+      this.detectorRefreshSubscription.unsubscribe();
     }
-    if (this.refreshInstanceIdSubscription)
-    {
+    if (this.refreshInstanceIdSubscription) {
       this.refreshInstanceIdSubscription.unsubscribe();
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.html
@@ -50,7 +50,7 @@
     </div>
 
     <div class="control-group">
-      <div class="control"  (keyup.enter) = "detectorControlService.refresh()" (click)="detectorControlService.refresh()" name = "Refresh" value = "Refresh" aria-label = "Refresh" tabindex="0" role = "button">
+      <div class="control"  (keyup.enter) = "refreshPage()" (click)="refreshPage()" name = "Refresh" value = "Refresh" aria-label = "Refresh" tabindex="0" role = "button">
         <i class="fa fa-refresh"></i>
       </div>
     </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-control/detector-control.component.ts
@@ -53,6 +53,10 @@ export class DetectorControlComponent implements OnInit {
       this.detectorControlService.setCustomStartEnd(this.startTime, this.endTime);
     }
   }
+
+  refreshPage() {
+    this.detectorControlService.refresh("V3ControlRefresh");
+  }
 }
 
 @Pipe({

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -205,7 +205,7 @@ export class DetectorControlService {
     if (this.getTimeDurationError(start, end) === '') {
       this._startTime = startTime;
       this._endTime = endTime;
-      this._refreshData();
+      this._refreshData("V3ControlRefresh");
     }
     else {
       this.timeRangeDefaulted = true;
@@ -239,7 +239,7 @@ export class DetectorControlService {
           this._startTime = this._endTime.clone().subtract(1, 'days');
         }
       }
-      this._refreshData();
+      this._refreshData("V3ControlRefresh");
     }
   }
 


### PR DESCRIPTION
For the refresh command from the old detector control (Either click on refresh icon or set the time duration), we bypass the instanceId comparison logic. 