### PR TITLE
Add logic to enable external users with new expericence

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="isWindowsWebApp&&!isExternalSub">
+<ng-container *ngIf="initializedPortalVersion === 'v3'">
   <div *ngIf="useLegacy" class="switch2new-context-text">
     <i class="fa fa-info-circle info-banner-icon"></i>
     We have recently launched the new version of App Service Diagnostics.

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.scss
@@ -1,5 +1,6 @@
 .switch2new-context-text, .switch2old-context-text{
   background: #b3d6f2;
+  line-height: 30px;
   padding: 2px;
 }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
@@ -27,8 +27,7 @@ import { SubscriptionPropertiesService } from '../../../shared/services/subscrip
 })
 export class HomeComponent implements OnInit, AfterViewInit {
     useLegacy: boolean = true;
-    isWindowsWebApp: boolean = true;
-    isExternalSub: boolean = true;
+    initializedPortalVersion: string = "v2";
     resourceName: string;
     categories: Category[];
     searchValue = '';
@@ -60,15 +59,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
         private versionTestService: VersionTestService, private subscriptionPropertiesService: SubscriptionPropertiesService) {
 
         this.subscriptionId = this._activatedRoute.snapshot.params['subscriptionid'];
-        this.isExternalSub = this.versionTestService.isExternalSub;
         this.versionTestService.isLegacySub.subscribe(isLegacy => this.useLegacy = isLegacy);
-        this.versionTestService.isWindowsWebApp.subscribe(isWebAppResource => this.isWindowsWebApp = isWebAppResource);
-        
-        let initialViewLoaded = this.isWindowsWebApp && !this.isExternalSub ? "new" : "old";
+
+        this.versionTestService.initializedPortalVersion.subscribe(version => this.initializedPortalVersion = version); 
         let eventProps = {
             subscriptionId: this.subscriptionId,
             resourceName: this.resourceName,
-            intialView: initialViewLoaded,
+            intialView: this.initializedPortalVersion,
         };
         this._telemetryService.logEvent('DiagnosticsViewLoaded',eventProps);
 
@@ -103,7 +100,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
                 }
                 else {
                     this.homePageText = {
-                        title: 'App Service Diagnostics',
+                        title: 'App Service Diagnostics (Preview)',
                         description: 'Use App Service Diagnostics to investigate how your app is performing, diagnose issues, and discover how to\
             improve your application. Select the problem category that best matches the information or tool that you\'re\
             interested in:',
@@ -197,7 +194,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
     ngAfterViewInit() {
         this._telemetryService.logPageView(TelemetryEventNames.HomePageLoaded, {"numCategories": this.categories.length.toString()});
-        document.getElementById("healthCheck").focus();
+        if (document.getElementById("healthCheck"))
+        {
+            document.getElementById("healthCheck").focus();
+        }
     }
 
    

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
@@ -65,7 +65,6 @@ export class HomeComponent implements OnInit, AfterViewInit {
         let eventProps = {
             subscriptionId: this.subscriptionId,
             resourceName: this.resourceName,
-            intialView: this.initializedPortalVersion,
         };
         this._telemetryService.logEvent('DiagnosticsViewLoaded',eventProps);
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-appinsights-telemetry.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-appinsights-telemetry.service.ts
@@ -46,6 +46,7 @@ export class PortalAppInsightsTelemetryService implements ITelemetryProvider {
                             enableAutoRouteTracking: true,
                             maxBatchSizeInBytes: 5,
                             maxBatchInterval: 1,
+                            autoTrackPageVisitTime: true,
                         }
                     };
                     

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.service.ts
@@ -15,6 +15,7 @@ export class TelemetryService {
     eventPropertiesSubject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
     private eventPropertiesLocalCopy: { [name: string]: string } = {};
     private isLegacy: boolean;
+    private initializedPortalVersion: string = "v2";
     private isPublic:boolean;
     private enabledResourceTypes: { resourceType: string, name: string }[] = [
         {
@@ -62,6 +63,7 @@ export class TelemetryService {
             }
         });
         this._versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
+        this._versionService.initializedPortalVersion.subscribe(initializedVersion => this.initializedPortalVersion = initializedVersion);
     }
 
     /**
@@ -79,6 +81,7 @@ export class TelemetryService {
             properties.Url = window.location.href;
         }
 
+        properties.initializedPortalVersion = this.initializedPortalVersion;
         properties.PortalVersion = this.isLegacy ? 'V2' : 'V3';
 
         let productName = "";

--- a/AngularApp/projects/diagnostic-data/src/lib/services/version.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/version.service.ts
@@ -6,5 +6,6 @@ import { BehaviorSubject } from 'rxjs';
 })
 export class VersionService {
   public isLegacySub: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+  public initializedPortalVersion: BehaviorSubject<string> = new BehaviorSubject<string>("v2");
   constructor() { }
 }


### PR DESCRIPTION
1. Add logic to pass percentage of external traffic for new experience
2. Enable page view time for application insights
3. Bug fix for old experience when there is no "healthcheck"  element to focus
4. Small UI change:
![image](https://user-images.githubusercontent.com/38216903/82272561-ccff0880-992f-11ea-84da-295b1cb781c5.png)
