### PR TITLE
Fix breadcrumb and few logging issues

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
@@ -78,7 +78,7 @@ export class CategorySummaryComponent implements OnInit {
             this.categoryName = this.category.name;
 
             this.resourceName = this._activatedRoute.snapshot.params.resourcename;
-            this._portalActionService.updateDiagnoseCategoryBladeTitle(`${this.resourceName} - ` + this.categoryName);
+            this._portalActionService.updateDiagnoseCategoryBladeTitle(`${this.resourceName} | ` + this.categoryName);
         });
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
@@ -28,16 +28,13 @@ export class CategoryTileV4Component implements OnInit {
 
   openBladeDiagnoseCategoryBlade() {
     this._portalService.openBladeDiagnoseCategoryBlade(this.category.id);
-    this._telemetryService.logEvent('CategorySelection',{
+    this._telemetryService.logEvent('CategorySelected',{
       'CategoryName': this.category.name
     });
   }
 
   navigateToCategory(): void {
-
-    // this._logger.LogCategorySelected(this.category.name);
-    // this._logger.LogClickEvent('CategorySelection', 'HomeV4', this.category.name);
-    this._telemetryService.logEvent('CategorySelection',{
+    this._telemetryService.logEvent('CategorySelected',{
       'CategoryName': this.category.name
     });
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
@@ -23,7 +23,7 @@ export class CategoryTileComponent implements OnInit {
   navigateToCategory(): void {
 
     this._logger.LogCategorySelected(this.category.name);
-    this._logger.LogClickEvent('CategorySelection', 'HomeV2', this.category.name);
+    this._logger.LogClickEvent('CategorySelected', 'HomeV2', this.category.name);
 
     if (this.category.overridePath) {
       this._router.navigateByUrl(this.category.overridePath);

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="matchesSearchTerm">
-    <div class="menu-item" (click)="handleClick()" [class.selected]="isSelected()" style="padding-top:6px!important"
+    <div [id]="menuItem.label" class="menu-item" (click)="handleClick()" [class.selected]="isSelected()" style="padding-top:6px!important"
         [style.padding-left]="getPadding()" [style.font-size]="getFontSize()">
         <div tabindex="0" role="button" (keyup.enter)="handleClick()" aria-label="menuItem.label" type="button">
             <i class="fa expand-icon" *ngIf=" menuItem.subItems && menuItem.subItems.length > 0"

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.ts
@@ -37,6 +37,11 @@ export class CollapsibleMenuItemComponent implements OnInit {
       this.menuItem.expanded = !this.menuItem.expanded;
     }
     else {
+      if (document.getElementById(this.menuItem.label))
+      {
+        document.getElementById(this.menuItem.label).focus();
+      }
+
       this.telemetryService.logEvent(TelemetryEventNames.CategoryNavItemClicked,{
         'Title':this.menuItem.label
       });

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.html
@@ -42,8 +42,8 @@
                     <b>{{ connection.Name }}</b>
                     <span>({{ getDatabaseTypeName(connection) }})</span>
                     <span class="pull-right">
-                        <i class="fa fa-plus" *ngIf="!connection.Expanded" aria-hidden="true"></i>
-                        <i class="fa fa-minus" *ngIf="connection.Expanded" aria-hidden="true"></i>
+                        <i class="fa fa-plus" *ngIf="!connection.Expanded" tabindex="0" aria-label="Expand connections"></i>
+                        <i class="fa fa-minus" *ngIf="connection.Expanded"  tabindex="0" aria-label="Collapse connections"></i>
                     </span>
                 </div>
                 <div class="panel-body" *ngIf="connection.Expanded">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -336,7 +336,11 @@ export class ArmService {
             loggingError.message = actualError;
         }
         
-        this.telemetryService.logException(loggingError, null, loggingProps);
+        if (this.telemetryService)
+        {
+            this.telemetryService.logException(loggingError, null, loggingProps);
+        }
+        
         return observableThrowError(actualError);
     }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-markdown/app-insights-markdown.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-markdown/app-insights-markdown.component.html
@@ -54,7 +54,9 @@
                   easily.
                 </div>
 
-                <button type="button" class="btn btn-info" class="app-insights-blade"
+                <button type="button" class="btn btn-info app-insights-blade"
+                  aria-label="Open Application Insights Blade" tabindex="0" role="button"
+                  (keyup.enter)="this._appInsightsService.openAppInsightsBlade()"
                   (click)="this._appInsightsService.openAppInsightsBlade()">
                   Open Application Insights Blade
                   <i class="fa fa-chevron-right"></i>
@@ -91,7 +93,9 @@
                       easily.
                     </div>
 
-                    <button type="button" class="btn btn-info" class="app-insights-blade"
+                    <button type="button" class="btn btn-info app-insights-blade"
+                      aria-label="Enable Application Insights" tabindex="0" role="button"
+                      (keyup.enter)="this._appInsightsService.openAppInsightsBlade()"
                       (click)="this._appInsightsService.openAppInsightsBlade()">
                       Enable Application Insights
                       <i class="fa fa-chevron-right"></i>
@@ -110,7 +114,10 @@
               [applicationInsightContainerStyle]="1">
               <dynamic-data [diagnosticData]="data.diagnosticData" [startTime]="startTime" [endTime]="endTime">
               </dynamic-data>
-              <button type="button" class="btn btn-info" class="app-insights-blade"
+              <button type="button" class="btn btn-info app-insights-blade"
+                attr.aria-label="Open Application Insights - {{data.poralBladeInfo.description}}" tabindex="0"
+                role="button"
+                (keyup.enter)="this._appInsightsService.openAppInsightsExtensionBlade(data.poralBladeInfo.bladeName)"
                 (click)="_appInsightsService.openAppInsightsExtensionBlade(data.poralBladeInfo.bladeName)">
                 {{data.poralBladeInfo.description}}
                 <i class="fa fa-chevron-right"></i>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -100,7 +100,7 @@
                     code easily.
                   </div>
                   <div class="app-insights-blade-link">
-                    <a (keyup.enter)="this._appInsightsService.openAppInsightsBlade()" role="button"
+                    <a (keyup.enter)="this._appInsightsService.openAppInsightsBlade()" tabindex="0" role="button"
                       aria-label="Enable Application Insights link"
                       (click)="this._appInsightsService.openAppInsightsBlade()">
                       Enable Application Insights
@@ -124,7 +124,7 @@
                     <dynamic-data [diagnosticData]="data.diagnosticData" [startTime]="startTime" [endTime]="endTime">
                     </dynamic-data>
                     <div class="app-insights-blade-link">
-                      <a aria-label="Link to open Application Insights blade" role="button"
+                      <a aria-label="Link to open Application Insights blade" tabindex="0" role="button"
                         (keyup.enter)="_appInsightsService.openAppInsightsExtensionBlade(data.poralBladeInfo.bladeName)"
                         (click)="_appInsightsService.openAppInsightsExtensionBlade(data.poralBladeInfo.bladeName)">
                         {{data.poralBladeInfo.description}}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
@@ -5,7 +5,7 @@
     </div>
     <div style="margin-left:20px;">
         <div class="input-group input-group-sm search-input-group" role="search" *ngIf="!searchConfiguration.DetectorSearchEnabled || detectorId == ''">
-            <input aria-controls="search-results" class="form-control" [(ngModel)]="searchTerm" tabindex="0" type="search" placeholder="Describe your problem here" (keyup.enter)="hitSearch()" maxlength="140">
+            <input aria-controls="search-results" class="form-control search-result-input" [(ngModel)]="searchTerm" tabindex="0" type="search" placeholder="Describe your problem here" (keyup.enter)="hitSearch()" maxlength="140">
             <div class="input-group-btn" id="clear-search">
                 <button aria-label="At least 2 characters" [style.display]="searchTerm?.trim().length>0 && searchTerm?.trim().length<2? '': 'none'" class="btn btn-default" style="padding-top:1px;" tabindex="0" title="At least 2 characters" type="button">
                     <i class="fa fa-exclamation icon-err"></i>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.scss
@@ -47,6 +47,10 @@
     height: 30px;
 }
 
+.search-result-input::placeholder {
+    color: #716f6f
+}
+
 .successful-section-title {
     cursor:pointer;
     color:#1074fe;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dropdown-v4/dropdown-v4.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dropdown-v4/dropdown-v4.component.scss
@@ -6,7 +6,7 @@
     margin-right: 10px;
 }
 .label-container > label {
-    color:#969696;
+    color:#6b6969;
     font-weight: 500;
     font-size: 13px;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dropdown/dropdown.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dropdown/dropdown.component.scss
@@ -6,7 +6,7 @@
     margin-right: 10px;
 }
 .label-container > label {
-    color:#969696;
+    color:#6b6969;
     font-weight: 500;
     font-size: 13px;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.html
@@ -1,6 +1,6 @@
 <div>
     <div *ngIf="!isChildComponent" class="input-group input-group-sm search-input-group" role="search">
-        <input aria-controls="search-results" class="form-control" [(ngModel)]="searchTerm" tabindex="0" type="search" placeholder="Describe your problem here" (keyup.enter)="refresh()" maxlength="140">
+        <input aria-controls="search-results" class="form-control search-result-input" [(ngModel)]="searchTerm" tabindex="0" type="search" placeholder="Describe your problem here" (keyup.enter)="refresh()" maxlength="140">
         <div class="input-group-btn" id="clear-search">
             <button aria-label="At least 2 characters" [style.display]="searchTerm?.trim().length>0 && searchTerm?.trim().length<2? '': 'none'" class="btn btn-default" style="padding-top:1px;" tabindex="0" title="At least 2 characters" type="button">
                 <i class="fa fa-exclamation icon-err"></i>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
@@ -3,6 +3,10 @@
     height: 30px;
 }
 
+.search-result-input::placeholder {
+    color: #716f6f
+}
+
 .icon-err{
     color: #bf0000;
 }


### PR DESCRIPTION
Hey @ShekharGupta1988  I realized we have control over for the whole string here:

![image](https://user-images.githubusercontent.com/38216903/82106807-3684da00-96d8-11ea-8e1a-47ff797ff316.png)

The reason I didn't change this to **Diagnose and solve problems | Availability and Performance**  is that before we send the whole string from our Iframe to ibiza, ibiza will show the resource name by default first, and then change it to our string. So it will be changed from "BuggyBakery" to "Diagnose and solve problems | Availability and Performance", which is a bit jarring. So I keep the string to be as it is to make the switch look more smooth.