### PR TITLE
Accessing route snapshot in routing events

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
@@ -119,9 +119,9 @@ export class CategoryNavComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.getCurrentItemId();
         this.hasUncategorizedDetectors = false;
         this._route.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(event => {
+            this.getCurrentItemId();
             this.getCurrentRoutePath();
         });
 


### PR DESCRIPTION
This is regarding to the client side exception fix for this service health item:
TypeError: Cannot read property 'params' of undefined 
https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_queries/edit/1399/?triage=true