### PR TITLE
Nmallick1/reduce cxp chat popup size

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.html
@@ -1,18 +1,21 @@
 <div #chatComponentContainer *ngIf="isComponentInitialized()">
   <div class="cxpChat-ConfContainer" *ngIf="showChatConfDialog">
-    <div class = "cxpChat-CloseIconBackground">
-      <i role="button" aria-label="Close chat dialogue" title="Close" class="fa fa-times-circle cxpChat-CloseIcon" (click)="hideChatConfDialog(true, 'CloseIcon')"></i>
-	</div>
     <div class="cxpChat-ConfText">
-      <div>
-        <img src="assets/img/jen.jpg" class="agentImage">
-        <span class="agentName"> Jen </span>
+      <div class="cxpChat-ConsentContainer">
+        <div>
+          <img src="assets/img/jen.jpg" class="agentImage">
+          <span class="agentName"> Jen </span>
+        </div>
+        <div class="cxpChat-ChangeIcon" role="button" aria-label="Close chat dialogue" title="Close"
+          (click)="hideChatConfDialog(true, 'CloseIcon')">
+          <i class="fa fa-times cxpChat-CloseIcon"></i>
+          <i class="fa fa-window-close fa-lg cxpChat-CloseIcon"></i>
+        </div>
       </div>
       <hr>
       <div>
-        <markdown ngPreserveWhitespaces [data]="chatWelcomeMessage"></markdown>        
+        <markdown ngPreserveWhitespaces [data]="chatWelcomeMessage"></markdown>
       </div>
-      <br/>
       <div *ngIf="showDiagnosticsConsentOption" class="cxpChat-ConsentContainer">
         <div class="cxpChat-ConsentOptionContainer">
           <div>
@@ -22,17 +25,18 @@
             <label for="chkBoxDiagnosticConsent">Share diagnostic information.</label>
           </div>
         </div>
-          <div>
-          <a target="_blank" role="link" aria-label="Click to learn more about the information we collect" title="Click to learn more about the information we collect."
-           href="https://azure.microsoft.com/en-us/support/legal/support-diagnostic-information-collection/">
+        <div>
+          <a target="_blank" role="link" aria-label="Click to learn more about the information we collect"
+            title="Click to learn more about the information we collect."
+            href="https://azure.microsoft.com/en-us/support/legal/support-diagnostic-information-collection/">
             <i class="fa fa-info-circle"></i>
           </a>
         </div>
       </div>
     </div>
     <div *ngIf="showChatButtons" class="cxpChat-actionBtnContainer">
-      <input class="custom-button inactive-button white-border" (click)="hideChatConfDialog(true, 'CancelButton')" type="button" role="button"
-        aria-label="Maybe later" value="Maybe later" />
+      <input class="custom-button inactive-button white-border" (click)="hideChatConfDialog(true, 'CancelButton')"
+        type="button" role="button" aria-label="Maybe later" value="Maybe later" />
       <input class="custom-button default-button white-border" (click)="openChatPopup()" type="button" role="button"
         aria-label="Confirm and Start" value="Confirm & Start!" />
     </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
@@ -71,30 +71,18 @@ $zIndex:99;
     bottom:5.2em;    
 }
 
-.cxpChat-CloseIconBackground {
-    display: flex;
-    justify-content: flex-end;
-    padding-right: 5px;
-    padding-top: 5px;
-}
-
 .cxpChat-CloseIcon {
     cursor: pointer;
-    color:darkred;
-    background: radial-gradient(#DBDBDB 50%, transparent 50%);
-    background: -webkit-gradient(#DBDBDB 50%, transparent 50%);
-    background: -webkit-radial-gradient(#DBDBDB 50%, transparent 50%);
-    background: -moz-radial-gradient(#DBDBDB 50%, transparent 50%);
-    background: -o-radial-gradient(#DBDBDB 50%, transparent 50%);
-    background: -ms-radial-gradient(#DBDBDB 50%, transparent 50%);
+    color: white;
+    margin-right:4px;    
 }
 
 .cxpChat-ConfText {
-    padding-top: 18px;
-    padding-right: 24px;
-    padding-bottom: 20px;
-    padding-left: 24px;  
-    width: 30em;  
+    padding-top: 10px;
+    padding-right: 15px;
+    padding-bottom: 15px;
+    padding-left: 15px;  
+    width: 25em;
 }
 
 .cxpChat-ConsentContainer {
@@ -112,10 +100,17 @@ $zIndex:99;
 
 label {
     color: white;
+    margin-left: 3px;
+    margin-bottom: 0px;
 }
 
 a {
     color: skyblue;
+}
+
+hr {
+    margin-top: 5px;
+    margin-bottom: 10px;
 }
 
 .cxpChat-actionBtnContainer {
@@ -126,6 +121,9 @@ a {
 
 .inactive-button {
     background-color: $chatBubble-color;
+    margin-left: 0px;
+    padding-left: 35px;
+    padding-right: 35px;
     &:hover {
         background-color: $primary-color;
     }
@@ -135,6 +133,9 @@ a {
     background-color: white;
     color: $chatBubble-color;
     font-weight: bold;
+    margin-left: 0px;
+    padding-left: 35px;
+    padding-right: 35px;
     &:hover{
         color: white;
         background-color: $primary-color;
@@ -143,4 +144,15 @@ a {
 
 .white-border {
     border: 1px solid white;
+}
+
+.cxpChat-ChangeIcon > .fa + .fa,
+.cxpChat-ChangeIcon:hover > .fa {
+  display: none;
+}
+.cxpChat-ChangeIcon:hover > .fa + .fa {
+  display: inherit;
+  color: #ba141a;
+  margin-top: 5px;
+  margin-right: 0px;
 }


### PR DESCRIPTION
Change the size of the CXP chat popup window to allow more space for diagnostics. We should look at the detector engagement metric in case submission and determine if we notice any increase to check the effectiveness if this change,

**Current**
![image](https://user-images.githubusercontent.com/20996681/87998757-a84d1b80-caad-11ea-827b-c24435192f3e.png)


**After the change**


![image](https://user-images.githubusercontent.com/20996681/87998815-dd596e00-caad-11ea-8a8e-8b7200798827.png)


![image](https://user-images.githubusercontent.com/20996681/87999783-c8320e80-cab0-11ea-8a77-b8dce48a4f4a.png)


