### PR TITLE
Nmallick1/reduce cxp chat logging

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
@@ -6,8 +6,8 @@ import { FeatureNavigationService, TelemetryService, DiagnosticService, DownTime
 import { AuthService } from '../../../startup/services/auth.service';
 import { DetectorListAnalysisComponent } from 'diagnostic-data';
 import { SearchAnalysisMode } from 'projects/diagnostic-data/src/lib/models/search-mode';
-import { CXPChatService } from 'diagnostic-data' ;
-import {GenericSupportTopicService} from '../../../../../../diagnostic-data/src/lib/services/generic-support-topic.service';
+import { CXPChatService } from 'diagnostic-data';
+import { GenericSupportTopicService } from '../../../../../../diagnostic-data/src/lib/services/generic-support-topic.service';
 
 
 @Component({
@@ -19,7 +19,7 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
   @Input() analysisId: string = "";
   @Input() searchTerm: string = "";
   @Input() searchMode: SearchAnalysisMode = SearchAnalysisMode.CaseSubmission;
-  @Input() resourceId: string="";
+  @Input() resourceId: string = "";
   @Input() targetedScore: number = 0;
   detectorId: string = "";
   detectorName: string = "";
@@ -30,14 +30,14 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
   displayDetectorContainer: boolean = true;
   searchBarFocus: boolean = false;
   downTime: DownTime;
-  @ViewChild('detectorListAnalysis', {static:true}) detectorListAnalysis: DetectorListAnalysisComponent
+  @ViewChild('detectorListAnalysis', { static: true }) detectorListAnalysis: DetectorListAnalysisComponent
   isPublic: boolean = false;
   cxpChatTrackingId: string = '';
-  supportTopicId:string = '';
-  cxpChatUrl: string = ''; 
+  supportTopicId: string = '';
+  cxpChatUrl: string = '';
 
   constructor(private _activatedRouteLocal: ActivatedRoute, private _diagnosticServiceLocal: DiagnosticService, _resourceService: ResourceService, _authServiceInstance: AuthService, _telemetryService: TelemetryService,
-    _navigator: FeatureNavigationService, private _routerLocal: Router, private _supportTopicService:GenericSupportTopicService, private _cxpChatService:CXPChatService,
+    _navigator: FeatureNavigationService, private _routerLocal: Router, private _supportTopicService: GenericSupportTopicService, private _cxpChatService: CXPChatService,
     @Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
     super(_activatedRouteLocal, _diagnosticServiceLocal, _resourceService, _authServiceInstance, _telemetryService, _navigator, _routerLocal);
     this.isPublic = config && config.isPublic;
@@ -55,27 +55,29 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
     else {
       var checkOutcome = {
         _supportTopicServiceObj: !!this._supportTopicService,
-        supportTopicId: (!!this._supportTopicService)? this._supportTopicService.supportTopicId : '_supportTopicService is NULL',
+        supportTopicId: (!!this._supportTopicService) ? this._supportTopicService.supportTopicId : '_supportTopicService is NULL',
         _cxpChatService: !!this._cxpChatService,
-        isSupportTopicEnabledForLiveChat:  (!!this._supportTopicService && !!this._cxpChatService)? this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId): null,
+        isSupportTopicEnabledForLiveChat: (!!this._supportTopicService && !!this._cxpChatService) ? this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId) : null,
         isPublic: false
       };
 
-      this._cxpChatService.logChatEligibilityCheck('Call to CXP Chat API skipped. Config is not Public.', JSON.stringify(checkOutcome));
-    }    
+      this._cxpChatService.logChatEligibilityCheck(
+        ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''),
+        'Call to CXP Chat API skipped. Config is not Public.',
+        JSON.stringify(checkOutcome));
+    }
     this._activatedRouteLocal.paramMap.subscribe(params => {
-      this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId'))? params.get('analysisId') : this.analysisId;
+      this.analysisId = (this.analysisId != 'searchResultsAnalysis' && !!params.get('analysisId')) ? params.get('analysisId') : this.analysisId;
       this.analysisDetector = this.analysisId;
       this.detectorId = params.get('detectorName') === null ? "" : params.get('detectorName');
       this._activatedRouteLocal.queryParamMap.subscribe(qParams => {
         this.searchTerm = qParams.get('searchTerm') === null ? this.searchTerm : qParams.get('searchTerm');
-        if (this.analysisId=== "searchResultsAnalysis" && this.searchTerm && this.searchTerm.length>0){
-            this.showSearchBar = this.searchMode === SearchAnalysisMode.CaseSubmission ? true : this.showSearchBar;
-            this.displayDetectorContainer = false;
+        if (this.analysisId === "searchResultsAnalysis" && this.searchTerm && this.searchTerm.length > 0) {
+          this.showSearchBar = this.searchMode === SearchAnalysisMode.CaseSubmission ? true : this.showSearchBar;
+          this.displayDetectorContainer = false;
         }
-        else
-        {
-            this.showSearchBar = false;
+        else {
+          this.showSearchBar = false;
         }
 
         this._diagnosticServiceLocal.getDetectors().subscribe(detectorList => {
@@ -90,50 +92,53 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
     });
   }
 
-  updateLoadingStatus(dataOutput){
-      this.onComplete.emit(dataOutput);
+  updateLoadingStatus(dataOutput) {
+    this.onComplete.emit(dataOutput);
   }
 
-  triggerSearch(){
-    if (this.searchTerm && this.searchTerm.length>1) {
+  triggerSearch() {
+    if (this.searchTerm && this.searchTerm.length > 1) {
       this.searchBarFocus = false;
       var searchBar = document.getElementById('caseSubmissionFlowSearchBar');
       searchBar.blur();
-      this._routerLocal.navigate([`../../${this.analysisId}/search`], { relativeTo: this._activatedRouteLocal, queryParamsHandling: 'merge', queryParams: {searchTerm: this.searchTerm} });
+      this._routerLocal.navigate([`../../${this.analysisId}/search`], { relativeTo: this._activatedRouteLocal, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm } });
     }
   }
 
-  focusSearch(){
+  focusSearch() {
     var searchBar = document.getElementById('caseSubmissionFlowSearchBar');
     searchBar.focus();
     this.searchBarFocus = true;
   }
 
-  showChatButton():boolean {
+  showChatButton(): boolean {
     return this.isPublic && this.cxpChatTrackingId != '' && this.cxpChatUrl != '';
   }
 
-  renderCXPChatButton(){
-    if(this.cxpChatTrackingId === '' && this.cxpChatUrl === '') {
-      if(this._supportTopicService && this._cxpChatService && this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId)) {
-          this.cxpChatTrackingId = this._cxpChatService.generateTrackingId();
-          this.supportTopicId = this._supportTopicService.supportTopicId;
-          this._cxpChatService.getChatURL(this._supportTopicService.supportTopicId, this.cxpChatTrackingId).subscribe((chatApiResponse:any)=>{
-            if (chatApiResponse && chatApiResponse != '') {
-              this.cxpChatUrl = chatApiResponse;
-            }
-          });               
+  renderCXPChatButton() {
+    if (this.cxpChatTrackingId === '' && this.cxpChatUrl === '') {
+      if (this._supportTopicService && this._cxpChatService && this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId)) {
+        this.cxpChatTrackingId = this._cxpChatService.generateTrackingId(((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''));
+        this.supportTopicId = this._supportTopicService.supportTopicId;
+        this._cxpChatService.getChatURL(this._supportTopicService.supportTopicId, this.cxpChatTrackingId).subscribe((chatApiResponse: any) => {
+          if (chatApiResponse && chatApiResponse != '') {
+            this.cxpChatUrl = chatApiResponse;
+          }
+        });
       }
       else {
         var checkOutcome = {
           _supportTopicServiceObj: !!this._supportTopicService,
-          supportTopicId: (!!this._supportTopicService)? this._supportTopicService.supportTopicId : '_supportTopicService is NULL',
+          supportTopicId: (!!this._supportTopicService) ? this._supportTopicService.supportTopicId : '_supportTopicService is NULL',
           _cxpChatService: !!this._cxpChatService,
-          isSupportTopicEnabledForLiveChat:  (!!this._supportTopicService && !!this._cxpChatService)? this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId): null,
+          isSupportTopicEnabledForLiveChat: (!!this._supportTopicService && !!this._cxpChatService) ? this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId) : null,
           isPublic: true
         };
 
-        this._cxpChatService.logChatEligibilityCheck('Call to CXP Chat API skipped', JSON.stringify(checkOutcome));
+        this._cxpChatService.logChatEligibilityCheck(
+          ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''),
+          'Call to CXP Chat API skipped',
+          JSON.stringify(checkOutcome));
       }
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
@@ -153,6 +153,7 @@ hr {
 .cxpChat-ChangeIcon:hover > .fa + .fa {
   display: inherit;
   color: #ba141a;
+  background-color: white;
   margin-top: 5px;
   margin-right: 0px;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -190,7 +190,10 @@ export class DetectorViewComponent implements OnInit {
               isAnalysisView: !!this.isAnalysisView,
               DetectorMetadata: data.metadata
             };
-            this._cxpChatService.logChatEligibilityCheck('Call to CXP Chat API skipped for analysis', JSON.stringify(checkOutcome));
+            this._cxpChatService.logChatEligibilityCheck(
+              ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''),
+              'Call to CXP Chat API skipped for analysis',
+              JSON.stringify(checkOutcome));
           }
         }
         else {
@@ -203,7 +206,10 @@ export class DetectorViewComponent implements OnInit {
             isAnalysisView: !!this.isAnalysisView,
             DetectorMetadata: data.metadata
           };
-          this._cxpChatService.logChatEligibilityCheck('Call to CXP Chat API skipped. Detector does not match support Topic', JSON.stringify(checkOutcome));
+          this._cxpChatService.logChatEligibilityCheck(
+            ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''),
+            'Call to CXP Chat API skipped. Detector does not match support Topic',
+            JSON.stringify(checkOutcome));
         }
 
         this.ratingEventProperties = {
@@ -685,7 +691,7 @@ export class DetectorViewComponent implements OnInit {
   renderCXPChatButton() {
     if (this.cxpChatTrackingId === '' && this.cxpChatUrl === '') {
       if (this._supportTopicService && this._cxpChatService && this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId)) {
-        this.cxpChatTrackingId = this._cxpChatService.generateTrackingId();
+        this.cxpChatTrackingId = this._cxpChatService.generateTrackingId( ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''));
         this.supportTopicId = this._supportTopicService.supportTopicId;
         this._cxpChatService.getChatURL(this._supportTopicService.supportTopicId, this.cxpChatTrackingId).subscribe((chatApiResponse: any) => {
           if (chatApiResponse && chatApiResponse != '') {
@@ -701,7 +707,10 @@ export class DetectorViewComponent implements OnInit {
           isSupportTopicEnabledForLiveChat: (!!this._supportTopicService && !!this._cxpChatService) ? this._cxpChatService.isSupportTopicEnabledForLiveChat(this._supportTopicService.supportTopicId) : null
         };
 
-        this._cxpChatService.logChatEligibilityCheck('Call to CXP Chat API skipped', JSON.stringify(checkOutcome));
+        this._cxpChatService.logChatEligibilityCheck(
+          ((!!this._supportTopicService && !!this._supportTopicService.supportTopicId) ? this._supportTopicService.supportTopicId : ''),
+          'Call to CXP Chat API skipped',
+          JSON.stringify(checkOutcome));
       }
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/cxp-chat.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/cxp-chat.service.ts
@@ -13,14 +13,18 @@ export class CXPChatService {
     return false;
   }
 
-  public generateTrackingId(): string {
+  /**
+ * @param supportTopicId  Support Topic id for which the chat is being initiated for.
+ * @returns a Guid that can be used as a tracking id.
+ */
+  public generateTrackingId(supportTopicId: string): string {
     return 'Not Implemented';
   }
 
 
   /**
  * @param supportTopicId  Support Topic id for which the chat is being initiated for.
- * @param trackingIdGuid  Guid used for tracking. Get this by calling generateTrackingId().
+ * @param trackingIdGuid  Guid used for tracking. Get this by calling  `generateTrackingId(supportTopicId:string)`.
  * @returns CXP Chat type. If no engineer is available, it will return None, else it will return the type of chat that can be initiated for this support topic.
  */
   public getChatAvailability(supportTopicId: string, trackingIdGuid: string): ReplaySubject<any> {
@@ -30,7 +34,7 @@ export class CXPChatService {
   /**
  * @param cxpChatType  Get this from the output of cxpChatService.getChatAvailability call.
  * @param queueForSupportTopic This is the output of getChatAvailability call.
- * @param trackingIdGuid  Guid used for tracking. Get this by calling generateTrackingId().
+ * @param trackingIdGuid  Guid used for tracking. Get this by calling `generateTrackingId(supportTopicId:string)`.
  * @returns Chat URL string. This can be an empty string if no agents are available or if the queue is not found. Always handle for empty string.
  */
   public buildChatUrl(cxpChatType: string, queueForSupportTopic: any, trackingIdGuid: string): Observable<string> {
@@ -40,8 +44,8 @@ export class CXPChatService {
 
   /**
    * @param supportTopicId  Support Topic id for which the chat is being initiated for.
-   * @param trackingIdGuid  Guid used for tracking. Get this by calling generateTrackingId().
-   * @param forceFetch Optional boolean. If set to true, will force fetch the ChatURK ignoring the one currently cached.
+   * @param trackingIdGuid  Guid used for tracking. Get this by calling `generateTrackingId(supportTopicId:string)`.
+   * @param forceFetch Optional boolean. If set to true, will force fetch the ChatURL ignoring the one currently cached.
    * @returns Chat URL string. This can be an empty string if no agents are available or if the queue is not found. Always handle for empty string.
    */
   public getChatURL(supportTopicId: string, trackingIdGuid: string, forceFetch:boolean=false): Observable<string> {
@@ -66,9 +70,10 @@ export class CXPChatService {
 
 
   /**
+   * @param supportTopicId  Support Topic id for which the chat is being initiated for.
    * @param checkType Which button did the user click on
    * @param checkOutcome  Guid used for tracking. This is the trackingId for which the Chat was initiated.
    */
-  public logChatEligibilityCheck(checkType: string, checkOutcome: string): void {
+  public logChatEligibilityCheck(supportTopicId: string, checkType: string, checkOutcome: string): void {
   }
 }


### PR DESCRIPTION
Reduce cxp chat logging. This PR will eliminate around 28K events per day. There were times when these unnecessary events were raised as much as 70 times per minute. This will help with Ibiza telmetry throttling.

 
let extensionName="WebsitesExtension";
let endTime=now();
let startTime = endTime - 1d;
 database("AzurePortal").ExtTelemetry
| where PreciseTimeStamp >= startTime and PreciseTimeStamp < endTime and extension == extensionName
| where data has ';checkType=SupportTopicEnabledForCXPChat;checkOutcome= is not enabled.;'
| count