### PR TITLE
Improve DAAS Validation Checks and fixing duplicate insights in Analysis

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -137,12 +137,6 @@
               <strong>Current Settings</strong>
               <autohealing-config-summary [autohealSettings]="originalSettings">
               </autohealing-config-summary>
-              <div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word"
-                *ngIf="storageAccountLengthExceeding">
-                Due to a limitation in Autohealing module, the length of the chosen storage account should be less than
-                13 characters. Please choose a different storage account or reduce the account length. This limitation
-                will be removed in the upcoming versions of Azure App Service.
-              </div>
             </div>
             <div class="summary" *ngIf="currentSettings && saveEnabled" style="margin-top:25px">
               <strong>New Settings</strong>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -39,7 +39,6 @@ export class AutohealingComponent implements OnInit {
   detectorHasData: boolean = false;
   validationWarning: string[];
   selectedTab: string = 'autoHealing';
-  storageAccountLengthExceeding: boolean = false;
 
   constructor(private _siteService: SiteService, private _autohealingService: AutohealingService, private _logger: AvailabilityLoggingService, protected _route: ActivatedRoute) {
   }
@@ -67,38 +66,6 @@ export class AutohealingComponent implements OnInit {
     this.originalAutoHealSettings = JSON.parse(this.originalSettings);
     this.updateConditionsAndActions();
     this.updateSummaryText();
-    this.checkStorageLength(this.originalAutoHealSettings);
-  }
-
-  checkStorageLength(autoHealSettings: AutoHealSettings) {
-    if (autoHealSettings.autoHealEnabled &&
-      autoHealSettings.autoHealRules != null &&
-      autoHealSettings.autoHealRules.actions != null &&
-      autoHealSettings.autoHealRules.actions.actionType === AutoHealActionType.CustomAction &&
-      autoHealSettings.autoHealRules.actions.customAction != null &&
-      autoHealSettings.autoHealRules.actions.customAction.parameters != null) {
-      let storageAccountName = this.getStorageAccountNameFromActionParams(autoHealSettings.autoHealRules.actions.customAction.parameters);
-      if (storageAccountName.length > 12) {
-        this.storageAccountLengthExceeding = true;
-      } else {
-        this.storageAccountLengthExceeding = false;
-      }
-
-    }
-  }
-
-  getStorageAccountNameFromActionParams(customActionParams: string): string {
-    let storageAccountName = "";
-    let searchString = "blobsasuri:\"https://";
-    let startIndex = customActionParams.toLowerCase().indexOf(searchString);
-    if (startIndex > 0) {
-      startIndex = startIndex + searchString.length;
-      let endIndex = customActionParams.indexOf(".", startIndex);
-      if (endIndex > 0) {
-        storageAccountName = customActionParams.substring(startIndex, endIndex);
-      }
-    }
-    return storageAccountName;
   }
 
   updateConditionsAndActions() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
@@ -29,8 +29,7 @@
       </div>
 
       <div *ngIf="chosenOption.option === 'ChooseExisting'">
-        <select class="mt-2 fixed-width" id="storageAccountsList" [ngModel]="chosenStorageAccount"
-          (ngModelChange)="onStorageAccountChange($event)">
+        <select class="mt-2 fixed-width" id="storageAccountsList" [(ngModel)]="chosenStorageAccount">
           <optgroup *ngFor="let location of getLocations()" [label]="location">
             <option *ngFor="let account of getStorageAccountsForLocation(location)" [ngValue]="account"
               [selected]="account === chosenStorageAccount">{{account.name}}
@@ -39,14 +38,8 @@
         </select>
       </div>
 
-      <div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word"
-        *ngIf="storageAccountLengthExceeding">
-        Due to a limitation in Autohealing module, the length of the chosen storage account should be less than 13
-        characters. Please choose a different storage account or reduce the account length. This limitation will be 
-        removed in the upcoming versions of Azure App Service.
-      </div>
       <button type="button" class="btn btn-primary mt-3 mb-2"
-        [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount || storageAccountLengthExceeding"
+        [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount"
         (click)="saveChanges()">Save</button>
       <button type="button" class="btn btn-primary mt-3 mb-2"
         [disabled]="!saveEnabled || generatingSasUri || creatingStorageAccount || !editMode"

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -35,7 +35,6 @@ export class ConfigureStorageAccountComponent implements OnInit {
   editMode: boolean = false;
   validationResult: DaasValidationResult = new DaasValidationResult();
   error: any;
-  storageAccountLengthExceeding: boolean = false;
 
   ngOnInit() {
     this._storageService.getStorageAccounts(this.siteToBeDiagnosed.subscriptionId).subscribe(resp => {
@@ -74,8 +73,6 @@ export class ConfigureStorageAccountComponent implements OnInit {
 
   chooseOption(option: any) {
     this.chosenOption = option;
-    let accountName: string = this.chosenOption.option === 'CreateNew' ? this.newStorageAccountName : this.chosenStorageAccount.name;
-    this.checkAccountLength(accountName)
   }
 
   updateStorageAccount(storageAccount: string) {
@@ -85,7 +82,6 @@ export class ConfigureStorageAccountComponent implements OnInit {
     } else {
       this.saveEnabled = true;
     }
-    this.checkAccountLength(this.newStorageAccountName);
   }
 
   saveChanges() {
@@ -182,19 +178,6 @@ export class ConfigureStorageAccountComponent implements OnInit {
     this.editMode = false;
     this.validationResult.Validated = true;
     this.StorageAccountValidated.emit(this.validationResult);
-  }
-
-  onStorageAccountChange(selectedStorageAccount: StorageAccount) {
-    this.chosenStorageAccount = selectedStorageAccount;
-    this.checkAccountLength(this.chosenStorageAccount.name);
-  }
-
-  checkAccountLength(storageAccountName: string) {
-    if (storageAccountName.length > 12) {
-      this.storageAccountLengthExceeding = true;
-    } else {
-      this.storageAccountLengthExceeding = false;
-    }
   }
 
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.html
@@ -18,26 +18,46 @@
   </div>
 </div>
 
-<div *ngIf="!checkingSupportedTier && (supportedTier || !checkingSkuSucceeded) && !alwaysOnEnabled">
-  <div class="focus-box focus-box-warning">
-    <div>
+<div *ngIf="!checkingSupportedTier && (supportedTier || !checkingSkuSucceeded)">
+
+  <div *ngIf="!alwaysOnEnabled">
+    <div class="focus-box focus-box-warning">
       <strong>Error</strong> - We determined that the web app does not have Always-On enabled and due to these the
       diagnostic
       tools will not work reliably with AutoHeal. Please turn on the Always-On setting by going to the Application
       Settings
       for the web app and then run these tools.
     </div>
+
+  </div>
+  <div *ngIf="daasAppSettingsCheck != null && daasAppSettingsCheck.DaasDisabled">
+    <div class="focus-box focus-box-warning">
+      <strong>Error</strong> - We determined that Diagnostics As a Service is disabled for this app. Please remove the
+      app setting <code>WEBSITE_DAAS_DISABLED</code> and run this tool again.
+    </div>
+  </div>
+  <div *ngIf="daasAppSettingsCheck != null && daasAppSettingsCheck.LocalCacheEnabled">
+    <div class="focus-box focus-box-warning">
+      <strong>Error</strong> - We determined that the app has Local Cache feature enabled and due to that the
+      diagnostic
+      tools will not work. Please disable Local Cache by removing the app setting
+      <code>WEBSITE_LOCAL_CACHE_OPTION</code> and then run these tools.
+    </div>
+  </div>
+  <div *ngIf="daasAppSettingsCheck != null && daasAppSettingsCheck.WebjobsStopped">
+    <div class="focus-box focus-box-warning">
+      <strong>Error</strong> - We determined that the app has the app setting <code>WEBJOBS_STOPPED </code> exists on
+      the app so the DaaS webjob cannot run. Please remove this app setting and run this tool again.
+    </div>
   </div>
 </div>
 
 <div *ngIf="!daasRunnerJobRunning" class="focus-box focus-box-warning" style="margin-top:20px">
-  <div>
-    <strong>Error</strong> - We found that the DAAS Web job is in a stopped state. Please go to WebJobs under this Web
-    App and start
-    the DAAS Web job manually and re-run this tool. If this is the first time you are running these tools, try hitting
-    the refresh button
-    after a few minutes
-  </div>
+  <strong>Error</strong> - We found that the DAAS Web job is in a stopped state. Please go to WebJobs under this Web
+  App and start
+  the DAAS Web job manually and re-run this tool. If this is the first time you are running these tools, try hitting
+  the refresh button
+  after a few minutes
 </div>
 
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -96,8 +96,8 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     showWebSearchTimeout: any = null;
     searchDiagnosticData: DiagnosticData;
     readonly stringFormat: string = 'YYYY-MM-DDTHH:mm';
-    public inDrillDownMode:boolean = false;
-    drillDownDetectorId:string = '';
+    public inDrillDownMode: boolean = false;
+    drillDownDetectorId: string = '';
 
     constructor(public _activatedRoute: ActivatedRoute, private _router: Router,
         private _diagnosticService: DiagnosticService, private _detectorControl: DetectorControlService,
@@ -118,16 +118,16 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     @Input()
     detectorParmName: string;
 
-    public _downTime:DownTime = null;
+    public _downTime: DownTime = null;
     @Input()
     set downTime(downTime: DownTime) {
-      if (!!downTime && !!downTime.StartTime && !!downTime.EndTime) {
-          this._downTime = downTime;
-          this.refresh();
-      }
-      else {
-          this._downTime = null;
-      }
+        if (!!downTime && !!downTime.StartTime && !!downTime.EndTime) {
+            this._downTime = downTime;
+            this.refresh();
+        }
+        else {
+            this._downTime = null;
+        }
     }
 
     withinDiagnoseAndSolve: boolean = !this._detectorControl.internalClient;
@@ -238,24 +238,24 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
     }
 
-    analysisContainsDowntime() : Observable<boolean> {
-        if(this.analysisId === 'searchResultsAnalysis') {
+    analysisContainsDowntime(): Observable<boolean> {
+        if (this.analysisId === 'searchResultsAnalysis') {
             return of(false);
         }
         return this._diagnosticService.getDetector(this.analysisId, this._detectorControl.startTimeString, this._detectorControl.endTimeString).pipe(
             map((response: DetectorResponse) => {
                 let downTimeRenderingType = response.dataset.find(set => (<Rendering>set.renderingProperties).type === RenderingType.DownTime);
-                if(!!downTimeRenderingType) {
+                if (!!downTimeRenderingType) {
                     return true;
                 }
                 else {
                     return false;
                 }
             }),
-            catchError(e=>{return of(false)})
+            catchError(e => { return of(false) })
         );
     }
-  
+
     refresh() {
         if (this.withinGenie) {
             this.detectorId = "";
@@ -264,31 +264,31 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
         else {
             this._activatedRoute.paramMap.subscribe(params => {
-                this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId'))? params.get('analysisId') : this.analysisId;
+                this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId')) ? params.get('analysisId') : this.analysisId;
                 this.detectorId = params.get(this.detectorParmName) === null ? "" : params.get(this.detectorParmName);
                 if (this.analysisId != 'searchResultsAnalysis') this.goBackToAnalysis();
                 this.populateSupportTopicDocument();
                 this.analysisContainsDowntime().subscribe(containsDownTime => {
-                    if( (containsDownTime && !!this._downTime ) || !containsDownTime ) {
+                    if ((containsDownTime && !!this._downTime) || !containsDownTime) {
                         let currDowntime = this._downTime;
                         this.resetGlobals();
                         if (this.analysisId === "searchResultsAnalysis") {
                             this._activatedRoute.queryParamMap.subscribe(qParams => {
                                 this.resetGlobals();
-                                this.searchTerm = qParams.get('searchTerm') === null ? this.searchTerm : qParams.get('searchTerm');this.showAppInsightsSection = false;
+                                this.searchTerm = qParams.get('searchTerm') === null ? this.searchTerm : qParams.get('searchTerm'); this.showAppInsightsSection = false;
                                 if (this.searchTerm && this.searchTerm.length > 1) {
                                     this.isDynamicAnalysis = true;
-                                    if(this.detectorId) {
+                                    if (this.detectorId) {
                                         this.updateDrillDownMode(true, null);
                                         this._diagnosticService.getDetectors().subscribe(detectorList => {
                                             if (detectorList) {
                                                 if (this.detectorId !== "") {
-                                                let currentDetector = detectorList.find(detector => detector.id == this.detectorId)
-                                                this.detectorName = currentDetector.name;
+                                                    let currentDetector = detectorList.find(detector => detector.id == this.detectorId)
+                                                    this.detectorName = currentDetector.name;
                                                 }
                                             }
                                         });
-                                    }                                    
+                                    }
                                     this.showSuccessfulChecks = false;
                                     this.renderInsightsFromSearch(currDowntime);
                                 }
@@ -359,9 +359,9 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 searchMode: this.searchMode,
                 searchId: this.searchId,
                 query: this.searchTerm, results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({
-                        id: det.id,
-                        score: det.score
-                    }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
+                    id: det.id,
+                    score: det.score
+                }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
             });
             var detectorList = results[1];
             if (detectorList) {
@@ -384,13 +384,13 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 this.analysisContainsDowntime().subscribe(containsDownTime => {
                     this.startDetectorRendering(detectorList, downTime, containsDownTime);
                 });
-                
+
             }
         },
-        (err) => {
+            (err) => {
                 this.showPreLoader = false;
                 this.showPreLoadingError = true;
-        });
+            });
     }
 
     checkSearchEmbedded(response: DetectorResponse) {
@@ -407,7 +407,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         });
     }
 
-    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime:boolean) {
+    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime: boolean) {
         if (this.showWebSearchTimeout) {
             clearTimeout(this.showWebSearchTimeout);
         }
@@ -430,16 +430,21 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                         if (this.detectorViewModels[index].status === HealthStatus.Critical || this.detectorViewModels[index].status === HealthStatus.Warning) {
                             let insight = this.getDetectorInsight(this.detectorViewModels[index]);
                             let issueDetectedViewModel = { model: this.detectorViewModels[index], insightTitle: insight.title, insightDescription: insight.description };
+
+                            if (this.issueDetectedViewModels.length > 0) {
+                                this.issueDetectedViewModels = this.issueDetectedViewModels.filter(iVM => (!!iVM.model && !!iVM.model.metadata && !!iVM.model.metadata.id && iVM.model.metadata.id != issueDetectedViewModel.model.metadata.id));
+                            }
+
                             this.issueDetectedViewModels.push(issueDetectedViewModel);
                             this.issueDetectedViewModels = this.issueDetectedViewModels.sort((n1, n2) => n1.model.status - n2.model.status);
                         } else {
                             let insight = this.getDetectorInsight(this.detectorViewModels[index]);
                             let successViewModel = { model: this.detectorViewModels[index], insightTitle: insight.title, insightDescription: insight.description };
 
-                            if(this.successfulViewModels.length > 0) {
-                                this.successfulViewModels  = this.successfulViewModels.filter(sVM=> (!!sVM.model && !!sVM.model.metadata && !!sVM.model.metadata.id && sVM.model.metadata.id != successViewModel.model.metadata.id));
+                            if (this.successfulViewModels.length > 0) {
+                                this.successfulViewModels = this.successfulViewModels.filter(sVM => (!!sVM.model && !!sVM.model.metadata && !!sVM.model.metadata.id && sVM.model.metadata.id != successViewModel.model.metadata.id));
                             }
-                            
+
                             this.successfulViewModels.push(successViewModel);
                         }
                     }
@@ -577,14 +582,14 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         return viewModel;
     }
 
-    private getDetectorViewModel(detector: DetectorMetaData, downtime: DownTime, containsDownTime:boolean) {
-      let startTimeString = this._detectorControl.startTimeString;
-      let endTimeString = this._detectorControl.endTimeString;
+    private getDetectorViewModel(detector: DetectorMetaData, downtime: DownTime, containsDownTime: boolean) {
+        let startTimeString = this._detectorControl.startTimeString;
+        let endTimeString = this._detectorControl.endTimeString;
 
-      if (containsDownTime && !!downtime && !!downtime.StartTime && !!downtime.EndTime) {
-        startTimeString = downtime.StartTime.format(this.stringFormat);
-        endTimeString = downtime.EndTime.format(this.stringFormat);
-      }
+        if (containsDownTime && !!downtime && !!downtime.StartTime && !!downtime.EndTime) {
+            startTimeString = downtime.StartTime.format(this.stringFormat);
+            endTimeString = downtime.EndTime.format(this.stringFormat);
+        }
 
         return {
             title: detector.name,
@@ -627,34 +632,34 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
 
     }
 
-    public navigateToDetector():void {
-        if(!this.isPublic) {
-           if(!!this.drillDownDetectorId && this.drillDownDetectorId.length > 0 ) {
-            this._router.navigate([`./popout/${this.drillDownDetectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });            
-           }
+    public navigateToDetector(): void {
+        if (!this.isPublic) {
+            if (!!this.drillDownDetectorId && this.drillDownDetectorId.length > 0) {
+                this._router.navigate([`./popout/${this.drillDownDetectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
+            }
         }
     }
 
-    public goBackToAnalysis():void {
+    public goBackToAnalysis(): void {
         this.updateDrillDownMode(false, null);
-        if (this.analysisId=== "searchResultsAnalysis" && this.searchTerm){
-          this._router.navigate([`../../../../${this.analysisId}/search`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: {searchTerm: this.searchTerm} });
+        if (this.analysisId === "searchResultsAnalysis" && this.searchTerm) {
+            this._router.navigate([`../../../../${this.analysisId}/search`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm } });
         }
-        else{
-            if(!!this.analysisId && this.analysisId.length>0) {
+        else {
+            if (!!this.analysisId && this.analysisId.length > 0) {
                 this._router.navigate([`../${this.analysisId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
-            }          
+            }
         }
-      }
+    }
 
-    private updateDrillDownMode(inDrillDownMode:boolean, viewModel:any):void {
+    private updateDrillDownMode(inDrillDownMode: boolean, viewModel: any): void {
         this.inDrillDownMode = inDrillDownMode;
-        if(!this.inDrillDownMode) {
+        if (!this.inDrillDownMode) {
             this.detectorName = '';
             this.drillDownDetectorId = '';
         }
         else {
-            if(!!viewModel && !!viewModel.model && !!viewModel.model.metadata && !!viewModel.model.metadata.name) {
+            if (!!viewModel && !!viewModel.model && !!viewModel.model.metadata && !!viewModel.model.metadata.name) {
                 this.detectorName = viewModel.model.metadata.name;
                 this.drillDownDetectorId = viewModel.model.metadata.id;
             }
@@ -691,7 +696,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     //If in homepage then open second blade for Diagnostic Tool and second blade will continue to open third blade for
                     if (this.withinGenie) {
                         const isHomepage = !this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.snapshot.params["category"];
-                        if(detectorId == 'appchanges' && !this._detectorControl.internalClient) {
+                        if (detectorId == 'appchanges' && !this._detectorControl.internalClient) {
                             this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
                             return;
                         }
@@ -711,18 +716,18 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     }
                 }
                 else {
-                    if(detectorId === 'appchanges' && !this._detectorControl.internalClient) {
+                    if (detectorId === 'appchanges' && !this._detectorControl.internalClient) {
                         this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
                     } else {
                         this.updateDrillDownMode(true, viewModel);
                         if (viewModel.model.startTime != null && viewModel.model.endTime != null) {
                             this.analysisContainsDowntime().subscribe(containsDowntime => {
-                                if(containsDowntime) {
+                                if (containsDowntime) {
                                     this._router.navigate([`./detectors/${detectorId}`], {
                                         relativeTo: this._activatedRoute,
                                         queryParams: { startTimeChildDetector: viewModel.model.startTime, endTimeChildDetector: viewModel.model.endTime },
                                         queryParamsHandling: 'merge',
-                                        replaceUrl:true
+                                        replaceUrl: true
                                     });
                                 }
                                 else {
@@ -730,7 +735,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                         relativeTo: this._activatedRoute,
                                         queryParams: { startTime: viewModel.model.startTime, endTime: viewModel.model.endTime },
                                         queryParamsHandling: '',
-                                        replaceUrl:true
+                                        replaceUrl: true
                                     });
                                 }
                             });


### PR DESCRIPTION
With this PR:-

- Removing check for StorageAccount name length because the backend fix is in PROD
- Improving check for DAAS validator to check for LocalCache, WEBSITE_WEBJOBS_STOPPED, and WEBSITE_DAAS_DISABLED
- Fixing the Issue of Duplicate Insights in Analysis Component

The fix for duplicate insights is more of a workaround, the real issue is that the call to `this._activatedRoute.paramMap.subscribe` inside the `refresh()` method in `DetectorListAnalysisComponent` is getting called twice when navigating from one Analysis to other. Due to this every item in the array is getting added twice. I tried debugging for sometime but couldn't figure out what is causing. @nmallick1 - if you get check a chance, please debug this a bit.
