### PR TITLE
Fixing luminosity ratio for the Slider bar

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.scss
@@ -1,62 +1,71 @@
 .label-header {
     font-size: initial;
-    color:#0058ad;
+    color: #0058ad;
 }
 
 .input-row {
     min-height: 120px;
 }
 
-.tile-icon{
+.tile-icon {
     font-size: xx-large;
-    color:#0058ad;
+    color: #0058ad;
     min-width: 30px;
 }
 
-.summary-box { 
+.summary-box {
     padding: 10px;
     margin-left: 15px;
     background-color: rgba(44, 163, 216, 0.1);
-    border:1px Solid #0058ad;
+    border: 1px Solid #0058ad;
 }
 
-.summary-title{
+.summary-title {
     margin-left: 15px;
     background: #0058ad;
     width: 125px;
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
     padding: 2px;
-    padding-left:5px;
-    color:whitesmoke;
+    padding-left: 5px;
+    color: whitesmoke;
 }
 
-.media-body{
-    padding-left:13px;
+.media-body {
+    padding-left: 13px;
 }
 
-.readonly-mode
-{
+.readonly-mode {
     font-size: large;
     color: #0058ad;
     margin-top: 10px;
 }
 
 ::ng-deep {
-    .custom-slider .ng5-slider .ng5-slider-pointer:after {
-        width: 4px;
-        height: 4px;
-        top: 6px;
-        left: 6px;
-        border-radius: 4px;
+    .custom-slider .ng5-slider {
+        .ng5-slider-pointer:after {
+            width: 4px;
+            height: 4px;
+            top: 7px;
+            left: 7px;
+            border-radius: 4px;
         }
-            
-    .custom-slider .ng5-slider .ng5-slider-pointer {
-        width: 16px;
-        height: 16px;
-        top: -6px;
-        border-radius: 13px;
-        margin-left: 4px;
-        background-color: #0058ad;
+
+        .ng5-slider-pointer {
+            width: 19px;
+            height: 19px;
+            top: -8px;
+            border-radius: 14px;
+            margin-left: 4px;
+            background-color: #0058ad;
+        }
+
+        .ng5-slider-tick {
+            background: #0058ad;
+        }
+
+        .ng5-slider-bar {
+            background: #0058ad;
+        }
     }
 }


### PR DESCRIPTION
[7095541 ](https://msazure.visualstudio.com/Antares/_workitems/edit/7095541)| [Visual Requirements - App   Service Diagnostics - Proactive CPU Monitoring] Luminosity ratio is less than   3:1 for slider control on “Proactive CPU Monitoring” page.
-- | --

This is how it looks now.

![image](https://user-images.githubusercontent.com/5299838/86271044-dbf10000-bbe9-11ea-8500-e68018b67250.png)

