### PR TITLE
Fixing DAAS Storage Account selection for National Clouds

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -145,7 +145,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
         },
           error => {
             this.generatingSasUri = false;
-            this.error = error;
+            this.error = "Failed to set BlobSasUri for the current app. " + error;
           });
       }
     },

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
@@ -34,6 +34,15 @@ export class DaasValidatorComponent implements OnInit {
   diagnosers: DiagnoserDefinition[];
 
   constructor(private _serverFarmService: ServerFarmDataService, private _siteService: SiteService, private _daasService: DaasService) {
+    
+    //
+    // Temporary fix to unblock users in national clouds.
+    // Should be removed after DAAS 1.40 update
+    //
+    
+    if (this._daasService.isNationalCloud) {
+      this.diagnosersRequiringStorageAccount=[];
+    }
   }
 
   validateDaasSettings() {
@@ -113,7 +122,7 @@ export class DaasValidatorComponent implements OnInit {
   }
 
   validateDiagnoser(): void {
-    if (this.diagnosers == null){
+    if (this.diagnosers == null) {
       return;
     }
     this.storageAccountNeeded = this.diagnosersRequiringStorageAccount.findIndex(x => x === this.diagnoserName) >= 0;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -179,6 +179,7 @@ export class DaasSettings {
     BlobContainer: string;
     BlobKey: string;
     BlobAccount: string;
+    EndpointSuffix:string;
 }
 
 export class DaasValidationResult {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -28,12 +28,12 @@ export class ArmService {
     private diagRoleVersion: string = '';
     private readonly routeToLiberation = '2';
     private readonly routeToDiagnosticRole = '1';
-    private armEndpoint:string = '';
+    private armEndpoint: string = '';
     constructor(private _http: HttpClient, private _authService: AuthService, private _cache: CacheService, private _genericArmConfigService?: GenericArmConfigService,
-        private telemetryService?: PortalKustoTelemetryService ) {
+        private telemetryService?: PortalKustoTelemetryService) {
         this._authService.getStartupInfo().subscribe((startupInfo: StartupInfo) => {
-            if(!!startupInfo.armEndpoint && startupInfo.armEndpoint !='' && startupInfo.armEndpoint.length > 1) {
-                this.armEndpoint = startupInfo.armEndpoint ;
+            if (!!startupInfo.armEndpoint && startupInfo.armEndpoint != '' && startupInfo.armEndpoint.length > 1) {
+                this.armEndpoint = startupInfo.armEndpoint;
             }
             let resourceId = startupInfo.resourceId;
             let subscriptionId = resourceId.split('/')[2];
@@ -41,7 +41,7 @@ export class ArmService {
         });
     }
 
-    get isPublicAzure():boolean {
+    get isPublicAzure(): boolean {
         return this.armUrl === this.publicAzureArmUrl;
     }
 
@@ -54,11 +54,11 @@ export class ArmService {
     }
 
     get isMooncake(): boolean {
-        return this.armUrl ===  this.chinaAzureArmUrl;
+        return this.armUrl === this.chinaAzureArmUrl;
     }
 
     get isUsnat(): boolean {
-        return this.armUrl ===  this.usnatAzureArmUrl;
+        return this.armUrl === this.usnatAzureArmUrl;
     }
 
     get isNationalCloud(): boolean {
@@ -66,24 +66,28 @@ export class ArmService {
     }
 
     get armUrl(): string {
-        if(this.armEndpoint !='' && this.armEndpoint.length > 1 ) {
-            return  this.armEndpoint;
+        if (this.armEndpoint != '' && this.armEndpoint.length > 1) {
+            return this.armEndpoint;
         }
         else {
             let browserUrl = (window.location != window.parent.location) ? document.referrer : document.location.href;
             let armUrl = this.publicAzureArmUrl;
 
-            if (browserUrl.includes("azure.cn")){
+            if (browserUrl.includes("azure.cn")) {
                 armUrl = this.chinaAzureArmUrl;
             }
-            else if(browserUrl.includes("azure.us")){
+            else if (browserUrl.includes("azure.us")) {
                 armUrl = this.usGovernmentAzureArmUrl;
-            } else if(browserUrl.includes("azure.de")) {
+            } else if (browserUrl.includes("azure.de")) {
                 armUrl = this.blackforestAzureArmUrl;
             }
 
             return armUrl;
         }
+    }
+
+    get storageUrl(): string {
+        return this.armUrl.replace("management", "core");
     }
 
     getApiVersion(resourceUri: string, apiVersion?: string): string {
@@ -123,11 +127,11 @@ export class ArmService {
         //If the value is set to other than 1 or if the header is not present at all, requests will go to runtimehost
         additionalHeaders.set('x-ms-diagversion', this.diagRoleVersion);
         // This is just for logs so that we know requests are coming from Portal.
-        if(this.diagRoleVersion === this.routeToLiberation) {
+        if (this.diagRoleVersion === this.routeToLiberation) {
             additionalHeaders.set('x-ms-azureportal', 'true');
         }
         let eventProps = {
-            'resourceId' : resourceUri,
+            'resourceId': resourceUri,
             'targetRuntime': this.diagRoleVersion == this.routeToLiberation ? "Liberation" : "DiagnosticRole"
         };
         this.telemetryService.logEvent("RequestRoutingDetails", eventProps);
@@ -314,15 +318,15 @@ export class ArmService {
                 actualError = JSON.stringify(error.error);
                 if (error.error instanceof ErrorEvent) {
                     loggingError.message = error.error.message;
-                    loggingProps['reason']= "A client-side or network error occured.";
+                    loggingProps['reason'] = "A client-side or network error occured.";
                 }
             }
             else if (error.message) {
-                loggingProps['reason']= "Server side unsuccessful response code.";
+                loggingProps['reason'] = "Server side unsuccessful response code.";
             } else {
                 actualError = 'Server Error';
             }
-            loggingProps['url']= error.url;
+            loggingProps['url'] = error.url;
             loggingProps['status'] = error.status.toString();
             loggingProps['statusText'] = error.statusText;
         }
@@ -331,8 +335,7 @@ export class ArmService {
             loggingError.message = actualError;
         }
 
-        if (this.telemetryService)
-        {
+        if (this.telemetryService) {
             this.telemetryService.logException(loggingError, null, loggingProps);
         }
 
@@ -351,13 +354,13 @@ export class ArmService {
         // When x-ms-diagversion is set to 1, the requests will be sent to DiagnosticRole.
         //If the value is set to other than 1 or if the header is not present at all, requests will go to runtimehost
         additionalHeaders.set('x-ms-diagversion', this.diagRoleVersion);
-         // This is just for logs so that we know requests are coming from Portal.
-         if(this.diagRoleVersion === this.routeToLiberation) {
+        // This is just for logs so that we know requests are coming from Portal.
+        if (this.diagRoleVersion === this.routeToLiberation) {
             additionalHeaders.set('x-ms-azureportal', 'true');
         }
 
         let eventProps = {
-            'resourceId' : resourceId,
+            'resourceId': resourceId,
             'targetRuntime': this.diagRoleVersion == this.routeToLiberation ? "Liberation" : "DiagnosticRole"
         };
         this.telemetryService.logEvent("RequestRoutingDetails", eventProps);
@@ -383,9 +386,9 @@ export class ArmService {
             headers = headers.set('If-None-Match', etag);
         }
 
-        if(additionalHeaders) {
+        if (additionalHeaders) {
             additionalHeaders.forEach((headerVal: string, headerKey: string) => {
-                if(headerVal.length > 0 && headerKey.length > 0) {
+                if (headerVal.length > 0 && headerKey.length > 0) {
                     headers = headers.set(headerKey, headerVal);
                 }
             });

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -143,6 +143,10 @@ export class DaasService {
         settings.BlobContainer = BlobContainerName.toLowerCase();
         settings.BlobKey = blobKey;
         settings.BlobAccount = blobAccount;
+        settings.EndpointSuffix = "";
+        if (this._armClient.isNationalCloud) {
+            settings.EndpointSuffix = this._armClient.storageUrl;
+        }
 
         return <Observable<boolean>>(this._armClient.postResource(resourceUri, settings, null, true));
     }
@@ -152,9 +156,13 @@ export class DaasService {
         return <Observable<DaasSettings>>(this._armClient.getResourceWithoutEnvelope<DaasSettings>(resourceUri, null, true));
     }
 
-    putStdoutSetting(resourceUrl: string, enabled: boolean): Observable<{ Stdout: string } > {
+    putStdoutSetting(resourceUrl: string, enabled: boolean): Observable<{ Stdout: string }> {
         const resourceUri: string = this._uriElementsService.getStdoutSettingUrl(resourceUrl);
-        return <Observable<{ Stdout: string }>>this._armClient.putResourceWithoutEnvelope<{Stdout: string}, any>(resourceUri, {Stdout: enabled ? "Enabled" : "Disabled"});
+        return <Observable<{ Stdout: string }>>this._armClient.putResourceWithoutEnvelope<{ Stdout: string }, any>(resourceUri, { Stdout: enabled ? "Enabled" : "Disabled" });
+    }
+
+    get isNationalCloud(){
+        return this._armClient.isNationalCloud;
     }
 
     private _getHeaders(): HttpHeaders {


### PR DESCRIPTION
With this PR:-
1. Temporarily disabling the forcing of storage account for Memory dumps for National Clouds
2. Adding the relevant information to pass while setting the BlobSasUri when DAAS update is everywhere.
