### PR TITLE
Luminosity ratio for text inside insight

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/connection-diagnoser-tool/connection-diagnoser-tool.component.html
@@ -85,7 +85,7 @@
                                     Status
                                 </th>
                                 <td tabindex="0">
-                                    <div *ngIf="connection.Succeeded" style="color:rgb(19, 140, 57)">
+                                    <div *ngIf="connection.Succeeded" style="color:#137c39">
                                         <strong>We could connect successfully to this connection.</strong>
                                     </div>
                                     <div *ngIf="!connection.Succeeded">


### PR DESCRIPTION
A bug was reactivated. I had resolved it for the insight title but missed the internal text inside insight.
![image](https://user-images.githubusercontent.com/8492235/85429296-63c47380-b533-11ea-9d4d-9314df042f91.png)


Old ratio: 4.17:1
Minimum Required: 4.5:1
New ratio: 5.08:1
[Bug 7096293](https://msazure.visualstudio.com/Antares/_workitems/edit/7096293): [Visual Requirements - App Service Diagnostics - Diagnostic Tools - Check connection strings] Luminosity ratio of the highlighted text is less than the minimum required value of 4.5:1.