### PR TITLE
AutoHeal Text Changes and removing resource specific text

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
@@ -53,7 +53,7 @@
   </div>
   <div class="row">
     <div class="col-sm-6">
-      <label for="durationCount">How frequently (in seconds) do you want to check?</label>
+      <label for="durationCount">What is the time interval (in seconds) in which the above condition should be met?</label>
     </div>
     <div class="col-sm-4">
       <timespan [(timeSpan)]="ruleCopy.timeInterval" placeholder="e.g. 60" label="How frequently do you want to check?"></timespan>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -1,5 +1,6 @@
 <div *ngIf="rule == null && !editMode">
-  If the performance of your application starts degrading and several pages start taking longer time to render, you can configure
+  If the performance of your application starts degrading and several pages start taking longer time to render, you can
+  configure
   a rule to mitigate the issue or collect diagnostic data to identify the root cause of the problem.
 
   <div class="rule-button">
@@ -49,8 +50,8 @@
       <label for="requestsCountSlow">After how many slow requests you want this condition to kick in?</label>
     </div>
     <div class="col-sm-4">
-      <input type="number" min="1" id="requestsCountSlow" aria-describedby="requestsCountSlowHelp" placeholder="Enter count" [(ngModel)]="ruleCopy.count"
-        min="1">
+      <input type="number" min="1" id="requestsCountSlow" aria-describedby="requestsCountSlowHelp"
+        placeholder="Enter count" [(ngModel)]="ruleCopy.count" min="1">
       <span style="color:red">*</span>
       <div *ngIf="ruleCopy.count <=0" class="alert alert-danger" style="margin-top:5px">
         Request count should be more than zero
@@ -69,10 +70,14 @@
 
   <div class="row">
     <div class="col-sm-6">
-      <label for="durationSlow">How frequently (in seconds) do you want to check?</label>
+      <label for="durationSlow">What is the time interval (in seconds) in which the above condition should be
+        met?</label>
     </div>
     <div class="col-sm-4">
       <timespan [(timeSpan)]="ruleCopy.timeInterval" placeholder="e.g. 300" label="Check Duration"></timespan>
+      <div *ngIf="showIntervalRecommendation" class="alert alert-danger" style="margin-top:5px">
+        It is recommended that the time interval is higher than the minimum duration setting.
+      </div>
     </div>
   </div>
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
@@ -14,6 +14,8 @@ export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleCompone
     super();
   }
 
+  showIntervalRecommendation: boolean = false;
+
   addNewRule() {
     this.rule = new SlowRequestsBasedTrigger();
     this.ruleCopy = new SlowRequestsBasedTrigger();
@@ -21,8 +23,13 @@ export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleCompone
   }
 
   isValid(): boolean {
+    this.showIntervalRecommendation = false;
     if (this.ruleCopy && this.ruleCopy.timeInterval && this.ruleCopy.timeInterval !== '' && this.ruleCopy.timeTaken && this.ruleCopy.timeTaken != '') {
-      return (this.ruleCopy.count > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeInterval) > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeTaken) > 0);
+      let isValid: boolean = (this.ruleCopy.count > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeInterval) > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeTaken) > 0);
+      if (isValid) {
+        this.showIntervalRecommendation = this.ruleCopy.timeInterval < this.ruleCopy.timeTaken
+      }
+      return isValid;
     } else {
       return false;
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
@@ -100,7 +100,7 @@
 
     <div class="row">
       <div class="col-sm-6">
-        <label for="durationStatusCode">How frequently (in seconds) do you want to check?</label>
+        <label for="durationStatusCode">What is the time interval (in seconds) in which the above condition should be met?</label>
       </div>
       <div class="col-sm-4">
         <timespan [(timeSpan)]="currentRule.timeInterval" placeholder="e.g. 60" label="Check Duration"></timespan>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -193,7 +193,7 @@
             <i *ngIf="showSuccessfulChecks" class="fa fa-minus expand-icon"></i>
           </span>
         </div>
-        <div>Tests that succeeded for your app</div>
+        <div>Tests that succeeded</div>
         <div class="list-text" [class.sucessful-check]="showSuccessfulChecks" [class.hide-successful-check]="!showSuccessfulChecks">
           <table class="table detector-list">
             <thead>


### PR DESCRIPTION
1. Changing wording for some of the questions that we present in AutoHeal
2. Showing a warning if timeInterval is less than request interval
3. Removing the resource specific text from Analysis List page