### PR TITLE
Trigger downtime when first or last point of the graph is selected

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -558,8 +558,8 @@ export class DetectorViewComponent implements OnInit {
 
   onDownTimeChange(selectedDownTime:DownTime, downtimeInteractionSource:string) {
     if( selectedDownTime.downTimeLabel != this.getDefaultDowntimeEntry().downTimeLabel   && 
-         momentNs.duration(selectedDownTime.StartTime.diff(this.startTime)).asMinutes() > 0 &&
-         momentNs.duration(this.endTime.diff(selectedDownTime.EndTime)).asMinutes() > 0
+         momentNs.duration(selectedDownTime.StartTime.diff(this.startTime)).asMinutes() > -1 &&
+         momentNs.duration(this.endTime.diff(selectedDownTime.EndTime)).asMinutes() > -1
     ) {
       if(this.validateDowntimeEntry(selectedDownTime)) {
         this.updateDownTimeErrorMessage('');


### PR DESCRIPTION
Trigger downtime even when first or last point on the graph is selected. The UI behavior was breaking earlier, the dropdown value would change however the observations would not get triggered. This will fix it.