### PR TITLE
Luminosity ratio bugs

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.scss
@@ -1,5 +1,10 @@
 .panel-heading {
   cursor: pointer;
+  color: #000000;
+}
+
+.healthy-icon-color {
+    color: #488b00
 }
 
 .panel-body {


### PR DESCRIPTION
Fixing accessibility bugs for luminosity ratio
1. Overriding the healthy-icon-color class for this component only (because the icon is used in different places and the background colors there are different). Updated luminosity ratio is 3.88 : 1 (required is minimum 3 : 1)
2. Updating the panel heading color from gray to black (since the background is light gray too). Updated luminosity ratio is 19.26 : 1 (required is minimum 4.5 : 1)
https://msazure.visualstudio.com/Antares/_workitems/edit/7096293
https://msazure.visualstudio.com/Antares/_workitems/edit/7096303

Before look:
![image](https://user-images.githubusercontent.com/8492235/82246826-3f54f600-98fa-11ea-9dd6-7a4918083b27.png)

After look:
![image](https://user-images.githubusercontent.com/8492235/82246858-50056c00-98fa-11ea-89a2-3520c2970710.png)
