### PR TITLE
Forcing Storage Account selection on Proactive CPU Monitoring

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.ts
@@ -13,6 +13,7 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
 
   @Input() siteToBeDiagnosed: SiteDaasInfo;
   @Input() activeSession: MonitoringSession;
+  @Input() blobSasUri:string;
   @Output() monitoringConfigurationChange: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() savingMonitoringConfiguration: EventEmitter<boolean> = new EventEmitter<boolean>();
 
@@ -182,6 +183,7 @@ export class CpuMonitoringConfigurationComponent implements OnInit, OnChanges {
       newSession.CpuThreshold = this.monitoringSession.CpuThreshold;
       newSession.MaximumNumberOfHours = this.monitoringSession.MaximumNumberOfHours;
       newSession.MonitorScmProcesses = this.monitoringSession.MonitorScmProcesses;
+      newSession.BlobSasUri = this.blobSasUri;
 
       this._daasService.submitMonitoringSession(this.siteToBeDiagnosed, newSession).subscribe(
         result => {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-sessions/cpu-monitoring-sessions.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-sessions/cpu-monitoring-sessions.component.html
@@ -14,76 +14,81 @@
 
         <div *ngIf="monitoringSessions.length > 0">
           <table class="table table-hover table-bordered">
-            <tr>
-              <th>Rule</th>
-              <th>Action</th>
-              <th>Started</th>
-              <th>Status</th>
-              <th>Dumps and Reports</th>
-            </tr>
-
-            <tr *ngFor="let monitoringSession of monitoringSessions"
-              [ngClass]="{'active-rule':isSessionActive(monitoringSession)}">
-              <td>
-                <div> CPU &gt; {{ monitoringSession.CpuThreshold }}% for &gt; {{ monitoringSession.ThresholdSeconds }}s
-                </div>
-              </td>
-              <td>
-                <div> {{ monitoringSession.Mode }} </div>
-              </td>
-              <td>
-                <div [innerHTML]="formatStartDate(monitoringSession)"></div>
-              </td>
-              <td>
-                <div [ngClass]="{'active-rule-bold':isSessionActive(monitoringSession)}">
-                  {{ isSessionActive(monitoringSession) ? 'Active' : 'Completed' }}</div>
-              </td>
-              <td>
-                <div *ngIf="monitoringSession.Mode !== 'Kill'">
-                  <div
-                    *ngIf="monitoringSession.FilesCollected == null || monitoringSession.FilesCollected.length === 0">
-                    <span>{{ isSessionActive(monitoringSession) ? 'Waiting for dumps...' : 'No dumps collected' }}</span>
+            <thead>
+              <tr>
+                <th>Rule</th>
+                <th>Action</th>
+                <th>Started</th>
+                <th>Status</th>
+                <th>Dumps and Reports</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let monitoringSession of monitoringSessions"
+                [ngClass]="{'active-rule':isSessionActive(monitoringSession)}">
+                <td>
+                  <div> CPU &gt; {{ monitoringSession.CpuThreshold }}% for &gt;
+                    {{ monitoringSession.ThresholdSeconds }}s
                   </div>
-                  <ul *ngIf="monitoringSession.FilesCollected.length > 0" style="list-style-type:none;padding:0">
-                    <li *ngFor="let file of monitoringSession.FilesCollected">
-                      {{ getfileNameFromPath(file.RelativePath) }}.dmp
-                      <a (click)="openReport(file.RelativePath)">
-                        <i class="fa fa-external-link"></i>
-                      </a>
-                    </li>
-                  </ul>
-
-                  <button class="btn btn-sm btn-primary"
-                    *ngIf="!monitoringSession.AnalysisSubmitted && monitoringSession.AnalysisStatus === 'NotStarted' && monitoringSession.FilesCollected != null && monitoringSession.FilesCollected.length > 0 && !isSessionActive(monitoringSession)"
-                    (click)="analyzeSession(monitoringSession)">Analyze</button>
-
-                  <div class="focus-box focus-box-warning" *ngIf="monitoringSession.ErrorSubmittingAnalysis">
-                    <strong>Error</strong> - {{ error }}
-                  </div>
-
-                  <div *ngIf="monitoringSession.AnalysisStatus === 'InProgress' || monitoringSession.AnalysisSubmitted">
-                    <i class=" fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-                    Analysis in progress...
-                  </div>
-                  <div *ngIf="monitoringSession.AnalysisStatus !== 'NotStarted'">
-                    <ul style="list-style-type:none;padding:0">
+                </td>
+                <td>
+                  <div> {{ monitoringSession.Mode }} </div>
+                </td>
+                <td>
+                  <div [innerHTML]="formatStartDate(monitoringSession)"></div>
+                </td>
+                <td>
+                  <div [ngClass]="{'active-rule-bold':isSessionActive(monitoringSession)}">
+                    {{ isSessionActive(monitoringSession) ? 'Active' : 'Completed' }}</div>
+                </td>
+                <td>
+                  <div *ngIf="monitoringSession.Mode !== 'Kill'">
+                    <div
+                      *ngIf="monitoringSession.FilesCollected == null || monitoringSession.FilesCollected.length === 0">
+                      <span>{{ isSessionActive(monitoringSession) ? 'Waiting for dumps...' : 'No dumps collected' }}</span>
+                    </div>
+                    <ul *ngIf="monitoringSession.FilesCollected.length > 0" style="list-style-type:none;padding:0">
                       <li *ngFor="let file of monitoringSession.FilesCollected">
-                        <div *ngIf="file.ReportFileRelativePath != null">
-                          {{ getfileNameFromPath(file.ReportFileRelativePath) }}.mht
-                          <a (click)="openReport(file.ReportFileRelativePath)">
-                            <i class="fa fa-external-link"></i>
-                          </a>
-                        </div>
+                        {{ getfileNameFromPath(file.RelativePath) }}.dmp
+                        <a (click)="openReport(file.RelativePath, monitoringSession.BlobSasUri)">
+                          <i class="fa fa-external-link"></i>
+                        </a>
                       </li>
                     </ul>
-                  </div>
-                </div>
 
-                <div *ngIf="monitoringSession.Mode === 'Kill'">
-                  None
-                </div>
-              </td>
-            </tr>
+                    <button class="btn btn-sm btn-primary"
+                      *ngIf="!monitoringSession.AnalysisSubmitted && monitoringSession.AnalysisStatus === 'NotStarted' && monitoringSession.FilesCollected != null && monitoringSession.FilesCollected.length > 0 && !isSessionActive(monitoringSession)"
+                      (click)="analyzeSession(monitoringSession)">Analyze</button>
+
+                    <div class="focus-box focus-box-warning" *ngIf="monitoringSession.ErrorSubmittingAnalysis">
+                      <strong>Error</strong> - {{ error }}
+                    </div>
+
+                    <div
+                      *ngIf="monitoringSession.AnalysisStatus === 'InProgress' || monitoringSession.AnalysisSubmitted">
+                      <i class=" fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+                      Analysis in progress...
+                    </div>
+                    <div *ngIf="monitoringSession.AnalysisStatus !== 'NotStarted'">
+                      <ul style="list-style-type:none;padding:0">
+                        <li *ngFor="let file of monitoringSession.FilesCollected">
+                          <div *ngIf="file.ReportFileRelativePath != null">
+                            {{ getfileNameFromPath(file.ReportFileRelativePath) }}.mht
+                            <a (click)="openReport(file.ReportFileRelativePath, '')">
+                              <i class="fa fa-external-link"></i>
+                            </a>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+
+                  <div *ngIf="monitoringSession.Mode === 'Kill'">
+                    None
+                  </div>
+                </td>
+              </tr>
+            </tbody>
           </table>
         </div>
       </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-sessions/cpu-monitoring-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-sessions/cpu-monitoring-sessions.component.ts
@@ -28,8 +28,13 @@ export class CpuMonitoringSessionsComponent implements OnInit, OnChanges {
   ngOnChanges() {
   }
 
-  openReport(url: string) {
-    this._windowService.open(`https://${this.scmPath}/api/vfs/${url}`);
+  openReport(relativePath: string, blobSasUri: string) {
+    if (blobSasUri && blobSasUri.toLowerCase().startsWith("https")) {
+      let blobUrl = new URL(blobSasUri);
+      this._windowService.open(`https://${blobUrl.host}${blobUrl.pathname}/${relativePath}?${blobUrl.searchParams}`);
+    } else {
+      this._windowService.open(`https://${this.scmPath}/api/vfs/${relativePath}`);
+    }
   }
 
   getfileNameFromPath(path: string): string {
@@ -67,8 +72,8 @@ export class CpuMonitoringSessionsComponent implements OnInit, OnChanges {
     var date = new Date(session.StartDate);
     let formattedDate = (date.getUTCMonth() + 1).toString().padStart(2, '0') + '/' + date.getUTCDate().toString().padStart(2, '0') + '/' + date.getUTCFullYear().toString() + ' ' + (date.getUTCHours() < 10 ? '0' : '') + date.getUTCHours()
       + ':' + (date.getUTCMinutes() < 10 ? '0' : '') + date.getUTCMinutes() + ' UTC';
-    
-      const utc = new Date().toUTCString();
+
+    const utc = new Date().toUTCString();
     if (this.isSessionActive(session)) {
       formattedDate += "<br/>" + FormatHelper.getDurationFromDate(session.StartDate, utc) + ' ago';
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring.component.html
@@ -11,6 +11,7 @@
       <collapsible-list [title]="titles[0]" [collapsed]="configCollapsed">
         <collapsible-list-item>
           <cpu-monitoring-configuration [siteToBeDiagnosed]="siteToBeDiagnosed"
+            [blobSasUri] = "blobSasUri"
             [activeSession]="activeMonitoringSession == null ? null : activeMonitoringSession.Session"
             (monitoringConfigurationChange)="updateMonitoringConfiguration($event)" (savingMonitoringConfiguration)="savingMonitoringConfiguration($event)">
           </cpu-monitoring-configuration>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring.component.ts
@@ -30,6 +30,7 @@ export class CpuMonitoringComponent implements OnInit, OnDestroy {
   configCollapsed: boolean = false;
   monitoringCollapsed: boolean = true;
   sessionsCollapsed: boolean = true;
+  blobSasUri:string ="";
 
   titles: string[] = ['1. Configure', '2. Observe', '3. Analyze'];
   constructor(private _siteService: SiteService, private _daasService: DaasService) {
@@ -42,6 +43,7 @@ export class CpuMonitoringComponent implements OnInit, OnDestroy {
 
   onDaasValidated(validated: DaasValidationResult) {
     this.validationResult = validated;
+    this.blobSasUri = this.validationResult.BlobSasUri;
   }
 
   ngOnInit(): void {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
@@ -29,7 +29,7 @@ export class DaasValidatorComponent implements OnInit {
   alwaysOnEnabled: boolean = true;
   error: string = '';
   storageAccountNeeded: boolean = false;
-  diagnosersRequiringStorageAccount: string[] = ['Memory Dump'];
+  diagnosersRequiringStorageAccount: string[] = ['Memory Dump', 'CPU Monitoring'];
   validationResult: DaasValidationResult = new DaasValidationResult();
   diagnosers: DiagnoserDefinition[];
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -143,6 +143,7 @@ export class MonitoringSession {
     AnalysisStatus: AnalysisStatus;
     AnalysisSubmitted: boolean = false;
     ErrorSubmittingAnalysis: string = "";
+    BlobSasUri: string = "";
 }
 
 export interface MonitoringFile {


### PR DESCRIPTION
With this change, we will now force customers to configure a Storage Account even when they try to use memory dump collection for Proactive CPU Monitoring.

![image](https://user-images.githubusercontent.com/5299838/79987487-1bed8580-84cb-11ea-99f9-ca9321262096.png)
