### PR TITLE
Create diagnostic sessions panel in new D&S

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.html
@@ -15,5 +15,6 @@
         <i class="fa fa-angle-double-left" style="margin: 5px;font-size:13px;"></i>
       </div>
     </section>
+    <diagostic-sessions-panel></diagostic-sessions-panel>
   </div>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.html
@@ -1,0 +1,20 @@
+<fab-panel [isOpen]="globals.openSessionPanel" [type]="type" [customWidth]="width" [isHiddenOnDismiss]="true"
+  [isLightDismiss]="true" [hasCloseButton]="true" [closeButtonAriaLabel]="'close'" (onDismissed)="dismissedHandler()">
+  <div class="row">
+    <div style="margin-bottom: 10px">
+      <div
+        style="position: absolute; left:25px; right: 32px; top:0px; height: 32px; font-family: 'segoe UI'; font-size: 18px; line-height: 24px; font-weight: 600;display: flex; align-items: flex-end"
+        tabindex="0" aria-label="Hi my name is genie">
+        Diagnostic sessions</div>
+      <p>
+        Below is the list of all the diagnostic sessions collected in the past for this web app. To save disk space,
+        older
+        diagnostic sessions and their data collected will be deleted automatically.
+      </p>
+      <div class="sessions">
+        <daas-sessions [diagnoserNameLookup]="" [scmPath]="scmPath" [siteToBeDiagnosed]="siteToBeDiagnosed">
+        </daas-sessions>
+      </div>
+    </div>
+  </div>
+</fab-panel>

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.spec.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DiagosticSessionsPanelComponent } from './diagostic-sessions-panel.component';
+
+describe('DiagosticSessionsPanelComponent', () => {
+  let component: DiagosticSessionsPanelComponent;
+  let fixture: ComponentFixture<DiagosticSessionsPanelComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DiagosticSessionsPanelComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DiagosticSessionsPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { PanelType } from 'office-ui-fabric-react';
-import { TelemetryService, TelemetryEventNames } from 'diagnostic-data';
 import { Globals } from '../../../globals';
 import { SiteDaasInfo } from '../../../shared/models/solution-metadata';
-import { SiteFeatureService } from '../../../resources/web-sites/services/site-feature.service';
 import { WebSitesService } from '../../../resources/web-sites/services/web-sites.service';
 import { SiteService } from '../../../shared/services/site.service';
 
@@ -18,7 +16,7 @@ export class DiagosticSessionsPanelComponent implements OnInit {
   type: PanelType = PanelType.custom;
   width: string = "850px";
 
-  constructor(private _sitesFeatureService: SiteFeatureService, public webSiteService: WebSitesService, private _siteService: SiteService, protected telemetryService: TelemetryService, public globals: Globals) {
+  constructor(public webSiteService: WebSitesService, private _siteService: SiteService, public globals: Globals) {
     this._siteService.getSiteDaasInfoFromSiteMetadata().subscribe(site => {
       this.siteToBeDiagnosed = site;
     });

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
@@ -16,7 +16,7 @@ export class DiagosticSessionsPanelComponent implements OnInit {
   siteToBeDiagnosed: SiteDaasInfo;
   scmPath: string;
   type: PanelType = PanelType.custom;
-  width: string = "800px";
+  width: string = "850px";
 
   constructor(private _sitesFeatureService: SiteFeatureService, public webSiteService: WebSitesService, private _siteService: SiteService, protected telemetryService: TelemetryService, public globals: Globals) {
     this._siteService.getSiteDaasInfoFromSiteMetadata().subscribe(site => {

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/diagostic-sessions-panel/diagostic-sessions-panel.component.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit } from '@angular/core';
+import { PanelType } from 'office-ui-fabric-react';
+import { TelemetryService, TelemetryEventNames } from 'diagnostic-data';
+import { Globals } from '../../../globals';
+import { SiteDaasInfo } from '../../../shared/models/solution-metadata';
+import { SiteFeatureService } from '../../../resources/web-sites/services/site-feature.service';
+import { WebSitesService } from '../../../resources/web-sites/services/web-sites.service';
+import { SiteService } from '../../../shared/services/site.service';
+
+@Component({
+  selector: 'diagostic-sessions-panel',
+  templateUrl: './diagostic-sessions-panel.component.html',
+  styleUrls: ['./diagostic-sessions-panel.component.scss']
+})
+export class DiagosticSessionsPanelComponent implements OnInit {
+  siteToBeDiagnosed: SiteDaasInfo;
+  scmPath: string;
+  type: PanelType = PanelType.custom;
+  width: string = "800px";
+
+  constructor(private _sitesFeatureService: SiteFeatureService, public webSiteService: WebSitesService, private _siteService: SiteService, protected telemetryService: TelemetryService, public globals: Globals) {
+    this._siteService.getSiteDaasInfoFromSiteMetadata().subscribe(site => {
+      this.siteToBeDiagnosed = site;
+    });
+
+    this.scmPath = this.webSiteService.resource.properties.enabledHostNames.find(hostname => hostname.indexOf('.scm.') > 0);
+  }
+
+  ngOnInit() {
+  }
+
+  dismissedHandler() {
+    this.globals.openSessionPanel = false;
+  }
+
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/fabric.module.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/fabric.module.ts
@@ -53,6 +53,8 @@ import { RouterModule } from '@angular/router';
 import { DiagnosticDataModule } from 'diagnostic-data';
 import { CollapsibleMenuItemComponent } from '../home/components/collapsible-menu-item/collapsible-menu-item.component';
 import { SearchPipe, SearchMatchPipe } from '../home/components/pipes/search.pipe';
+import { DiagosticSessionsPanelComponent } from './components/diagostic-sessions-panel/diagostic-sessions-panel.component';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
     declarations: [
@@ -66,7 +68,8 @@ import { SearchPipe, SearchMatchPipe } from '../home/components/pipes/search.pip
         SectionDividerComponent,
         CollapsibleMenuItemComponent,
         SearchPipe,
-        SearchMatchPipe
+        SearchMatchPipe,
+        DiagosticSessionsPanelComponent
     ],
     imports: [
         CommonModule,
@@ -113,7 +116,8 @@ import { SearchPipe, SearchMatchPipe } from '../home/components/pipes/search.pip
         FabProgressIndicatorModule,
         // FabNavModule,
         FabContextualMenuModule,
-        DiagnosticDataModule
+        DiagnosticDataModule,
+        SharedModule
     ],
     exports: [
         FabricSearchResultsComponent,

--- a/AngularApp/projects/app-service-diagnostics/src/app/globals.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/globals.ts
@@ -27,6 +27,7 @@ export class Globals {
   private _openGeniePanel:boolean = false;
   openFeedback: boolean = false;
   openTimePicker: boolean = false;
+  openSessionPanel: boolean = false;
   private localStorageKey: string = "genieChat";
   public timePickerInfoSub:BehaviorSubject<TimePickerInfo> = new BehaviorSubject<TimePickerInfo>({
     selectedKey: "Last24Hours"

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.html
@@ -41,5 +41,4 @@
       </daas-sessions>
     </div>
   </div>
-
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.html
@@ -1,7 +1,11 @@
 <div *ngIf="supportedTier && !showDetailedView" class="header2">Last 5 {{DiagnoserHeading}}
     <div *ngIf="showDetailsLink" style="display:inline">
-        <div style="display:inline" [routerLink]="allSessions">
+        <div *ngIf="!enableSessionsPanel else useSessionsPanel" style="display:inline" [routerLink]="allSessions">
             (<a tabindex="0" aria-label="View all sessions">View all sessions</a>)</div>
+        <ng-template #useSessionsPanel>
+            <div style="display:inline" (click)="toggleSessionPanel()"  (keyup.enter)="toggleSessionPanel()">
+                (<a tabindex="0" aria-label="View all sessions">View all sessions</a>)</div>
+        </ng-template>
     </div>
 </div>
 <div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -7,9 +7,9 @@ import { SiteDaasInfo } from '../../models/solution-metadata';
 import { Subscription, Observable, interval } from 'rxjs';
 import { retry } from 'rxjs/operators';
 import { FormatHelper } from '../../utilities/formattingHelper';
-import { VersionTestService } from '../../../fabric-ui/version-test.service';
 import { ActivatedRoute } from '@angular/router';
 import { Globals } from '../../../globals';
+import { TelemetryService } from 'diagnostic-data';
 
 @Component({
     selector: 'daas-sessions',
@@ -36,7 +36,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     allSessions: string = '../../diagnosticTools';
     subscription: Subscription;
 
-    constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService, private _daasService: DaasService, protected _route: ActivatedRoute, public globals: Globals) {
+    constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService, private _daasService: DaasService, protected _route: ActivatedRoute, public globals: Globals, public telemetryService: TelemetryService) {
         this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
             if (serverFarm) {
                 if (serverFarm.sku.tier === 'Standard' || serverFarm.sku.tier === 'Basic' || serverFarm.sku.tier.indexOf('Premium') > -1) {
@@ -208,6 +208,8 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
 
     toggleSessionPanel() {
         this.globals.openSessionPanel=!this.globals.openSessionPanel;
+        this.telemetryService.logEvent("OpenSesssionsPanel");
+        this.telemetryService.logPageView("SessionsPanelView");
     }
 }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -7,6 +7,9 @@ import { SiteDaasInfo } from '../../models/solution-metadata';
 import { Subscription, Observable, interval } from 'rxjs';
 import { retry } from 'rxjs/operators';
 import { FormatHelper } from '../../utilities/formattingHelper';
+import { VersionTestService } from '../../../fabric-ui/version-test.service';
+import { ActivatedRoute } from '@angular/router';
+import { Globals } from '../../../globals';
 
 @Component({
     selector: 'daas-sessions',
@@ -26,14 +29,14 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
 
     DiagnoserHeading: string;
     supportedTier: boolean = false;
+    enableSessionsPanel: boolean = false;
 
     @Input() refreshSessions: boolean = false;
     showDetailedView: boolean = false;
     allSessions: string = '../../diagnosticTools';
     subscription: Subscription;
 
-
-    constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService, private _daasService: DaasService) {
+    constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService, private _daasService: DaasService, protected _route: ActivatedRoute, public globals: Globals) {
         this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
             if (serverFarm) {
                 if (serverFarm.sku.tier === 'Standard' || serverFarm.sku.tier === 'Basic' || serverFarm.sku.tier.indexOf('Premium') > -1) {
@@ -43,7 +46,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
         }, error => {
             //TODO: handle error
         });
-
+       this.enableSessionsPanel = this._route.snapshot.params['category'] != null || this._route.parent.snapshot.params['category']!= null;      
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -203,6 +206,9 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
         return datestring.toUpperCase().endsWith('Z') ? datestring : datestring += 'Z';;
     }
 
+    toggleSessionPanel() {
+        this.globals.openSessionPanel=!this.globals.openSessionPanel;
+    }
 }
 
 @Pipe({ name: 'datetimediff' })

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.service.ts
@@ -69,7 +69,7 @@ export class TelemetryService {
     /**
      * Writes event to the registered logging providers.
      */
-    public logEvent(eventMessage: string, properties: { [name: string]: string }, measurements?: any) {
+    public logEvent(eventMessage: string, properties: { [name: string]: string } = {}, measurements?: any) {
         if (this.eventPropertiesLocalCopy) {
             for (const id of Object.keys(this.eventPropertiesLocalCopy)) {
                 if (this.eventPropertiesLocalCopy.hasOwnProperty(id)) {


### PR DESCRIPTION
In new Diagnose & Solve portal, whenever customer clicks “view all sessions” link from “Collect Memory Dump” page or “Collect Profiler Trace” page, a context menu with the sessions table will show up in a context menu:
![image](https://user-images.githubusercontent.com/38216903/82410418-b5557c00-9a24-11ea-9088-14b419f2cb7a.png)
