### PR TITLE
Fix client side exception in daas session component

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -20,7 +20,7 @@ import { TelemetryService } from 'diagnostic-data';
 export class DaasSessionsComponent implements OnChanges, OnDestroy {
 
     checkingExistingSessions: boolean;
-    sessions: Session[];
+    sessions: Session[] = [];
 
     @Input() public diagnoserNameLookup: string = '';
     @Input() public siteToBeDiagnosed: SiteDaasInfo;
@@ -79,9 +79,16 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
             .subscribe(sessions => {
                 if (sessions != null) {
                     const newSessions = sessions.map(this.reducedSession);
-                    const existingSessions = this.sessions.map(this.reducedSession);
-                    let anySessionUpdated = newSessions.filter(newSession => existingSessions.findIndex(session => JSON.stringify(session) === JSON.stringify(newSession)) === -1).length > 0;
-                    if (newSessions.length !== existingSessions.length || anySessionUpdated) {
+                    if (this.sessions != null)
+                    {
+                        const existingSessions = this.sessions.map(this.reducedSession);
+                        let anySessionUpdated = newSessions.filter(newSession => existingSessions.findIndex(session => JSON.stringify(session) === JSON.stringify(newSession)) === -1).length > 0;
+                        if (newSessions.length !== existingSessions.length || anySessionUpdated) {
+                            this.sessions = this.setExpanded(sessions);
+                        }
+                    }
+                    else
+                    {
                         this.sessions = this.setExpanded(sessions);
                     }
                 }


### PR DESCRIPTION
Looks like a new exception introduced recently:
User Story 1367: [Client side exceptions]: Cannot read property 'map' of undefined at e._next
https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1367/

Application insights End to End transaction:
https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/ComponentId/%7B%22SubscriptionId%22%3A%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%2C%22ResourceGroup%22%3A%22DiagnoseAndSolve%22%2C%22Name%22%3A%22DiagnoseAndSolvePortal%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%2Fsubscriptions%2Fc1972e9d-b3c7-4de4-acb3-681773b28ced%2FresourceGroups%2FDiagnoseAndSolve%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FDiagnoseAndSolvePortal%22%2C%22ResourceType%22%3A%22microsoft.insights%2Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel/%7B%22eventId%22%3A%22bcceece0-c4af-11ea-9b00-3b8a2adba4c2%22%2C%22timestamp%22%3A%222020-07-13T02%3A22%3A45.262Z%22%2C%22cacheId%22%3A%226e49eb86-9b62-44f0-b260-83107217a794%22%2C%22eventTable%22%3A%22exceptions%22%7D
