### PR TITLE
Fix side nav width to be adjusted with zoom and resize

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
@@ -19,7 +19,7 @@
     width: 80%;
     top: 0px;
     bottom: 0px;
-    left: 256px;
+    left: 265px;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
@@ -4,7 +4,7 @@
     }
 
   section.sidebar {
-      width: 20%;
+      min-width: 265px;
       position: fixed;
       top: 0px;
       bottom: 0px;
@@ -15,10 +15,11 @@
 
   section.content {
     position: fixed;
+    min-width: calc(100% - 265px);
     width: 80%;
     top: 0px;
     bottom: 0px;
-    left: 20%;
+    left: 256px;
     overflow-y: auto;
     overflow-x: hidden;
   }


### PR DESCRIPTION
Behavior is in alignment with ibiza sidebar:

Zoom 80%:
![image](https://user-images.githubusercontent.com/38216903/88441659-a42f3f80-cdc6-11ea-9f8f-8233f3bca401.png)

Zoom 300%:

![image](https://user-images.githubusercontent.com/38216903/88441636-895ccb00-cdc6-11ea-9af9-ff7e28b75d3a.png)

Window resize:

![image](https://user-images.githubusercontent.com/38216903/88441685-c1fca480-cdc6-11ea-9b51-cd83c98f4dd7.png)
