### PR TITLE
Add reboot to allowedRoutes for solution ARM API

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-solution.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-solution.service.ts
@@ -16,6 +16,7 @@ export class GenericSolutionService {
 
   allowedRoutes = {
     'restart': ['post'],
+    'reboot': ['post'],
     'config/web': ['get', 'put', 'patch'],
     'config/appsettings/list': ['get', 'put'],
     'config/logs': ['put']


### PR DESCRIPTION
This PR allows Solutions on D&S to perform the reboot worker API, which is a POST ARM call.