### PR TITLE
Fix for bug 7095672 and 7096151

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-memory-rule/autohealing-memory-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-memory-rule/autohealing-memory-rule.component.html
@@ -14,18 +14,18 @@
 <table class="table table-bordered" *ngIf="!editMode && rule > 0">
   <thead>
     <tr>
-      <th scope="col">
+      <th tabindex="0">
         Private Bytes
       </th>
-      <th scope="col">
+      <th tabindex="0">
         Action
       </th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>{{ formatBytes(rule * 1024) }}</td>
-      <td>
+      <td tabindex="0">{{ formatBytes(rule * 1024) }}</td>
+      <td tabindex="0">
         <button class="image-btn" *ngIf="!editMode" (click)="editRule()" title="Edit rule" name="editRule">
           <i class="fa fa-edit"></i>
         </button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
@@ -14,22 +14,22 @@
 <table class="table table-bordered" *ngIf="!editMode && rule != null">
   <thead>
     <tr>
-      <th scope="col">
+      <th tabindex="0">
         Request Count
       </th>
-      <th scope="col">
+      <th tabindex="0">
         Duration
       </th>
-      <th scope="col">
+      <th tabindex="0">
         Action
       </th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>{{ rule.count }}</td>
-      <td>{{ rule.timeInterval }}</td>
-      <td>
+      <td tabindex="0">{{ rule.count }}</td>
+      <td tabindex="0">{{ rule.timeInterval }}</td>
+      <td tabindex="0">
         <button class="image-btn" *ngIf="!editMode" (click)="editRule()" title="Edit rule" name="editRule">
           <i class="fa fa-edit"></i>
         </button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -16,18 +16,18 @@
 <table class="table table-bordered" *ngIf="!editMode && rule != null">
   <thead>
     <tr>
-      <th scope="col">Request Count</th>
-      <th scope="col">Time Taken</th>
-      <th scope="col">Duration</th>
-      <th scope="col">Action</th>
+      <th tabindex="0">Request Count</th>
+      <th tabindex="0">Time Taken</th>
+      <th tabindex="0">Duration</th>
+      <th tabindex="0">Action</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td scope="row">{{ rule.count }}</td>
-      <td>{{ rule.timeTaken }}</td>
-      <td>{{ rule.timeInterval }}</td>
-      <td>
+      <td tabindex="0" scope="row">{{ rule.count }}</td>
+      <td tabindex="0">{{ rule.timeTaken }}</td>
+      <td tabindex="0">{{ rule.timeInterval }}</td>
+      <td tabindex="0">
         <button role="button" class="image-btn" *ngIf="!editMode" (click)="editRule()" title="Edit rule" name="editRule">
           <i class="fa fa-edit"></i>
         </button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
@@ -16,34 +16,34 @@
   <table class="table table-bordered" *ngIf="rule!==null && rule.length > 0" style="margin-top:20px">
     <thead>
       <tr>
-        <th>
+        <th tabindex="0">
           Count
         </th>
-        <th>
+        <th tabindex="0">
           Status Code
         </th>
-        <th>
+        <th tabindex="0">
           Sub-Status
         </th>
-        <th>
+        <th tabindex="0">
           Win32-Status
         </th>
-        <th>
+        <th tabindex="0">
           Interval
         </th>
-        <th>
+        <th tabindex="0">
           Action
         </th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let singleRule of rule; let i = index">
-        <td>{{ singleRule.count }}</td>
-        <td>{{ singleRule.status }}</td>
-        <td>{{ singleRule.subStatus }}</td>
-        <td>{{ singleRule.win32Status }}</td>
-        <td>{{ singleRule.timeInterval }}</td>
-        <td>
+        <td tabindex="0">{{ singleRule.count }}</td>
+        <td tabindex="0">{{ singleRule.status }}</td>
+        <td tabindex="0">{{ singleRule.subStatus }}</td>
+        <td tabindex="0">{{ singleRule.win32Status }}</td>
+        <td tabindex="0">{{ singleRule.timeInterval }}</td>
+        <td tabindex="0">
           <button class="image-btn" *ngIf="!editMode" (click)="editStatusCodeRule(i)" title="Edit rule" name="editRule">
             <i class="fa fa-edit"></i>
           </button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="validationResult.Validated">
     <div class="action-box" *ngIf="siteToBeDiagnosed">
         <div>
-            <table class="table table-borderless">
+            <table role="presentation" class="table table-borderless">
                 <tr>
                     <th tabindex="0" class="unbold" scope="row">App: </th>
                     <td tabindex="0" class="highlight-blue">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="action-box" *ngIf="siteToBeDiagnosed && !checkingAppInfo">
         <div>
-            <table style="border:none;">
+            <table role="presentation" class="table table-borderless">
                 <tr>
                     <th tabindex="0" class="unbold" scope="row">App: </th>
                     <td tabindex="0" class="highlight-blue">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-trace-tool/network-trace-tool.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-trace-tool/network-trace-tool.component.html
@@ -60,7 +60,7 @@
 
         <div style="margin-top:20px;">
             Choose duration to collect the Network Trace
-            <select [attr.aria-label]="'select duration'" (click)="durationClicked()" [(ngModel)]="duration"
+            <select [attr.aria-label]="'select duration'" [(ngModel)]="duration"
                 [disabled]="status >= NetworkTraceStatus.Starting">
                 <option value="60">60 seconds</option>
                 <option value="120">2 minutes</option>


### PR DESCRIPTION
Fix for the following accessiblity bugs as I noticed that one got reopened.

- [Bug 7095672](https://msazure.visualstudio.com/Antares/_workitems/edit/7095672): [Screen Reader - App Service Diagnostics - Collect .Net Profile Trace] Screen reader is reading some unnecessary table information when focus moves to controls under “Collect a Profiler Trace” heading on “Collect .Net Profile Trace” page.
- [Bug 7096151](https://msazure.visualstudio.com/Antares/_workitems/edit/7096151): [Screen readers - App Service Diagnostics - Diagnostic Tools - Custom Auto-Heal Rules] The data in the table cells are not associated with the column headers.

The only way I was able to get screen reader to associate table cell with header was by adding tabindex=0. This seems easiest approach vs. moving to any new library for now.

Also fixing 
- [User Story 1342](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1342): [Portal Client exception] i.durationClicked is not a function at Object.handleEvent