### PR TITLE
Fix local build heap limit allocation failure

### DIFF
--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "applens": "ng serve applens --aot --optimization=false",
+    "applens": "node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng serve applens --aot --optimization=false",
     "ncloud-applens-prod": "ng serve applens --configuration=nationalcloud-production --aot --optimization=false",
     "ncloud-applens-local": "ng serve applens --configuration=nationalcloud-local --aot --optimization=false",
-    "ssl": "ng serve app-service-diagnostics --aot --optimization=false --ssl --sslCert ./ssl/server.crt --sslKey ./ssl/server.key",
+    "ssl": "node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng serve app-service-diagnostics --aot --optimization=false --ssl --sslCert ./ssl/server.crt --sslKey ./ssl/server.key",
     "ssl-local": "npm run ssl -- -c local",
     "asd": "concurrently -k \"npm run ssl\" \"npm run lib\"",
     "build-lib": "node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build diagnostic-data",


### PR DESCRIPTION
To fix the heap limit allocation failure we see sometimes when we run "npm run applens" or "npm run ssl-local"