### PR TITLE
Breadcrumb fix and few logging fix

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/availability/problem-solution/problem-solution.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/availability/problem-solution/problem-solution.component.ts
@@ -124,7 +124,7 @@ export class ProblemSolutionComponent implements OnInit {
                 title = 'Memory Issue';
                 break;
             case 'autoheal':
-                title = 'Auto Heal';
+                title = 'Auto-Heal';
                 break;
             default:
                 title = 'App Issue'

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
@@ -78,7 +78,7 @@ export class CategorySummaryComponent implements OnInit {
             this.categoryName = this.category.name;
 
             this.resourceName = this._activatedRoute.snapshot.params.resourcename;
-            this._portalActionService.updateDiagnoseCategoryBladeTitle(`${this.resourceName} - ` + this.categoryName);
+            this._portalActionService.updateDiagnoseCategoryBladeTitle(`${this.resourceName} | ` + this.categoryName);
         });
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
@@ -28,16 +28,13 @@ export class CategoryTileV4Component implements OnInit {
 
   openBladeDiagnoseCategoryBlade() {
     this._portalService.openBladeDiagnoseCategoryBlade(this.category.id);
-    this._telemetryService.logEvent('CategorySelection',{
+    this._telemetryService.logEvent('CategorySelected',{
       'CategoryName': this.category.name
     });
   }
 
   navigateToCategory(): void {
-
-    // this._logger.LogCategorySelected(this.category.name);
-    // this._logger.LogClickEvent('CategorySelection', 'HomeV4', this.category.name);
-    this._telemetryService.logEvent('CategorySelection',{
+    this._telemetryService.logEvent('CategorySelected',{
       'CategoryName': this.category.name
     });
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
@@ -23,7 +23,7 @@ export class CategoryTileComponent implements OnInit {
   navigateToCategory(): void {
 
     this._logger.LogCategorySelected(this.category.name);
-    this._logger.LogClickEvent('CategorySelection', 'HomeV2', this.category.name);
+    this._logger.LogClickEvent('CategorySelected', 'HomeV2', this.category.name);
 
     if (this.category.overridePath) {
       this._router.navigateByUrl(this.category.overridePath);

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -156,7 +156,7 @@ export class SitesCategoryService extends CategoryService {
         id: 'DiagnosticTools',
         name: 'Diagnostic Tools',
         description: 'Sometimes deeper investigation is necessary. With Diagnostic Tools, you can run language-specific tools to profile your app, collect network traces, memory dumps, and more.',
-        keywords: ['Profiler', 'Memory Dump', 'DaaS', 'AutoHeal', 'Metrics', 'Security'],
+        keywords: ['Profiler', 'Memory Dump', 'DaaS', 'Auto-Heal', 'Metrics', 'Security'],
         color: 'rgb(170, 192, 208)',
         createFlowForCategory: false,
         overridePath: `resource${siteId}/diagnosticTools`

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -336,7 +336,11 @@ export class ArmService {
             loggingError.message = actualError;
         }
         
-        this.telemetryService.logException(loggingError, null, loggingProps);
+        if (this.telemetryService)
+        {
+            this.telemetryService.logException(loggingError, null, loggingProps);
+        }
+        
         return observableThrowError(actualError);
     }
 


### PR DESCRIPTION
Hey @ShekharGupta1988  I realized we have control over for the whole string here:

![image](https://user-images.githubusercontent.com/38216903/82106807-3684da00-96d8-11ea-8e1a-47ff797ff316.png)

The reason I didn't change this to **Diagnose and solve problems | Availability and Performance**  is that before we send the whole string from our Iframe to ibiza, ibiza will show the resource name by default first, and then change it to our string. So it will be changed from "BuggyBakery" to "Diagnose and solve problems | Availability and Performance", which is a bit jarring. So I keep the string to be as it is to make the switch look more smooth.