### PR TITLE
Fix for format issue in error message and timestamp format for logging

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -166,8 +166,8 @@ export class DetectorViewComponent implements OnInit {
       this.detectorDataLocalCopy = data;
       if (data) {
         this.detectorEventProperties = {
-          'StartTime': String(this.startTime),
-          'EndTime': String(this.endTime),
+          'StartTime': this.startTime.toISOString(),
+          'EndTime': this.startTime.toISOString(),
           'DetectorId': data.metadata.id,
           'ParentDetectorId': this.parentDetectorId,
           'Url': window.location.href

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -79,17 +79,17 @@ export class DetectorControlService {
     let returnValue: string = '';
     this.timeRangeDefaulted = false;
     this.timeRangeErrorString = '';
-
+    let timeStringFormat = this.internalClient ? "YYYY-MM-DD hh:mm" : "MM/DD/YY hh:mm"
     if (startTime && endTime) {
       start = moment.utc(startTime);
       if (!start.isValid()) {
-        returnValue = 'Invalid Start date time specified. Expected format: YYYY-MM-DD hh:mm';
+        returnValue = `Invalid Start date time specified. Expected format: ${timeStringFormat}`;
         this.timeRangeErrorString = returnValue;
         return returnValue;
       }
       end = moment.utc(endTime);
       if (!end.isValid()) {
-        returnValue = 'Invalid End date time specified. Expected format: YYYY-MM-DD hh:mm';
+        returnValue = `Invalid End date time specified. Expected format: ${timeStringFormat}`;
         this.timeRangeErrorString = returnValue;
         return returnValue;
       }
@@ -148,7 +148,7 @@ export class DetectorControlService {
       if (startTime) {
         start = moment.utc(startTime);
         if (!start.isValid()) {
-          returnValue = 'Invalid Start date time specified. Expected format: YYYY-MM-DD hh:mm';
+          returnValue = `Invalid Start date time specified. Expected format: ${timeStringFormat}`;
           this.timeRangeErrorString = returnValue;
           return returnValue;
         }


### PR DESCRIPTION
- Fix for error message in time picker in external UI should indicate the input time format should be "MM/DD/YY hh:mm"

- Fix for logging StartTime and EndTime as ISO string so that Kusto query can use it directly.