### PR TITLE
Screen Reader to announce Collapse \ Expand on collapsible list

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.html
@@ -1,10 +1,8 @@
 <div *ngIf="title" class="row collapsable-list">
-
-    <div role="button" attr.aria-label="Collapsible button for {{ title }}" attr.aria-labelledby="{{ title }} {{ collapsed ?'collapsed':'expanded' }} " (click)="collapsed = !collapsed" class="list-header">
-        <i tabindex="0" (keypress)="collapsed = !collapsed" class="collapse-icon fa" [class.fa-plus]="collapsed"
-            [class.fa-minus]="!collapsed"></i>
+    <button [attr.aria-expanded]="collapsed ?'false':'true'" (click)="collapsed = !collapsed" class="list-header">
+        <i class="collapse-icon fa" [class.fa-plus]="collapsed" [class.fa-minus]="!collapsed"></i>
         <span class="pl-3">{{title}}</span>
-    </div>
+    </button>
 
     <div *ngIf="!collapsed" class="list-items-container">
         <ng-content></ng-content>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.scss
@@ -8,7 +8,7 @@
     border-bottom:1px solid #eef;
     cursor:pointer;
 
-    -webkit-user-select: none; /* Chrome/Safari */        
+    -webkit-user-select: none; /* Chrome/Safari */
     -moz-user-select: none; /* Firefox */
     -ms-user-select: none; /* IE10+ */
     -o-user-select: none;
@@ -38,3 +38,15 @@
 .list-item.disabled:hover{
     text-decoration: none;
 }
+
+button {
+    all: inherit;
+    border: 0;
+    width: 100%;
+  }
+
+button:focus {
+    outline-color: #00bcf2;
+    outline-width: 1px;
+    outline-style: dashed;
+  }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -46,7 +46,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
         }, error => {
             //TODO: handle error
         });
-       this.enableSessionsPanel = this._route.snapshot.params['category'] != null || this._route.parent.snapshot.params['category']!= null;      
+        this.enableSessionsPanel = this._route.snapshot.params['category'] != null || this._route.parent.snapshot.params['category'] != null;
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -77,11 +77,13 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     checkSessions() {
         this._daasService.getDaasSessionsWithDetails(this.siteToBeDiagnosed).pipe(retry(2))
             .subscribe(sessions => {
-                const newSessions = sessions.map(this.reducedSession);
-                const existingSessions = this.sessions.map(this.reducedSession);
-                let anySessionUpdated = newSessions.filter(newSession => existingSessions.findIndex(session => JSON.stringify(session) === JSON.stringify(newSession)) === -1).length > 0;
-                if (newSessions.length !== existingSessions.length || anySessionUpdated) {
-                    this.sessions = this.setExpanded(sessions);
+                if (sessions != null) {
+                    const newSessions = sessions.map(this.reducedSession);
+                    const existingSessions = this.sessions.map(this.reducedSession);
+                    let anySessionUpdated = newSessions.filter(newSession => existingSessions.findIndex(session => JSON.stringify(session) === JSON.stringify(newSession)) === -1).length > 0;
+                    if (newSessions.length !== existingSessions.length || anySessionUpdated) {
+                        this.sessions = this.setExpanded(sessions);
+                    }
                 }
             });
     }
@@ -207,7 +209,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     }
 
     toggleSessionPanel() {
-        this.globals.openSessionPanel=!this.globals.openSessionPanel;
+        this.globals.openSessionPanel = !this.globals.openSessionPanel;
         this.telemetryService.logEvent("OpenSesssionsPanel");
         this.telemetryService.logPageView("SessionsPanelView");
     }


### PR DESCRIPTION
- Fixing the below bug


[7095516 ](https://msazure.visualstudio.com/Antares/_workitems/edit/7095516)| [Screen Reader - App Service   Diagnostics - Proactive CPU Monitoring] Name/Role property is not defined for   “Expand/Collapse” button present on “Proactive CPU Monitoring” page.
-- | --


- Also fixing the below error in Diagnostic Tools

`Cannot read property 'map' of undefined at t._next`