### PR TITLE
Remove check isHomePage with ActivatedRoute

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -572,7 +572,7 @@ export class SiteFeatureService extends FeatureService {
   }
 
   private navigateTo(resourceId: string, toolId: string) {
-    const isHomepage = !this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.snapshot.params["category"];
+    const isHomepage = this._router.url.endsWith(resourceId);
     //If in homepage then open second blade for Diagnostic Tool and second blade will continue to open third blade for 
     if (isHomepage) {
       this._portalActionService.openBladeDiagnosticToolId(toolId);


### PR DESCRIPTION
This is to fix  [Cannot read property 'snapshot' of null at e.navigateTo](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1398) exception