### PR TITLE
Token refresh mechanism for portal blade

### DIFF
--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -57,7 +57,6 @@
     "highcharts-custom-events": "^2.2.2",
     "ie-shim": "^0.1.0",
     "jquery": "^3.4.1",
-    "jwt-decode": "^2.2.0",
     "moment": "^2.22.1",
     "ng-in-viewport": "^6.1.0",
     "ng-pick-datetime": "^6.0.16",

--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -57,6 +57,7 @@
     "highcharts-custom-events": "^2.2.2",
     "ie-shim": "^0.1.0",
     "jquery": "^3.4.1",
+    "jwt-decode": "^2.2.0",
     "moment": "^2.22.1",
     "ng-in-viewport": "^6.1.0",
     "ng-pick-datetime": "^6.0.16",

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
@@ -55,7 +55,7 @@ export class AuthService {
             try{
                 var token = jwt_decode(this.currentToken);
                 var currentTime = (new Date().getTime())/1000;
-                var refreshInterval = token.exp - currentTime - 60;
+                var refreshInterval = token.exp - currentTime + 5;
                 // Keeping this console log for tracking during debugging purposes
                 console.log("Scheduling token refresh - ", " current time: ", currentTime, " refreshes in: ", refreshInterval);
                 if (refreshInterval <= 0) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
@@ -5,7 +5,6 @@ import { StartupInfo, ResourceType } from '../../shared/models/portal';
 import { PortalService } from './portal.service';
 import { map } from 'rxjs/operators';
 import { environment } from 'projects/app-service-diagnostics/src/environments/environment';
-import * as jwt_decode from "jwt-decode";
 
 @Injectable()
 export class AuthService {

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -19,7 +19,6 @@ export class PortalService {
 
 
     private shellSrc: string;
-    private willRefreshToken: boolean = false;
     private tokenObservable: ReplaySubject<string>;
 
     constructor(private _broadcastService: BroadcastService) {
@@ -65,11 +64,6 @@ export class PortalService {
 
     notifyChatOpened():ReplaySubject<any> {
         return this.notifyChatOpenedObservable;
-    }
-
-    refreshToken(): void {
-        this.willRefreshToken = true;
-        this.postMessage(Verbs.getStartupInfo, null);
     }
 
     initializeIframe(): void {
@@ -145,12 +139,6 @@ export class PortalService {
         console.log('[iFrame] Received mesg: ' + methodName, event);
 
         if (methodName === Verbs.sendStartupInfo) {
-            if (this.willRefreshToken){
-                const info = <StartupInfo>data;
-                this.tokenObservable.next(info.token);
-                this.willRefreshToken = false;
-                return;
-            }
             const info = <StartupInfo>data;
             this.sessionId = info.sessionId;
             this.startupInfoObservable.next(info);
@@ -169,6 +157,9 @@ export class PortalService {
         } else if (methodName == Verbs.notifyChatOpenedResponse) {
             const notifyChatOpenedResponse = data;
             this.notifyChatOpenedObservable.next(notifyChatOpenedResponse);
+        } else if (methodName == Verbs.sendToken) {
+            const token = data;
+            this.tokenObservable.next(token);            
         }
     }
 


### PR DESCRIPTION
Service Health Issue [1333: [Portal] 401 (expired token) exceptions in Portal while talking to ARM](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1333)
We see a lot of 401 (expired token) issues in portal when talking to ARM. It's because of the ARM token being expired and not getting refreshed from ibiza.
This is hampering our customer experience by displaying them nothing when requests are made. ~1,667 distinct users have been impacted due to this issue in last 1 month.

[Failure count trend weekly](https://ms.portal.azure.com/#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fc1972e9d-b3c7-4de4-acb3-681773b28ced%2FresourceGroups%2FDiagnoseAndSolve%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FDiagnoseAndSolvePortal/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA12P3WrDMAyF7wN9B5GrBEbdwmBsbXqzJ1Fs0RhiOUgypWUP37iFdez2Oz%252FSmclAbcBz7j53oT9smnkl9CT7VEGghTgQ%252B0i6aX7gMpEQWEykhmmB01oAyOEPOq4NLytjIvCZDSMrtJPZol%252FOJWQ8UyK2Ld6K0Nbn5LSM6iUuFjOrax%252B9%252F%252FIukJG3LNq%252Bbghpme07B4JhgPfdvkpaUkKJt5oubF0P4xXGyN3vp2%252FwEfpqlTpRHhP8hGLQ3AGWVKvkGgEAAA%253D%253D)
![image](https://user-images.githubusercontent.com/8492235/84563201-a2298980-ad0e-11ea-958b-adfdca512e3a.png)
