### PR TITLE
Remove token query parameter for Github API call

### DIFF
--- a/ApplensBackend/Helpers/Constants.cs
+++ b/ApplensBackend/Helpers/Constants.cs
@@ -46,7 +46,7 @@ namespace AppLensV3.Helpers
     internal static class SelfHelpConstants
     {
         internal const string RawFileHeaderMediaType = "application/vnd.github.VERSION.raw";
-        internal const string ArticleTemplatePath = "https://api.github.com/repos/Azure/SelfHelpContent/contents/articles/{0}?ref=master&access_token={1}";
+        internal const string ArticleTemplatePath = "https://api.github.com/repos/Azure/SelfHelpContent/contents/articles/{0}?ref=master";
     }
 
     internal static class InsightsConstants

--- a/ApplensBackend/Services/SelfHelpContentService/SelfHelpContentService.cs
+++ b/ApplensBackend/Services/SelfHelpContentService/SelfHelpContentService.cs
@@ -51,6 +51,7 @@ namespace AppLensV3.Services
 
             HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             HttpClient.DefaultRequestHeaders.Add("User-Agent", "applensv3");
+            HttpClient.DefaultRequestHeaders.Add("Authorization", $"token {AccessToken}");
         }
 
         public SelfHelpContentService(IConfiguration configuration)


### PR DESCRIPTION
Github API authentication from query parameters will be deprecated soon, fix the existing API call by changing it to header authorization:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/