### PR TITLE
Fixing Slider to be visible in High Contrast Mode

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/cpu-monitoring/cpu-monitoring-configuration/cpu-monitoring-configuration.component.scss
@@ -69,3 +69,39 @@
         }
     }
 }
+
+@media screen and (-ms-high-contrast: black-on-white) {
+    ::ng-deep {
+        .custom-slider .ng5-slider {
+            .ng5-slider-pointer {
+                border: 1px solid #000;
+            }
+
+            .ng5-slider-tick {
+                border: 1px solid #000;
+            }
+
+            .ng5-slider-bar {
+                border: 1px solid #000;
+            }
+        }
+    }
+}
+
+@media screen and (-ms-high-contrast: white-on-black) {
+    ::ng-deep {
+        .custom-slider .ng5-slider {
+            .ng5-slider-pointer {
+                border: 1px solid #fff;
+            }
+
+            .ng5-slider-tick {
+                border: 1px solid #fff;
+            }
+
+            .ng5-slider-bar {
+                border: 1px solid #fff;
+            }
+        }
+    }
+}


### PR DESCRIPTION

[7095528 ](https://msazure.visualstudio.com/Antares/_workitems/edit/7095528)| [Supporting   the Platform - App Service Diagnostics - Proactive CPU Monitoring] Slider   control is not visible properly in high contrast mode black/white on   “Proactive CPU Monitoring” page.
-- | --

![image](https://user-images.githubusercontent.com/5299838/88681868-a61f3880-d10f-11ea-85e9-aadf5786dbc7.png)

![image](https://user-images.githubusercontent.com/5299838/88681887-a9b2bf80-d10f-11ea-957e-d6a28bd7d2cd.png)
