### PR TITLE
Accessibility bug v4: Make aria-expanded to false by default

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/dropdown-v4/dropdown-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dropdown-v4/dropdown-v4.component.html
@@ -11,7 +11,7 @@
     <div class="dropdown-container">
       <div class="dropdown">
         <button class="btn btn-default dropdown-toggle dropdown-button" type="button" id="dropdownMenuId"
-          data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span [innerHtml]="selectedKey"></span>
           <span class="caret"></span>
         </button>


### PR DESCRIPTION
Had fixed this issue for the dropdown component in an earlier PR.
But seems we are using a new component in the new UI code. So here is the same fix for that component too.