### PR TITLE
Replace ngx-datatable with Fabric DetailList

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -597,7 +597,7 @@ export class SiteFeatureService extends FeatureService {
   }
 
   private navigateTo(resourceId: string, toolId: string) {
-    const isHomepage = !this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.snapshot.params["category"];
+    const isHomepage = this._router.url.endsWith(resourceId);
     //If in homepage then open second blade for Diagnostic Tool and second blade will continue to open third blade for 
     if (isHomepage) {
       this._portalActionService.openBladeDiagnosticToolId(toolId);

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,14 +1,13 @@
 <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
   <div *ngIf="allowColumnSearch" class="text-field">
-    <fab-text-field (onChange)=updateFilter($event)
-      [rows]="1"
-      [placeholder]="searchAriaLabel" [ariaLabel]="searchAriaLabel"></fab-text-field>
+    <fab-text-field (onChange)=updateFilter($event) [rows]="1" [placeholder]="searchAriaLabel"
+      [ariaLabel]="searchAriaLabel"></fab-text-field>
   </div>
   <div [attr.data-is-scrollable]="true" style="overflow: auto;">
     <fab-details-list [items]="rows">
       <columns>
-        <fab-details-list-column #fabDetailListColumn *ngFor="let col of columns;let colIndex=index"
-          [key]="col.key" [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
+        <fab-details-list-column #fabDetailListColumn *ngFor="let col of columns;let colIndex=index" [key]="col.key"
+          [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
           [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,0 +1,81 @@
+<!-- <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
+  <ng-container
+    *ngIf="!renderingProperties.groupByColumnName && !(renderingProperties.groupByColumnName === ''); else groupedTable">
+    <ngx-datatable #myTable class="bootstrap with-shadow"
+      [columnMode]="'force'"
+      [rowHeight]="'auto'"
+      [footerHeight]="0"
+      [scrollbarH]="false"
+      [selected]="selected"
+      (activate)="onActivate($event)"
+      [ngStyle]="currentStyles">
+    </ngx-datatable>
+    <div *ngIf="renderingProperties.descriptionColumnName && selected.length > 0">
+      <pre class="description-text">{{ getValue() }}</pre>
+    </div>
+  </ng-container>
+  <ng-template #headerTemplate let-column="column" let-sort="sortFn" >
+    <span (click)="sort()">
+      <input type="text" [placeholder]="column.name" (click)="onInputClicked($event)" (keyup)="updateFilter($event, column.prop)" />
+    </span>
+  </ng-template>
+
+  <ng-template #groupedTable>
+    <ngx-datatable #myTable class="bootstrap with-shadow"
+      [rows]="rows"
+      [columns]="columns"
+      [columnMode]="'force'"
+      [rowHeight]="'auto'"
+      [footerHeight]="0"
+      [scrollbarH]="false"
+      [groupRowsBy]="renderingProperties.groupByColumnName"
+      [groupExpansionDefault]="false">
+      <ngx-datatable-group-header [rowHeight]="50" #myGroupHeader>
+        <ng-template let-group="group" let-expanded="expanded" ngx-datatable-group-header-template>
+          <div class="group-header" style="padding-left:5px;" (click)="toggleExpandGroup(group)">
+            <div class="expander">
+              <i class="fa" [class.fa-chevron-right]="!expanded" [class.fa-chevron-down]="expanded"></i>
+            </div>
+            <span class="hit-count badge badge-info label label-primary">{{group.value.length}}</span>
+            <div class="group-key">
+              {{group.key}}
+            </div>
+          </div>
+        </ng-template>
+      </ngx-datatable-group-header>
+    </ngx-datatable>
+  </ng-template>
+</data-container> -->
+
+<!-- use let-variable="property name" to get property from IDetailsHeaderProps -->
+<!-- <ng-template #fabDetailListHeader let-columns="columns">
+  <div style="display: flex;">
+    <div *ngFor="let col of columns" [ngStyle]="{'width.px': col.currentWidth}" style="display: flex;">
+      <fab-text-field #fabTextField [cols]="1" [placeholder]="col.name" (onChange)="updateFilter($event,col)" [autoComplete]="false" [value]="searchTexts[col.name]"
+        (onBlur)="onBlurHandler()"></fab-text-field> -->
+
+
+
+
+
+
+
+        <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
+
+          <div [attr.data-is-scrollable]="true">
+            <fab-details-list [items]="rows">
+              <columns>
+                <fab-details-list-column #fabDetailListColumn *ngFor="let col of tableColumns;let colIndex=index"
+                  [key]="col.key" [name]="col.name" [minWidth]="150" [isSorted]="col.isSorted"
+                  [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
+                  [isResizable]="col.isResizable" [isMultiline]="col.isMultiline">
+                  <render>
+                    <ng-template let-item="item" let-column="column" let-rowIndex="index">
+                      <div [innerHTML]="item[column.name]"></div>
+                    </ng-template>
+                  </render>
+                </fab-details-list-column>
+              </columns>
+            </fab-details-list>
+          </div>
+        </data-container>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -7,7 +7,7 @@
   <div [attr.data-is-scrollable]="true" style="overflow: auto;">
     <fab-details-list [items]="rows">
       <columns>
-        <fab-details-list-column #fabDetailListColumn *ngFor="let col of tableColumns;let colIndex=index"
+        <fab-details-list-column #fabDetailListColumn *ngFor="let col of columns;let colIndex=index"
           [key]="col.key" [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
           [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,81 +1,25 @@
-<!-- <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
-  <ng-container
-    *ngIf="!renderingProperties.groupByColumnName && !(renderingProperties.groupByColumnName === ''); else groupedTable">
-    <ngx-datatable #myTable class="bootstrap with-shadow"
-      [columnMode]="'force'"
-      [rowHeight]="'auto'"
-      [footerHeight]="0"
-      [scrollbarH]="false"
-      [selected]="selected"
-      (activate)="onActivate($event)"
-      [ngStyle]="currentStyles">
-    </ngx-datatable>
-    <div *ngIf="renderingProperties.descriptionColumnName && selected.length > 0">
-      <pre class="description-text">{{ getValue() }}</pre>
-    </div>
-  </ng-container>
-  <ng-template #headerTemplate let-column="column" let-sort="sortFn" >
-    <span (click)="sort()">
-      <input type="text" [placeholder]="column.name" (click)="onInputClicked($event)" (keyup)="updateFilter($event, column.prop)" />
-    </span>
-  </ng-template>
-
-  <ng-template #groupedTable>
-    <ngx-datatable #myTable class="bootstrap with-shadow"
-      [rows]="rows"
-      [columns]="columns"
-      [columnMode]="'force'"
-      [rowHeight]="'auto'"
-      [footerHeight]="0"
-      [scrollbarH]="false"
-      [groupRowsBy]="renderingProperties.groupByColumnName"
-      [groupExpansionDefault]="false">
-      <ngx-datatable-group-header [rowHeight]="50" #myGroupHeader>
-        <ng-template let-group="group" let-expanded="expanded" ngx-datatable-group-header-template>
-          <div class="group-header" style="padding-left:5px;" (click)="toggleExpandGroup(group)">
-            <div class="expander">
-              <i class="fa" [class.fa-chevron-right]="!expanded" [class.fa-chevron-down]="expanded"></i>
-            </div>
-            <span class="hit-count badge badge-info label label-primary">{{group.value.length}}</span>
-            <div class="group-key">
-              {{group.key}}
-            </div>
-          </div>
-        </ng-template>
-      </ngx-datatable-group-header>
-    </ngx-datatable>
-  </ng-template>
-</data-container> -->
-
-<!-- use let-variable="property name" to get property from IDetailsHeaderProps -->
-<!-- <ng-template #fabDetailListHeader let-columns="columns">
-  <div style="display: flex;">
-    <div *ngFor="let col of columns" [ngStyle]="{'width.px': col.currentWidth}" style="display: flex;">
-      <fab-text-field #fabTextField [cols]="1" [placeholder]="col.name" (onChange)="updateFilter($event,col)" [autoComplete]="false" [value]="searchTexts[col.name]"
-        (onBlur)="onBlurHandler()"></fab-text-field> -->
-
-
-
-
-
-
-
-        <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
-
-          <div [attr.data-is-scrollable]="true">
-            <fab-details-list [items]="rows">
-              <columns>
-                <fab-details-list-column #fabDetailListColumn *ngFor="let col of tableColumns;let colIndex=index"
-                  [key]="col.key" [name]="col.name" [minWidth]="150" [isSorted]="col.isSorted"
-                  [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
-                  [isResizable]="col.isResizable" [isMultiline]="col.isMultiline">
-                  <render>
-                    <ng-template let-item="item" let-column="column" let-rowIndex="index">
-                      <div [innerHTML]="item[column.name]"></div>
-                    </ng-template>
-                  </render>
-                </fab-details-list-column>
-              </columns>
-            </fab-details-list>
-          </div>
-        </data-container>
+<data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
+  <div *ngIf="allowColumnSearch" style="max-width: 300px; margin-bottom: 30px;">
+    <fab-text-field (onChange)=updateFilter($event)
+      placeHolder="Filter by all columns" [ariaLabel]="'Filter by all columns'"></fab-text-field>
+  </div>
+  <div [attr.data-is-scrollable]="true">
+    <fab-details-list [items]="rows">
+      <columns>
+        <fab-details-list-column #fabDetailListColumn *ngFor="let col of tableColumns;let colIndex=index"
+          [key]="col.key" [name]="col.name" [minWidth]="100" [isSorted]="col.isSorted"
+          [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
+          [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
+          <render>
+            <ng-template let-item="item" let-column="column" let-rowIndex="index">
+              <div [innerHTML]="item[column.name]"></div>
+            </ng-template>
+          </render>
+        </fab-details-list-column>
+      </columns>
+    </fab-details-list>
+  </div>
+  <div *ngIf="renderingProperties.descriptionColumnName && selectionText !== ''">
+    <pre class="description-text">{{ selectionText }}</pre>
+  </div>
+</data-container>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -7,7 +7,7 @@
     <fab-details-list [items]="rows">
       <columns>
         <fab-details-list-column #fabDetailListColumn *ngFor="let col of columns;let colIndex=index" [key]="col.key"
-          [name]="col.name" [minWidth]="100" [maxWidth]="200" [isSorted]="col.isSorted"
+          [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
           [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -7,7 +7,7 @@
     <fab-details-list [items]="rows">
       <columns>
         <fab-details-list-column #fabDetailListColumn *ngFor="let col of columns;let colIndex=index" [key]="col.key"
-          [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
+          [name]="col.name" [minWidth]="100" [maxWidth]="200" [isSorted]="col.isSorted"
           [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,13 +1,14 @@
 <data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
-  <div *ngIf="allowColumnSearch" style="max-width: 300px; margin-bottom: 30px;">
+  <div *ngIf="allowColumnSearch" class="text-field">
     <fab-text-field (onChange)=updateFilter($event)
-      placeHolder="Filter by all columns" [ariaLabel]="'Filter by all columns'"></fab-text-field>
+      [rows]="1"
+      [placeholder]="searchAriaLabel" [ariaLabel]="searchAriaLabel"></fab-text-field>
   </div>
-  <div [attr.data-is-scrollable]="true">
+  <div [attr.data-is-scrollable]="true" style="overflow: auto;">
     <fab-details-list [items]="rows">
       <columns>
         <fab-details-list-column #fabDetailListColumn *ngFor="let col of tableColumns;let colIndex=index"
-          [key]="col.key" [name]="col.name" [minWidth]="100" [isSorted]="col.isSorted"
+          [key]="col.key" [name]="col.name" [minWidth]="100" [maxWidth]="150" [isSorted]="col.isSorted"
           [isSortedDescending]="col.isSortedDescending" (onColumnClick)="clickColumn($event)"
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
@@ -1,0 +1,53 @@
+::ng-deep .datatable-body-row.active .datatable-row-group {
+    background-color: lightgray !important;
+    color:black !important;
+  }
+  
+  .group-header {
+    padding: 5px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  
+  .expander {
+    width: 40px;
+  }
+  
+  .group-key {
+    font-size: 20px;
+    white-space: normal;
+  }
+  
+  .hit-count {
+    margin-right: 10px;
+    font-size: 16px;
+  }
+  
+  .description-text{
+    margin-top: 5px;
+    padding: 5px;
+    height: 150px;
+    max-height: 150px;
+    overflow-y: scroll;
+    border-radius: 0px;
+    white-space: pre-wrap;
+  }
+  
+  :host ::ng-deep .ngx-datatable {
+    .sortable .sort-btn:before {
+      font-family: data-table;
+      padding-left: 1em;
+      content: "c";
+    }
+  
+    .sortable .sort-btn.datatable-icon-down:before {
+      content: "f";
+    }
+  
+    .sortable .sort-btn.datatable-icon-up:before {
+      content: "e";
+    }
+  }
+  

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
@@ -1,31 +1,4 @@
-::ng-deep .datatable-body-row.active .datatable-row-group {
-    background-color: lightgray !important;
-    color:black !important;
-  }
-  
-  .group-header {
-    padding: 5px;
-    cursor: pointer;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
-  
-  .expander {
-    width: 40px;
-  }
-  
-  .group-key {
-    font-size: 20px;
-    white-space: normal;
-  }
-  
-  .hit-count {
-    margin-right: 10px;
-    font-size: 16px;
-  }
-  
-  .description-text{
+.description-text{
     margin-top: 5px;
     padding: 5px;
     height: 150px;
@@ -33,21 +6,5 @@
     overflow-y: scroll;
     border-radius: 0px;
     white-space: pre-wrap;
-  }
-  
-  :host ::ng-deep .ngx-datatable {
-    .sortable .sort-btn:before {
-      font-family: data-table;
-      padding-left: 1em;
-      content: "c";
-    }
-  
-    .sortable .sort-btn.datatable-icon-down:before {
-      content: "f";
-    }
-  
-    .sortable .sort-btn.datatable-icon-up:before {
-      content: "e";
-    }
   }
   

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
@@ -7,4 +7,9 @@
     border-radius: 0px;
     white-space: pre-wrap;
   }
+
+  .text-field{
+    max-width: 300px; 
+    margin-bottom: 30px;
+  }
   

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -64,8 +64,7 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
   rowsClone: any[];
   rowLimit = 25;
   renderingProperties: DataTableRendering;
-  searchText = {};
-  tableColumns: IColumn[] = [];
+  columns: IColumn[] = [];
   allowColumnSearch: boolean = false;
   searchTimeout: any;
   searchAriaLabel = "Filter by all columns";
@@ -87,7 +86,7 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
         isMultiline: true,
       });
 
-    this.tableColumns = columns.filter((item) => item.name !== this.renderingProperties.descriptionColumnName);
+    this.columns = columns.filter((item) => item.name !== this.renderingProperties.descriptionColumnName);
     this.rows = [];
 
     this.diagnosticData.table.rows.forEach(row => {
@@ -120,21 +119,11 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
         'SearchValue': val
       });
     }, 5000);
-    // this.searchTexts[column.name] = val;
-    // const temp = this.rowsClone.filter(item => {
-    //   let allMatch = true;
-    //   Object.keys(this.searchTexts).forEach(key => {
-    //     if (item[key]) {
-    //       allMatch = allMatch && item[key].toString().toLowerCase().indexOf(this.searchTexts[key]) !== -1;
-    //     }
-    //   });
-    //   return allMatch;
-    // });
 
     //For single search bar
     const temp = [];
     for (const row of this.rowsClone) {
-      for (const col of this.tableColumns) {
+      for (const col of this.columns) {
         const cellValue: string = row[col.name].toString();
         if (cellValue.toString().toLowerCase().indexOf(val) !== -1) {
           temp.push(row);
@@ -159,7 +148,7 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     if (column.isSortedDescending) {
       this.rows.reverse();
     }
-    const col = this.tableColumns.find(c => c.name === columnName);
+    const col = this.columns.find(c => c.name === columnName);
     col.isSortedDescending = !isSortedDescending;
     col.isSorted = true;
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -1,0 +1,194 @@
+import { Component, ViewChild, AfterViewInit, TemplateRef, AfterContentInit, ContentChild, Directive, OnInit, ContentChildren, QueryList, ViewChildren } from '@angular/core';
+import { DiagnosticData, DataTableRendering, RenderingType } from '../../models/detector';
+import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
+import { DatatableComponent, SelectionType } from '@swimlane/ngx-datatable';
+import * as Highcharts from 'highcharts';
+import HC_exporting from 'highcharts/modules/exporting';
+import { SelectionMode, IColumn, IDetailsListProps, IDetailsHeaderProps, IDetailsFooterProps, IPlainCard, IPlainCardProps, IListProps, IDetailsColumnProps, IDetailsRowProps, IExpandingCardProps } from 'office-ui-fabric-react';
+import { InputRendererOptions } from '@angular-react/core';
+import { FabTextFieldComponent, FabDetailsListComponent, FabPlainCardComponent, IPlainCardOptions, IExpandingCardOptions, RenderCardContext, FabHoverCardComponent } from '@angular-react/fabric';
+import { TelemetryService } from '../../services/telemetry/telemetry.service';
+
+HC_exporting(Highcharts);
+
+@Component({
+  selector: 'data-table-v4',
+  templateUrl: './data-table-v4.component.html',
+  styleUrls: ['./data-table-v4.component.scss']
+})
+export class DataTableV4Component extends DataRenderBaseComponent implements AfterViewInit, AfterContentInit {
+  Highcharts: typeof Highcharts = Highcharts;
+  // constructor(protected telemetryService:TelemetryService) { 
+  //   super(telemetryService);
+  // }
+  ngAfterViewInit(): void {
+    if (this.renderingProperties.descriptionColumnName != null) {
+      this.table.selectionType = SelectionType.single;
+      this.table.scrollbarV = true;
+      this.table.scrollbarH = false;
+      this.table.rowHeight = 35;
+      this.currentStyles = { 'height': '300px' };
+    }
+
+    if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
+      this.currentStyles = { 'height': this.renderingProperties.height, 'overflow-y': 'visible' };
+    }
+
+    if (this.renderingProperties.tableOptions != null) {
+      Object.keys(this.renderingProperties.tableOptions).forEach(item => {
+        this.table[item] = this.renderingProperties.tableOptions[item];
+      });
+    }
+
+    this.table.rows = this.rows;
+    this.table.columns = this.columns;
+  }
+
+  ngAfterContentInit() {
+    this.createFabricDataTableObjects();
+
+    //For dynamic passing table properties
+    this.fabDetailsList.selectionMode = SelectionMode.none;
+    this.fabDetailsList.initialFocusedIndex = 0;
+    this.fabDetailsList.onShouldVirtualize = (list: IListProps<any>) => {
+      return this.rows.length > this.rowLimit ? false : true;
+    }
+    if (this.renderingProperties.allowColumnSearch) {
+      // this.fabDetailsList.renderDetailsHeader = this.headerWithSearch;
+    } 
+  }
+  
+  DataRenderingType = RenderingType.Table;
+  columns: any[];
+  selected = [];
+  rows: any[];
+  rowsClone: any[];
+  grouped: boolean = true;
+  rowLimit = 25;
+  renderingProperties: DataTableRendering;
+  currentStyles = {};
+  searchTexts = {};
+  selectionMode = SelectionMode.none;
+  tableColumns: IColumn[] = [];
+  @ViewChild('myTable', { static: false }) table: DatatableComponent;
+  @ViewChild(FabDetailsListComponent, { static: true }) fabDetailsList: FabDetailsListComponent;
+
+  protected processData(data: DiagnosticData) {
+    super.processData(data);
+    this.renderingProperties = <DataTableRendering>data.renderingProperties;
+  }
+
+  private createFabricDataTableObjects() {
+    let columns = this.diagnosticData.table.columns.map(column =>
+      <IColumn>{
+        key: column.columnName,
+        name: column.columnName,
+        ariaLabel: column.columnName,
+        isSortedDescending: true,
+        isSorted: false,
+        isResizable: true,
+        isMultiline: true,
+      });
+
+    this.tableColumns = columns.filter((item) => item.name !== this.renderingProperties.descriptionColumnName);
+    this.rows = [];
+
+    this.diagnosticData.table.rows.forEach(row => {
+      const rowObject: any = {};
+
+      for (let i: number = 0; i < this.diagnosticData.table.columns.length; i++) {
+        rowObject[this.diagnosticData.table.columns[i].columnName] = row[i];
+      }
+
+      this.rows.push(rowObject);
+
+      if (this.renderingProperties.descriptionColumnName && this.rows.length > 0) {
+        this.selected.push(this.rows[0]);
+      }
+
+      this.rowsClone = Object.assign([], this.rows);
+    });
+  }
+
+  toggleExpandGroup(group) {
+    this.table.groupHeader.toggleExpandGroup(group);
+  }
+
+  getValue(): any {
+    if (this.selected.length > 0) {
+      return this.selected[0][this.renderingProperties.descriptionColumnName];
+    }
+  }
+
+  //For now use one search bar for all columns 
+  updateFilter(event: { event: Event, newValue?: string }, column: IColumn) {
+
+    this.selected = [];
+    // const val = event.target.value.toLowerCase();
+    const val = event.newValue.toLowerCase();
+    this.searchTexts[column.name] = val;
+
+    const temp = this.rowsClone.filter(item => {
+      let allMatch = true;
+      Object.keys(this.searchTexts).forEach(key => {
+        if (item[key]) {
+          allMatch = allMatch && item[key].toString().toLowerCase().indexOf(this.searchTexts[key]) !== -1;
+        }
+      });
+      return allMatch;
+    });
+
+    this.rows = temp;
+    // this.table.rows = this.rows;
+  }
+
+  // onInputClicked(event: any) {
+  //   event.stopPropagation();
+  // }
+
+  onActivate(event: any) {
+    if (!event.row || !event.row.TIMESTAMP) {
+      return;
+    }
+
+    let timestamp = new Date(event.row.TIMESTAMP + 'Z');
+    for (let i = 0; i < Highcharts.charts.length; i++) {
+      let chart = Highcharts.charts[i];
+      if (chart) {
+        let xi = chart.xAxis[0];
+        xi.removePlotLine("myPlotLine");
+        xi.addPlotLine({
+          value: timestamp.valueOf(),
+          width: 1,
+          color: 'grey',
+          id: 'myPlotLine'
+        });
+      }
+    }
+  }
+
+  clickColumn(event: { ev: Event, column: IColumn }) {
+    this.sortColumn(event.column);
+  }
+
+  sortColumn(column: IColumn) {
+    const isSortedDescending = column.isSortedDescending;
+    const columnName = column.name;
+
+    this.rows.sort((r1, r2) => {
+      return r1[columnName] > r2[columnName] ? 1 : -1;
+    });
+
+    if (column.isSortedDescending) {
+      this.rows.reverse();
+    }
+
+    // let tableColumn = this.tableColumns.find(column => column.name === colName);
+    // tableColumn.isSortedDescending = !isSortedDescending;
+    // tableColumn.isSorted = true;
+    column.isSortedDescending = !isSortedDescending;
+    column.isSorted = true;
+  }
+}
+
+

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -1,13 +1,9 @@
 import { Component, ViewChild, AfterViewInit, AfterContentInit } from '@angular/core';
 import { DiagnosticData, DataTableRendering } from '../../models/detector';
 import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
-import * as Highcharts from 'highcharts';
-import HC_exporting from 'highcharts/modules/exporting';
 import { SelectionMode, IColumn, IListProps, ISelection, Selection, IDetailsListProps, DetailsListLayoutMode, ITextFieldProps, IStyle } from 'office-ui-fabric-react';
 import { FabDetailsListComponent } from '@angular-react/fabric';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
-
-HC_exporting(Highcharts);
 
 @Component({
   selector: 'data-table-v4',
@@ -15,7 +11,6 @@ HC_exporting(Highcharts);
   styleUrls: ['./data-table-v4.component.scss']
 })
 export class DataTableV4Component extends DataRenderBaseComponent implements AfterContentInit {
-  Highcharts: typeof Highcharts = Highcharts;
   constructor(protected telemetryService: TelemetryService) {
     super(telemetryService);
   }
@@ -35,7 +30,13 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       this.allowColumnSearch = this.renderingProperties.allowColumnSearch;
     }
 
-    //Customize table style
+    if(this.renderingProperties.descriptionColumnName){
+     this.fabDetailsList.getRowAriaLabel = (row:any) => {
+       const descriptionName = this.renderingProperties.descriptionColumnName;
+       return `${descriptionName} : ${row[descriptionName]}`;
+     } 
+    }
+
     const detailListStyles: IStyle = { height: '300px' };
     if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
       detailListStyles.height = this.renderingProperties.height;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -131,26 +131,38 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       }
     }
     this.rows = temp;
+    //Update rows order with column sorting
+    const column = this.columns.find(col => col.isSorted === true);
+    if(column){
+      this.sortColumn(column,column.isSortedDescending);
+    }
   }
 
   clickColumn(e: { ev: Event, column: IColumn }) {
-    this.sortColumn(e.column);
+    const isSortedDescending = !e.column.isSortedDescending;
+    this.sortColumn(e.column,isSortedDescending);
+
   }
 
-  private sortColumn(column: IColumn) {
-    const isSortedDescending = column.isSortedDescending;
+  private sortColumn(column: IColumn,isSortedDescending:boolean) {
     const columnName = column.name;
 
     this.rows.sort((r1, r2) => {
       return r1[columnName] > r2[columnName] ? 1 : -1;
     });
 
-    if (column.isSortedDescending) {
+    if (isSortedDescending) {
       this.rows.reverse();
     }
-    const col = this.columns.find(c => c.name === columnName);
-    col.isSortedDescending = !isSortedDescending;
-    col.isSorted = true;
+    this.columns.forEach(column => {
+      if(column.name === columnName){
+        column.isSortedDescending = isSortedDescending;
+        column.isSorted = true;
+      }else {
+        column.isSorted = false;
+        column.isSortedDescending = true;
+      }
+    });
   }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -1,7 +1,7 @@
-import { Component, ViewChild, AfterViewInit, AfterContentInit } from '@angular/core';
+import { Component, ViewChild, AfterContentInit } from '@angular/core';
 import { DiagnosticData, DataTableRendering } from '../../models/detector';
 import { DataRenderBaseComponent } from '../data-render-base/data-render-base.component';
-import { SelectionMode, IColumn, IListProps, ISelection, Selection, IDetailsListProps, DetailsListLayoutMode, ITextFieldProps, IStyle } from 'office-ui-fabric-react';
+import { SelectionMode, IColumn, IListProps, ISelection, Selection, IStyle } from 'office-ui-fabric-react';
 import { FabDetailsListComponent } from '@angular-react/fabric';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 
@@ -30,15 +30,15 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       this.allowColumnSearch = this.renderingProperties.allowColumnSearch;
     }
 
-    if(this.renderingProperties.descriptionColumnName){
-     this.fabDetailsList.getRowAriaLabel = (row:any) => {
-       const descriptionName = this.renderingProperties.descriptionColumnName;
-       return `${descriptionName} : ${row[descriptionName]}`;
-     } 
+    if (this.renderingProperties.descriptionColumnName) {
+      this.fabDetailsList.getRowAriaLabel = (row: any) => {
+        const descriptionName = this.renderingProperties.descriptionColumnName;
+        return `${descriptionName} : ${row[descriptionName]}`;
+      }
     }
 
     const detailListStyles: IStyle = { height: '300px' };
-    if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
+    if (this.renderingProperties.height) {
       detailListStyles.height = this.renderingProperties.height;
     }
     this.fabDetailsList.styles = { root: detailListStyles };

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -34,18 +34,15 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     if (this.renderingProperties.allowColumnSearch) {
       this.allowColumnSearch = this.renderingProperties.allowColumnSearch;
     }
-    this.fabDetailsList.layoutMode = DetailsListLayoutMode.justified;
-
 
     //Customize table style
-    const detailListStyles: IStyle = { height: '300px', overflowX: "hidden" };
+    const detailListStyles: IStyle = { height: '300px' };
     if (this.renderingProperties.height != null && this.renderingProperties.height !== "") {
       detailListStyles.height = this.renderingProperties.height;
     }
     this.fabDetailsList.styles = { root: detailListStyles };
   }
 
-  // DataRenderingType = RenderingType.Table;
   selection: ISelection = new Selection({
     onSelectionChanged: () => {
       const selectionCount = this.selection.getSelectedCount();
@@ -98,10 +95,6 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
 
       this.rows.push(rowObject);
 
-      if (this.renderingProperties.descriptionColumnName && this.rows.length > 0) {
-        this.selectionText = ""
-      }
-
       this.rowsClone = Object.assign([], this.rows);
     });
   }
@@ -109,7 +102,6 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
 
   //For now use one search bar for all columns 
   updateFilter(e: { event: Event, newValue?: string }) {
-    // const val = event.target.value.toLowerCase();
     const val = e.newValue.toLowerCase();
     if (this.searchTimeout) {
       clearTimeout(this.searchTimeout);

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -133,18 +133,18 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     this.rows = temp;
     //Update rows order with column sorting
     const column = this.columns.find(col => col.isSorted === true);
-    if(column){
-      this.sortColumn(column,column.isSortedDescending);
+    if (column) {
+      this.sortColumn(column, column.isSortedDescending);
     }
   }
 
   clickColumn(e: { ev: Event, column: IColumn }) {
     const isSortedDescending = !e.column.isSortedDescending;
-    this.sortColumn(e.column,isSortedDescending);
+    this.sortColumn(e.column, isSortedDescending);
 
   }
 
-  private sortColumn(column: IColumn,isSortedDescending:boolean) {
+  private sortColumn(column: IColumn, isSortedDescending: boolean) {
     const columnName = column.name;
 
     this.rows.sort((r1, r2) => {
@@ -155,10 +155,10 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       this.rows.reverse();
     }
     this.columns.forEach(column => {
-      if(column.name === columnName){
+      if (column.name === columnName) {
         column.isSortedDescending = isSortedDescending;
         column.isSorted = true;
-      }else {
+      } else {
         column.isSorted = false;
         column.isSortedDescending = true;
       }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -138,8 +138,7 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.TimeSeries:
         return TimeSeriesGraphComponent;
       case RenderingType.Table:
-        // return this.isLegacy ? DataTableComponent : DataTableV4Component;
-        return DataTableV4Component;
+        return this.isLegacy ? DataTableComponent : DataTableV4Component;
       case RenderingType.DataSummary:
         return DataSummaryComponent;
       case RenderingType.Email:

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -138,7 +138,7 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.TimeSeries:
         return TimeSeriesGraphComponent;
       case RenderingType.Table:
-        return this.isLegacy ? DataTableComponent : DataTableV4Component;
+        return DataTableV4Component;
       case RenderingType.DataSummary:
         return DataSummaryComponent;
       case RenderingType.Email:
@@ -154,7 +154,7 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.DetectorList:
         return DetectorListComponent;
       case RenderingType.DropDown:
-        return this.isLegacy ? DropdownComponent : DropdownV4Component;
+        return DropdownV4Component;
       case RenderingType.Cards:
         return this.isLegacy ? CardSelectionComponent : CardSelectionV4Component;
       case RenderingType.Solution:

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -138,9 +138,7 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.TimeSeries:
         return TimeSeriesGraphComponent;
       case RenderingType.Table:
-        //For testing only, in PROD dynamic return old/new table
-        return DataTableV4Component;
-        // return this.isLegacy ? DataTableComponent : DataTableV4Component;
+        return this.isLegacy ? DataTableComponent : DataTableV4Component;
       case RenderingType.DataSummary:
         return DataSummaryComponent;
       case RenderingType.Email:

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -37,6 +37,7 @@ import { DetectorSearchComponent } from '../detector-search/detector-search.comp
 import { xAxisPlotBand, zoomBehaviors, XAxisSelection } from '../../models/time-series';
 import { DynamicInsightV4Component } from '../dynamic-insight-v4/dynamic-insight-v4.component';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
+import { DataTableV4Component } from '../data-table-v4/data-table-v4.component';
 
 @Component({
   selector: 'dynamic-data',
@@ -46,7 +47,7 @@ import { TelemetryService } from '../../services/telemetry/telemetry.service';
     TimeSeriesGraphComponent, DataTableComponent, DataSummaryComponent, EmailComponent,
     InsightsComponent, TimeSeriesInstanceGraphComponent, DynamicInsightComponent, MarkdownViewComponent,
     DetectorListComponent, DropdownComponent, CardSelectionComponent, SolutionComponent, GuageControlComponent, FormComponent,
-    ChangeAnalysisOnboardingComponent, ChangesetsViewComponent, AppDependenciesComponent, AppInsightsMarkdownComponent, DetectorListAnalysisComponent, ConnectAppInsightsComponent, DetectorSearchComponent, SummaryCardsComponent, InsightsV4Component, DropdownV4Component, CardSelectionV4Component,DynamicInsightV4Component
+    ChangeAnalysisOnboardingComponent, ChangesetsViewComponent, AppDependenciesComponent, AppInsightsMarkdownComponent, DetectorListAnalysisComponent, ConnectAppInsightsComponent, DetectorSearchComponent, SummaryCardsComponent, InsightsV4Component, DropdownV4Component, CardSelectionV4Component,DynamicInsightV4Component,DataTableV4Component
   ]
 })
 export class DynamicDataComponent implements OnInit {
@@ -137,7 +138,9 @@ export class DynamicDataComponent implements OnInit {
       case RenderingType.TimeSeries:
         return TimeSeriesGraphComponent;
       case RenderingType.Table:
-        return DataTableComponent;
+        //For testing only, in PROD dynamic return old/new table
+        return DataTableV4Component;
+        // return this.isLegacy ? DataTableComponent : DataTableV4Component;
       case RenderingType.DataSummary:
         return DataSummaryComponent;
       case RenderingType.Email:

--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-insight/dynamic-insight.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-insight/dynamic-insight.component.html
@@ -3,9 +3,9 @@
   [class.warning-insight-panel]="insight.status === InsightStatus.Warning"
   [class.success-insight-panel]="insight.status === InsightStatus.Success"
   [class.info-insight-panel]="insight.status === InsightStatus.Info"
-  tabindex="0" (keyup.enter)="toggleInsightExpanded(insight)">
+  tabindex="0">
   <div class="panel-heading">
-    <h5 class="panel-title" [class.clickable-header]="insight.innerDiagnosticData"  (click)="toggleInsightExpanded(insight)">
+    <h5 class="panel-title" [class.clickable-header]="insight.innerDiagnosticData"  (click)="toggleInsightExpanded(insight)" (keyup.enter)="toggleInsightExpanded(insight)" tabindex="0">
       <div style="display: table;">
         <div style="display: table-row">
           <div style="display: table-cell">

--- a/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
@@ -98,6 +98,7 @@ import { DynamicInsightV4Component } from './components/dynamic-insight-v4/dynam
 import { InViewportModule } from "ng-in-viewport";
 import { ParseResourceService } from './services/parse-resource.service';
 import { MarkdownTextComponent } from './components/markdown-text/markdown-text.component';
+import { DataTableV4Component } from './components/data-table-v4/data-table-v4.component';
 
 @NgModule({
   imports: [
@@ -147,7 +148,8 @@ import { MarkdownTextComponent } from './components/markdown-text/markdown-text.
     WebSearchComponent,
     RenderFilterPipe,
     DynamicInsightV4Component,
-    MarkdownTextComponent
+    MarkdownTextComponent,
+    DataTableV4Component
   ],
   entryComponents: [DetectorListAnalysisComponent],
   exports: [

--- a/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/diagnostic-data.module.ts
@@ -82,7 +82,7 @@ import { AppDependenciesComponent } from './components/app-dependencies/app-depe
 import { HighchartsChartModule } from 'highcharts-angular';
 import { HighchartsGraphComponent } from './components/highcharts-graph/highcharts-graph.component';
 import { FabNavModule } from './components/fab-nav/fab-nav.module';
-import { FabIconModule, FabChoiceGroupModule, FabSearchBoxModule, FabDropdownModule } from '@angular-react/fabric';
+import { FabIconModule, FabChoiceGroupModule, FabSearchBoxModule, FabDropdownModule, FabDetailsListModule, FabTextFieldModule } from '@angular-react/fabric';
 import { SummaryCardsComponent } from './components/summary-cards/summary-cards.component';
 import { InsightsV4Component } from './components/insights-v4/insights-v4.component';
 import { CardSelectionV4Component } from './components/card-selection-v4/card-selection-v4.component';
@@ -113,7 +113,9 @@ import { MarkdownTextComponent } from './components/markdown-text/markdown-text.
     FabChoiceGroupModule,
     FabSearchBoxModule,
     FabDropdownModule,
-    InViewportModule
+    InViewportModule,
+    FabDetailsListModule,
+    FabTextFieldModule
   ],
   providers: [
     ClipboardService


### PR DESCRIPTION
- Ues Fabric DetailList component to replace ngx-datatable. 
- Use Fabric TextField component for searching

For now new datatable supports almost all functionalities, like : searching(but not able to search across multiple columns) , sorting , resizing columns and showing the description below the table

![image](https://user-images.githubusercontent.com/23129934/89335257-9ee6b600-d64c-11ea-91d0-b08e74e65b62.png)

![image](https://user-images.githubusercontent.com/23129934/89335639-259b9300-d64d-11ea-87b8-0bed0eee2bcd.png)




