### PR TITLE
Fix deeplinking from analysis to detector in drill down view

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-analysis/tab-analysis.component.ts
@@ -17,7 +17,7 @@ export class TabAnalysisComponent implements OnInit {
   downTime: DownTime;
   readonly stringFormat: string = 'YYYY-MM-DDTHH:mm';
 
-  @ViewChild('detectorListAnalysis', {static:true}) detectorListAnalysis: DetectorListAnalysisComponent
+  @ViewChild('detectorListAnalysis', { static: true }) detectorListAnalysis: DetectorListAnalysisComponent
 
   constructor(private _activatedRoute: ActivatedRoute, private _router: Router, private _diagnosticService: ApplensDiagnosticService) {
     this._activatedRoute.paramMap.subscribe(params => {
@@ -34,11 +34,13 @@ export class TabAnalysisComponent implements OnInit {
 
   onDowntimeChanged(event: DownTime) {
     this.detectorListAnalysis.downTime = event;
-    this._router.navigate([`./`], {
-      relativeTo: this._activatedRoute,
-      queryParams: { startTimeChildDetector: event.StartTime.format(this.stringFormat), endTimeChildDetector: event.EndTime.format(this.stringFormat) },
-      queryParamsHandling: 'merge',
-      replaceUrl:true
-    });
+    if (this._activatedRoute == null || this._activatedRoute.firstChild == null || !this._activatedRoute.firstChild.snapshot.paramMap.has('detector') || this._activatedRoute.firstChild.snapshot.paramMap.get('detector').length < 1) {
+      this._router.navigate([`./`], {
+        relativeTo: this._activatedRoute,
+        queryParams: { startTimeChildDetector: event.StartTime.format(this.stringFormat), endTimeChildDetector: event.EndTime.format(this.stringFormat) },
+        queryParamsHandling: 'merge',
+        replaceUrl: true
+      });
+    }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -20,10 +20,10 @@ export class DetectorContainerComponent implements OnInit {
   detectorResponse: DetectorResponse = null;
   error: any;
 
-  startTimeToUse:Moment;
-  endTimeToUse:Moment;
-  startTimeChildDetector : Moment = null;
-  endTimeChildDetector : Moment = null;
+  startTimeToUse: Moment;
+  endTimeToUse: Moment;
+  startTimeChildDetector: Moment = null;
+  endTimeChildDetector: Moment = null;
 
   @Input() hideDetectorControl: boolean = false;
   hideTimerPicker: boolean = false;
@@ -40,30 +40,30 @@ export class DetectorContainerComponent implements OnInit {
 
   @Input() analysisMode: boolean = false;
   @Input() isAnalysisView: boolean = false;
-  
-  @Output() XAxisSelection:EventEmitter<XAxisSelection> = new EventEmitter<XAxisSelection>();	
-  public onXAxisSelection(event:XAxisSelection) {
-		this.XAxisSelection.emit(event);
+
+  @Output() XAxisSelection: EventEmitter<XAxisSelection> = new EventEmitter<XAxisSelection>();
+  public onXAxisSelection(event: XAxisSelection) {
+    this.XAxisSelection.emit(event);
   }
   @Output() downTimeChanged: EventEmitter<DownTime> = new EventEmitter<DownTime>();
-  
+
   isCategoryOverview: boolean = false;
   private isLegacy: boolean
   constructor(private _route: ActivatedRoute, private _diagnosticService: DiagnosticService,
     public detectorControlService: DetectorControlService, private versionService: VersionService) {
   }
 
-  get isPopoutFromAnalysis():boolean {
-    if(!!this._route.parent) {
-      return !!this._route.parent.snapshot.url.find(urlPart=>urlPart.path === 'popout');
+  get isPopoutFromAnalysis(): boolean {
+    if (!!this._route.parent) {
+      return !!this._route.parent.snapshot.url.find(urlPart => urlPart.path === 'popout');
     }
     else {
       return false;
     }
-    
+
   }
 
-  ngOnInit() {
+  public initialize(): void {
     this.versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
     //Remove after A/B Test
     if (this.isLegacy) {
@@ -96,14 +96,21 @@ export class DetectorContainerComponent implements OnInit {
 
     let startTimeChildDetector: string = this._route.snapshot.queryParams['startTimeChildDetector'];
     if (!!startTimeChildDetector && startTimeChildDetector.length > 1 && moment.utc(startTimeChildDetector).isValid()) {
-      this.startTimeChildDetector =  moment.utc(startTimeChildDetector) ;
+      this.startTimeChildDetector = moment.utc(startTimeChildDetector);
     }
 
     let endTimeChildDetector: string = this._route.snapshot.queryParams['endTimeChildDetector'];
     if (!!endTimeChildDetector && endTimeChildDetector.length > 1 && moment.utc(endTimeChildDetector).isValid()) {
-      this.endTimeChildDetector =  moment.utc(endTimeChildDetector) ;
+      this.endTimeChildDetector = moment.utc(endTimeChildDetector);
     }
+  }
 
+  ngOnInit() {
+    this._route.queryParamMap.subscribe(paramMap => {
+      if (this.detectorName == null || !this.isAnalysisDetector()) {
+        this.initialize();
+      }
+    });
   }
 
   refresh(hardRefresh: boolean) {
@@ -112,17 +119,17 @@ export class DetectorContainerComponent implements OnInit {
     this.getDetectorResponse(hardRefresh);
   }
 
-  public get getStartTime():Moment {        
-    let startTime:Moment = this.detectorControlService.startTime;
-    if(!this.isAnalysisDetector()){
+  public get getStartTime(): Moment {
+    let startTime: Moment = this.detectorControlService.startTime;
+    if (!this.isAnalysisDetector()) {
       let startTimeChildDetector: string = this._route.snapshot.queryParams['startTimeChildDetector'];
 
       if (!!startTimeChildDetector && startTimeChildDetector.length > 1 && moment.utc(startTimeChildDetector).isValid()) {
-        startTime =  moment.utc(startTimeChildDetector);
-          this.startTimeChildDetector = startTime;
+        startTime = moment.utc(startTimeChildDetector);
+        this.startTimeChildDetector = startTime;
       }
       else {
-        if(!!this.startTimeChildDetector && startTimeChildDetector.length > 1) {
+        if (!!this.startTimeChildDetector && startTimeChildDetector.length > 1) {
           startTime = this.startTimeChildDetector;
         }
       }
@@ -130,17 +137,17 @@ export class DetectorContainerComponent implements OnInit {
     return startTime;
   }
 
-  public get getEndTime():Moment {    
-    let endTime:Moment = this.detectorControlService.endTime;
-    if(!this.isAnalysisDetector()){
+  public get getEndTime(): Moment {
+    let endTime: Moment = this.detectorControlService.endTime;
+    if (!this.isAnalysisDetector()) {
       let endTimeChildDetector: string = this._route.snapshot.queryParams['endTimeChildDetector'];
 
       if (!!endTimeChildDetector && endTimeChildDetector.length > 1 && moment.utc(endTimeChildDetector).isValid()) {
-        endTime =  moment.utc(endTimeChildDetector);
+        endTime = moment.utc(endTimeChildDetector);
         this.endTimeChildDetector = endTime;
       }
       else {
-        if(!!this.endTimeChildDetector && endTimeChildDetector.length > 1) {
+        if (!!this.endTimeChildDetector && endTimeChildDetector.length > 1) {
           endTime = this.endTimeChildDetector;
         }
       }
@@ -148,15 +155,15 @@ export class DetectorContainerComponent implements OnInit {
     return endTime;
   }
 
-  isAnalysisDetector():boolean {
+  isAnalysisDetector(): boolean {
     let analysisId = '';
-    if(this.analysisMode) {
+    if (this.analysisMode) {
       analysisId = this._route.parent.snapshot.paramMap.get("analysisId");
     }
     else {
-      analysisId = this._route.snapshot.paramMap.get('analysisId');  
+      analysisId = this._route.snapshot.paramMap.get('analysisId');
     }
-    
+
     return !(this.analysisMode && analysisId != this.detectorName);
   }
 
@@ -169,41 +176,41 @@ export class DetectorContainerComponent implements OnInit {
     let knownQueryParams = ['startTime', 'endTime'];
     let queryParamsToSkipForAnalysis = ['startTimeChildDetector', 'endTimeChildDetector'];
     Object.keys(allRouteQueryParams).forEach(key => {
-      if(knownQueryParams.indexOf(key) < 0) {
-        if(this.isAnalysisDetector()) {
-          if(queryParamsToSkipForAnalysis.indexOf(key)<0) {
+      if (knownQueryParams.indexOf(key) < 0) {
+        if (this.isAnalysisDetector()) {
+          if (queryParamsToSkipForAnalysis.indexOf(key) < 0) {
             additionalQueryString += `&${key}=${encodeURIComponent(allRouteQueryParams[key])}`;
           }
         }
         else {
           additionalQueryString += `&${key}=${encodeURIComponent(allRouteQueryParams[key])}`;
-        }        
+        }
       }
     });
-	
-	if (this.analysisMode) {
-    var startTimeChildDetector: string = allRouteQueryParams['startTimeChildDetector'];
-    var endTimeChildDetector: string = allRouteQueryParams['endTimeChildDetector'];
-		if (startTimeChildDetector != null) {
-      startTime = startTimeChildDetector ;
+
+    if (this.analysisMode) {
+      var startTimeChildDetector: string = allRouteQueryParams['startTimeChildDetector'];
+      var endTimeChildDetector: string = allRouteQueryParams['endTimeChildDetector'];
+      if (startTimeChildDetector != null) {
+        startTime = startTimeChildDetector;
+      }
+
+      if (endTimeChildDetector != null) {
+        endTime = endTimeChildDetector;
+      }
     }
-    
-    if (endTimeChildDetector != null) {
-      endTime = endTimeChildDetector;
-    }
-	}
-  
-  
-  
-	this._diagnosticService.getDetector(this.detectorName, startTime, endTime,
-    invalidateCache, this.detectorControlService.isInternalView, additionalQueryString)
+
+
+
+    this._diagnosticService.getDetector(this.detectorName, startTime, endTime,
+      invalidateCache, this.detectorControlService.isInternalView, additionalQueryString)
       .subscribe((response: DetectorResponse) => {
         this.shouldHideTimePicker(response);
         this.detectorResponse = response;
       }, (error: any) => {
         this.error = error;
       });
-}
+  }
 
   // TODO: Right now this is hardcoded to hide for cards, but make this configurable from backend
   shouldHideTimePicker(response: DetectorResponse) {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -349,7 +349,6 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                                 }
                                             });
                                         }
-                                        //console.log('I am here >>>>');
                                         return;
                                     } else {
                                         this.detectorEventProperties = {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -96,8 +96,8 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     showWebSearchTimeout: any = null;
     searchDiagnosticData: DiagnosticData;
     readonly stringFormat: string = 'YYYY-MM-DDTHH:mm';
-    public inDrillDownMode:boolean = false;
-    drillDownDetectorId:string = '';
+    public inDrillDownMode: boolean = false;
+    drillDownDetectorId: string = '';
 
     constructor(public _activatedRoute: ActivatedRoute, private _router: Router,
         private _diagnosticService: DiagnosticService, private _detectorControl: DetectorControlService,
@@ -118,16 +118,16 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     @Input()
     detectorParmName: string;
 
-    public _downTime:DownTime = null;
+    public _downTime: DownTime = null;
     @Input()
     set downTime(downTime: DownTime) {
-      if (!!downTime && !!downTime.StartTime && !!downTime.EndTime) {
-          this._downTime = downTime;
-          this.refresh();
-      }
-      else {
-          this._downTime = null;
-      }
+        if (!!downTime && !!downTime.StartTime && !!downTime.EndTime) {
+            this._downTime = downTime;
+            this.refresh();
+        }
+        else {
+            this._downTime = null;
+        }
     }
 
     withinDiagnoseAndSolve: boolean = !this._detectorControl.internalClient;
@@ -238,24 +238,24 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
     }
 
-    analysisContainsDowntime() : Observable<boolean> {
-        if(this.analysisId === 'searchResultsAnalysis') {
+    analysisContainsDowntime(): Observable<boolean> {
+        if (this.analysisId === 'searchResultsAnalysis') {
             return of(false);
         }
         return this._diagnosticService.getDetector(this.analysisId, this._detectorControl.startTimeString, this._detectorControl.endTimeString).pipe(
             map((response: DetectorResponse) => {
                 let downTimeRenderingType = response.dataset.find(set => (<Rendering>set.renderingProperties).type === RenderingType.DownTime);
-                if(!!downTimeRenderingType) {
+                if (!!downTimeRenderingType) {
                     return true;
                 }
                 else {
                     return false;
                 }
             }),
-            catchError(e=>{return of(false)})
+            catchError(e => { return of(false) })
         );
     }
-  
+
     refresh() {
         if (this.withinGenie) {
             this.detectorId = "";
@@ -264,31 +264,34 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
         else {
             this._activatedRoute.paramMap.subscribe(params => {
-                this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId'))? params.get('analysisId') : this.analysisId;
+                this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId')) ? params.get('analysisId') : this.analysisId;
                 this.detectorId = params.get(this.detectorParmName) === null ? "" : params.get(this.detectorParmName);
-                if (this.analysisId != 'searchResultsAnalysis') this.goBackToAnalysis();
+                if (this.detectorId == "" && !!this._activatedRoute.firstChild && this._activatedRoute.firstChild.snapshot.paramMap.has(this.detectorParmName) && this._activatedRoute.firstChild.snapshot.paramMap.get(this.detectorParmName).length > 1) {
+                    this.detectorId = this._activatedRoute.firstChild.snapshot.paramMap.get(this.detectorParmName);
+                }
+                if (this.analysisId != 'searchResultsAnalysis' && this.detectorId == "") this.goBackToAnalysis();
                 this.populateSupportTopicDocument();
                 this.analysisContainsDowntime().subscribe(containsDownTime => {
-                    if( (containsDownTime && !!this._downTime ) || !containsDownTime ) {
+                    if ((containsDownTime && !!this._downTime) || !containsDownTime) {
                         let currDowntime = this._downTime;
                         this.resetGlobals();
                         if (this.analysisId === "searchResultsAnalysis") {
                             this._activatedRoute.queryParamMap.subscribe(qParams => {
                                 this.resetGlobals();
-                                this.searchTerm = qParams.get('searchTerm') === null ? this.searchTerm : qParams.get('searchTerm');this.showAppInsightsSection = false;
+                                this.searchTerm = qParams.get('searchTerm') === null ? this.searchTerm : qParams.get('searchTerm'); this.showAppInsightsSection = false;
                                 if (this.searchTerm && this.searchTerm.length > 1) {
                                     this.isDynamicAnalysis = true;
-                                    if(this.detectorId) {
+                                    if (this.detectorId) {
                                         this.updateDrillDownMode(true, null);
                                         this._diagnosticService.getDetectors().subscribe(detectorList => {
                                             if (detectorList) {
                                                 if (this.detectorId !== "") {
-                                                let currentDetector = detectorList.find(detector => detector.id == this.detectorId)
-                                                this.detectorName = currentDetector.name;
+                                                    let currentDetector = detectorList.find(detector => detector.id == this.detectorId)
+                                                    this.detectorName = currentDetector.name;
                                                 }
                                             }
                                         });
-                                    }                                    
+                                    }
                                     this.showSuccessfulChecks = false;
                                     this.renderInsightsFromSearch(currDowntime);
                                 }
@@ -308,6 +311,45 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                     if (this.detectorId !== "") {
                                         let currentDetector = detectorList.find(detector => detector.id == this.detectorId)
                                         this.detectorName = currentDetector.name;
+                                        this.detectors = [];
+                                        detectorList.forEach(element => {
+                                            if (element.analysisTypes != null && element.analysisTypes.length > 0) {
+                                                element.analysisTypes.forEach(analysis => {
+                                                    if (analysis === this.analysisId) {
+                                                        this.detectors.push({ name: element.name, id: element.id });
+                                                        this.loadingMessages.push("Checking " + element.name);
+                                                    }
+                                                });
+                                            }
+                                        });
+                                        this.startDetectorRendering(detectorList, currDowntime, containsDownTime);
+                                        let currViewModel = {
+                                            model: this.getDetectorViewModel(currentDetector, currDowntime, containsDownTime),
+                                            insightTitle: '',
+                                            insightDescription: ''
+                                        };
+                                        this.updateDrillDownMode(true, currViewModel);
+                                        if (currViewModel.model.startTime != null && currViewModel.model.endTime != null) {
+                                            this.analysisContainsDowntime().subscribe(containsDowntime => {
+                                                if (containsDowntime) {
+                                                    this._router.navigate([`./detectors/${currentDetector.id}`], {
+                                                        relativeTo: this._activatedRoute,
+                                                        queryParams: { startTimeChildDetector: currViewModel.model.startTime, endTimeChildDetector: currViewModel.model.endTime },
+                                                        queryParamsHandling: 'merge',
+                                                        replaceUrl: true
+                                                    });
+                                                }
+                                                else {
+                                                    this._router.navigate([`./detectors/${currentDetector.id}`], {
+                                                        relativeTo: this._activatedRoute,
+                                                        queryParams: { startTime: currViewModel.model.startTime, endTime: currViewModel.model.endTime },
+                                                        queryParamsHandling: '',
+                                                        replaceUrl: true
+                                                    });
+                                                }
+                                            });
+                                        }
+                                        //console.log('I am here >>>>');
                                         return;
                                     } else {
                                         this.detectorEventProperties = {
@@ -359,9 +401,9 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 searchMode: this.searchMode,
                 searchId: this.searchId,
                 query: this.searchTerm, results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({
-                        id: det.id,
-                        score: det.score
-                    }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
+                    id: det.id,
+                    score: det.score
+                }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
             });
             var detectorList = results[1];
             if (detectorList) {
@@ -384,13 +426,13 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 this.analysisContainsDowntime().subscribe(containsDownTime => {
                     this.startDetectorRendering(detectorList, downTime, containsDownTime);
                 });
-                
+
             }
         },
-        (err) => {
+            (err) => {
                 this.showPreLoader = false;
                 this.showPreLoadingError = true;
-        });
+            });
     }
 
     checkSearchEmbedded(response: DetectorResponse) {
@@ -407,7 +449,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         });
     }
 
-    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime:boolean) {
+    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime: boolean) {
         if (this.showWebSearchTimeout) {
             clearTimeout(this.showWebSearchTimeout);
         }
@@ -436,10 +478,10 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                             let insight = this.getDetectorInsight(this.detectorViewModels[index]);
                             let successViewModel = { model: this.detectorViewModels[index], insightTitle: insight.title, insightDescription: insight.description };
 
-                            if(this.successfulViewModels.length > 0) {
-                                this.successfulViewModels  = this.successfulViewModels.filter(sVM=> (!!sVM.model && !!sVM.model.metadata && !!sVM.model.metadata.id && sVM.model.metadata.id != successViewModel.model.metadata.id));
+                            if (this.successfulViewModels.length > 0) {
+                                this.successfulViewModels = this.successfulViewModels.filter(sVM => (!!sVM.model && !!sVM.model.metadata && !!sVM.model.metadata.id && sVM.model.metadata.id != successViewModel.model.metadata.id));
                             }
-                            
+
                             this.successfulViewModels.push(successViewModel);
                         }
                     }
@@ -577,14 +619,14 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         return viewModel;
     }
 
-    private getDetectorViewModel(detector: DetectorMetaData, downtime: DownTime, containsDownTime:boolean) {
-      let startTimeString = this._detectorControl.startTimeString;
-      let endTimeString = this._detectorControl.endTimeString;
+    private getDetectorViewModel(detector: DetectorMetaData, downtime: DownTime, containsDownTime: boolean) {
+        let startTimeString = this._detectorControl.startTimeString;
+        let endTimeString = this._detectorControl.endTimeString;
 
-      if (containsDownTime && !!downtime && !!downtime.StartTime && !!downtime.EndTime) {
-        startTimeString = downtime.StartTime.format(this.stringFormat);
-        endTimeString = downtime.EndTime.format(this.stringFormat);
-      }
+        if (containsDownTime && !!downtime && !!downtime.StartTime && !!downtime.EndTime) {
+            startTimeString = downtime.StartTime.format(this.stringFormat);
+            endTimeString = downtime.EndTime.format(this.stringFormat);
+        }
 
         return {
             title: detector.name,
@@ -627,34 +669,34 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
 
     }
 
-    public navigateToDetector():void {
-        if(!this.isPublic) {
-           if(!!this.drillDownDetectorId && this.drillDownDetectorId.length > 0 ) {
-            this._router.navigate([`./popout/${this.drillDownDetectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });            
-           }
+    public navigateToDetector(): void {
+        if (!this.isPublic) {
+            if (!!this.drillDownDetectorId && this.drillDownDetectorId.length > 0) {
+                this._router.navigate([`./popout/${this.drillDownDetectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
+            }
         }
     }
 
-    public goBackToAnalysis():void {
+    public goBackToAnalysis(): void {
         this.updateDrillDownMode(false, null);
-        if (this.analysisId=== "searchResultsAnalysis" && this.searchTerm){
-          this._router.navigate([`../../../../${this.analysisId}/search`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: {searchTerm: this.searchTerm} });
+        if (this.analysisId === "searchResultsAnalysis" && this.searchTerm) {
+            this._router.navigate([`../../../../${this.analysisId}/search`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm } });
         }
-        else{
-            if(!!this.analysisId && this.analysisId.length>0) {
+        else {
+            if (!!this.analysisId && this.analysisId.length > 0) {
                 this._router.navigate([`../${this.analysisId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge' });
-            }          
+            }
         }
-      }
+    }
 
-    private updateDrillDownMode(inDrillDownMode:boolean, viewModel:any):void {
+    private updateDrillDownMode(inDrillDownMode: boolean, viewModel: any): void {
         this.inDrillDownMode = inDrillDownMode;
-        if(!this.inDrillDownMode) {
+        if (!this.inDrillDownMode) {
             this.detectorName = '';
             this.drillDownDetectorId = '';
         }
         else {
-            if(!!viewModel && !!viewModel.model && !!viewModel.model.metadata && !!viewModel.model.metadata.name) {
+            if (!!viewModel && !!viewModel.model && !!viewModel.model.metadata && !!viewModel.model.metadata.name) {
                 this.detectorName = viewModel.model.metadata.name;
                 this.drillDownDetectorId = viewModel.model.metadata.id;
             }
@@ -691,7 +733,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     //If in homepage then open second blade for Diagnostic Tool and second blade will continue to open third blade for
                     if (this.withinGenie) {
                         const isHomepage = !this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.snapshot.params["category"];
-                        if(detectorId == 'appchanges' && !this._detectorControl.internalClient) {
+                        if (detectorId == 'appchanges' && !this._detectorControl.internalClient) {
                             this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
                             return;
                         }
@@ -711,18 +753,18 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     }
                 }
                 else {
-                    if(detectorId === 'appchanges' && !this._detectorControl.internalClient) {
+                    if (detectorId === 'appchanges' && !this._detectorControl.internalClient) {
                         this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
                     } else {
                         this.updateDrillDownMode(true, viewModel);
                         if (viewModel.model.startTime != null && viewModel.model.endTime != null) {
                             this.analysisContainsDowntime().subscribe(containsDowntime => {
-                                if(containsDowntime) {
+                                if (containsDowntime) {
                                     this._router.navigate([`./detectors/${detectorId}`], {
                                         relativeTo: this._activatedRoute,
                                         queryParams: { startTimeChildDetector: viewModel.model.startTime, endTimeChildDetector: viewModel.model.endTime },
                                         queryParamsHandling: 'merge',
-                                        replaceUrl:true
+                                        replaceUrl: true
                                     });
                                 }
                                 else {
@@ -730,7 +772,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                         relativeTo: this._activatedRoute,
                                         queryParams: { startTime: viewModel.model.startTime, endTime: viewModel.model.endTime },
                                         queryParamsHandling: '',
-                                        replaceUrl:true
+                                        replaceUrl: true
                                     });
                                 }
                             });


### PR DESCRIPTION
Make downtimes shareable when opened in drill down mode. 
Maintain the current drill down view even when downtime selection is changed. The detector view updates to reflect the latest downtime selection instead of switching to observation list.