### PR TITLE
Add highchart menu button tool and skip focus on insight without content

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -509,6 +509,9 @@ export class HighchartsGraphComponent implements OnInit {
                                 series[i].setVisible(true, false);
                             }
                         }
+                    },
+                    contextButton: {
+                        titleKey: "contextButtonTitle"
                     }
                 },
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
@@ -2,7 +2,7 @@
      If there is a title I will wrap it in a container,
      otherwise I will show it by itself -->
 <ng-template #insightView>
-  <div *ngFor="let insight of insights" class="insight-container" tabindex="0" attr.name="{{insight.title}}"
+  <div *ngFor="let insight of insights" class="insight-container" attr.name="{{insight.title}}"
     attr.aria-label="{{insight.title}}" attr.aria-expanded="{{insight.isExpanded}}" role="button"
     (keyup.enter)="toggleInsightStatus(insight)">
     <div div class="panel insight-panel">
@@ -19,8 +19,8 @@
               <div style="display: table-cell;width:100%">
                 {{insight.title}}
               </div>
-              <div style="display: table-cell" class="pull-right">
-                <span class="fa insight-expand-icon" [class.fa-angle-right]="hasContent(insight) && !insight.isExpanded"
+              <div [hidden]="!hasContent(insight)" style="display: table-cell" class="pull-right">
+                <span tabindex="0" class="fa insight-expand-icon" [class.fa-angle-right]="hasContent(insight) && !insight.isExpanded"
                   [class.fa-angle-down]="hasContent(insight) && insight.isExpanded"></span>
               </div>
             </div>


### PR DESCRIPTION
This PR is to fix these two accessibility bugs:

Bug 7094718: [Supporting Platform - App Service Diagnostics - High CPU Analysis] Tooltip does not define for Hamburger menu control.

Bug 7095620: [Keyboard navigation - App Service Diagnostics - Web job details] Focus moves on non-interactive element via tab key for web job texts.