### PR TITLE
Show timer picker in detector view after poping it out from downtime triggered analysis

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.html
@@ -1,7 +1,7 @@
-<detector-control *ngIf="!hideDetectorControl && !hideTimerPicker && detectorResponse && !analysisMode"></detector-control>
+<detector-control *ngIf="(!hideDetectorControl && !hideTimerPicker && detectorResponse && !analysisMode) || isPopoutFromAnalysis"></detector-control>
 <div [ngStyle]="{'padding-top': hideTimerPicker? '10px': '0px'}" style="padding-left: 20px; padding-right: 20px"  >
   <detector-view [analysisMode]="analysisMode" [isAnalysisView]="isAnalysisView" [detectorResponse]="detectorResponse" [error]="error" [startTime]="getStartTime" [endTime]="getEndTime"
    [developmentMode]="false" [detector]="detectorName" (downTimeChanged)="onDowntimeChanged($event)" (XAxisSelection)="onXAxisSelection($event)" [hideDetectorHeader]="hideDetectorControl"
-   [isCategoryOverview]="isCategoryOverview">
+   [isCategoryOverview]="isCategoryOverview" [isPopoutFromAnalysis]="isPopoutFromAnalysis">
   </detector-view>
 </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -53,6 +53,16 @@ export class DetectorContainerComponent implements OnInit {
     public detectorControlService: DetectorControlService, private versionService: VersionService) {
   }
 
+  get isPopoutFromAnalysis():boolean {
+    if(!!this._route.parent) {
+      return !!this._route.parent.snapshot.url.find(urlPart=>urlPart.path === 'popout');
+    }
+    else {
+      return false;
+    }
+    
+  }
+
   ngOnInit() {
     this.versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
     //Remove after A/B Test

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="detectorDataLocalCopy">
-  <div *ngIf="!hideDetectorHeader && !analysisMode">
+  <div *ngIf="(!hideDetectorHeader && !analysisMode) || isPopoutFromAnalysis">
     <section class="content-header">
       <h2><span class="span-h1"
           *ngIf="!isSystemInvoker && !insideDetectorList">{{detectorDataLocalCopy.metadata.name}}</span></h2>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -92,6 +92,7 @@ export class DetectorViewComponent implements OnInit {
   @Input() compilationPackage: CompilationProperties;
   @Input() analysisMode: boolean = false;
   @Input() isAnalysisView: boolean = false;
+  @Input() isPopoutFromAnalysis: boolean = false;
   @Input() hideDetectorHeader: boolean = false;
   @Input() isCategoryOverview:boolean = false;
   feedbackButtonLabel: string = 'Send Feedback';


### PR DESCRIPTION
Match the popout view with regular detectors view in AppLens. Show detector author and header info along with time picker.