### PR TITLE
Pass user Ibiza language setting to CXP Chat API

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/cxp-chat-caller.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/cxp-chat-caller.service.ts
@@ -15,7 +15,7 @@ export class CXPChatCallerService {
   public pesId: string = '';
   public readonly cxpChatTagName: string = 'webapps';
   public readonly applensUserAgentForCXPChat: string = 'applensDiagnostics';
-  public readonly supportPlanType: string = 'Basic';
+  public supportPlanType: string = '';
   public chatLanguage: string = 'en';
 
   public trackingId:string = '';
@@ -32,10 +32,21 @@ export class CXPChatCallerService {
 
     this._authService.getStartupInfo()
       .subscribe(startupInfo => {
-        if (!!startupInfo && !!startupInfo.optionalParameters) {
-          var caseSubjectParam = startupInfo.optionalParameters.find(param => param.key === "caseSubject");
-          if (caseSubjectParam) {
-            this.caseSubject = caseSubjectParam.value;
+        if (!!startupInfo) {
+          if(!!startupInfo.effectiveLocale && startupInfo.effectiveLocale.length > 0) {
+            this.chatLanguage = startupInfo.effectiveLocale;
+          }
+
+          if(!!startupInfo.optionalParameters) {
+            var caseSubjectParam = startupInfo.optionalParameters.find(param => param.key === "caseSubject");
+            if (!!caseSubjectParam) {
+              this.caseSubject = caseSubjectParam.value;
+            }
+
+            var cxSupportPlanType = startupInfo.optionalParameters.find(param => param.key === "supportPlans");
+            if(!!cxSupportPlanType) {
+              this.supportPlanType = cxSupportPlanType.value.supportPlanType;
+            }
           }
         }
       });
@@ -205,7 +216,8 @@ export class CXPChatCallerService {
         subscriptionId: this._resourceService.subscriptionId,
         productId: this.pesId,
         supportTopicId: supportTopicId,
-        title: this.caseSubject
+        title: this.caseSubject,
+        resourceId: this._resourceService.resource.id
       }
     };
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
@@ -19,6 +19,7 @@ export interface StartupInfo {
     resourceType?: ResourceType;
     additionalParameters?: any;
     optionalParameters?: Array<KeyValuePair>;
+    effectiveLocale: string;
 }
 
 export enum ResourceType {


### PR DESCRIPTION
Update DiagnoseAndSolve to take users language settings from Ibiza and pass it to the CXP chat API. Also pass the resourceId along with ticket creation params to auto inject HealthSupportPlan in case the resource is found unhealthy. This was discussed with Nitin over IM.