### PR TITLE
Nmallick1/Reduce logging for request routed

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 import { Subscription } from '../models/subscription';
 import { ResponseMessageEnvelope, ResponseMessageCollectionEnvelope } from '../models/responsemessageenvelope';
 import { AuthService } from '../../startup/services/auth.service';
-import { CacheService, LogInfo } from './cache.service';
+import { CacheService } from './cache.service';
 import { catchError, retry, map, retryWhen, delay } from 'rxjs/operators';
 import { HttpClient, HttpHeaders, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { GenericArmConfigService } from './generic-arm-config.service';
@@ -14,6 +14,7 @@ import { VersioningHelper } from '../../../app/shared/utilities/versioningHelper
 import { PortalKustoTelemetryService } from './portal-kusto-telemetry.service';
 import { Guid } from '../utilities/guid';
 import { Router } from '@angular/router';
+import { TelemetryPayload } from 'diagnostic-data';
 
 @Injectable()
 export class ArmService {
@@ -151,9 +152,9 @@ export class ArmService {
         };
 
         let logData = {
-            eventMessage: "RequestRoutingDetails",
-            properties: eventProps
-        } as LogInfo;
+            eventIdentifier: "RequestRoutingDetails",
+            eventPayload: eventProps
+        } as TelemetryPayload;
 
         let requestHeaders = this.getHeaders(null, additionalHeaders);
         const request = this._http.get<ResponseMessageEnvelope<T>>(url, {
@@ -424,9 +425,9 @@ export class ArmService {
         };
 
         let logData = {
-            eventMessage: "RequestRoutingDetails",
-            properties: eventProps
-        } as LogInfo;
+            eventIdentifier: "RequestRoutingDetails",
+            eventPayload: eventProps
+        } as TelemetryPayload;
 
         const request = this._http.get(url, { headers: this.getHeaders(null, additionalHeaders) }).pipe(
             map<ResponseMessageCollectionEnvelope<ResponseMessageEnvelope<T>>, ResponseMessageEnvelope<T>[]>(r => r.value),

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/cache.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/cache.service.ts
@@ -3,16 +3,10 @@ import { throwError as observableThrowError, Observable, Subject, of } from 'rxj
 import { Injectable } from '@angular/core';
 import { tap, finalize } from 'rxjs/operators';
 import { PortalKustoTelemetryService } from './portal-kusto-telemetry.service';
+import { TelemetryPayload } from 'diagnostic-data';
 
 interface CacheContent {
     value: any;
-}
-
-export interface LogInfo {
-    eventMessage: string,
-    properties: {
-        [name: string]: string
-    }
 }
 
 @Injectable()
@@ -25,7 +19,7 @@ export class CacheService {
 
     constructor(private telemetryService?: PortalKustoTelemetryService) { }
 
-    get(key: string, fallback?: Observable<any>, invalidateCache: boolean = false, logDataForActualCall?: LogInfo): Observable<any> | Subject<any> {
+    get(key: string, fallback?: Observable<any>, invalidateCache: boolean = false, logDataForActualCall?: TelemetryPayload): Observable<any> | Subject<any> {
 
         if (this.has(key)) {
             if (invalidateCache) {
@@ -42,8 +36,8 @@ export class CacheService {
         } else if (fallback && fallback instanceof Observable) {
             this.inFlightObservables.set(key, new Subject());
             this.log(`%c Calling api for ${key}`, 'color: purple');
-            if (!!logDataForActualCall && !!logDataForActualCall.eventMessage && !!logDataForActualCall.properties) {
-                this.telemetryService.logEvent(logDataForActualCall.eventMessage, logDataForActualCall.properties);
+            if (!!logDataForActualCall && !!logDataForActualCall.eventIdentifier && !!logDataForActualCall.eventPayload) {
+                this.telemetryService.logEvent(logDataForActualCall.eventIdentifier, logDataForActualCall.eventPayload);
             }
             return fallback.pipe(
                 tap(

--- a/AngularApp/projects/applens/src/app/shared/services/cache.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/cache.service.ts
@@ -4,17 +4,10 @@ import { throwError as observableThrowError, of as observableOf, Observable, Sub
 import { tap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { environment } from '../../../environments/environment';
-import { TelemetryService } from 'diagnostic-data';
+import { TelemetryService, TelemetryPayload } from 'diagnostic-data';
 
 interface CacheContent {
     value: any;
-}
-
-export interface LogInfo {
-    eventMessage: string,
-    properties: {
-        [name: string]: string
-    }
 }
 
 @Injectable()
@@ -27,7 +20,7 @@ export class CacheService {
 
     constructor(private _telemetryService: TelemetryService) { }
 
-    get(key: string, fallback?: Observable<any>, invalidateCache: boolean = false, logDataForActualCall?: LogInfo): Observable<any> | Subject<any> {
+    get(key: string, fallback?: Observable<any>, invalidateCache: boolean = false, logDataForActualCall?: TelemetryPayload): Observable<any> | Subject<any> {
 
         if (this.has(key)) {
             if (invalidateCache) {
@@ -46,8 +39,8 @@ export class CacheService {
 
             this.inFlightObservables.set(key, new Subject());
             this.log(`%c Calling api for ${key}`, 'color: purple');
-            if (!!logDataForActualCall && !!logDataForActualCall.eventMessage && !!logDataForActualCall.properties) {
-                this._telemetryService.logEvent(logDataForActualCall.eventMessage, logDataForActualCall.properties);
+            if (!!logDataForActualCall && !!logDataForActualCall.eventIdentifier && !!logDataForActualCall.eventPayload) {
+                this._telemetryService.logEvent(logDataForActualCall.eventIdentifier, logDataForActualCall.eventPayload);
             }
             return fallback.pipe(tap((value) => { this.set(key, value); }, error => this.inFlightObservables.delete(key)));
         } else {

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -1,13 +1,13 @@
 import { AdalService } from 'adal-angular4';
 import { DetectorMetaData, DetectorResponse, QueryResponse, TelemetryService } from 'diagnostic-data';
-import {map, retry,  catchError, tap } from 'rxjs/operators';
+import { map, retry, catchError, tap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
-import { Observable ,  throwError as observableThrowError } from 'rxjs';
+import { Observable, throwError as observableThrowError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { HttpMethod } from '../models/http';
 import { Package } from '../models/package';
-import { CacheService } from './cache.service';
+import { CacheService, LogInfo } from './cache.service';
 import { Guid } from 'projects/app-service-diagnostics/src/app/shared/utilities/guid';
 import { Router } from '@angular/router';
 
@@ -20,7 +20,7 @@ export class DiagnosticApiService {
   public Location: string = null;
 
   constructor(private _httpClient: HttpClient, private _cacheService: CacheService,
-    private _adalService: AdalService, private _telemetryService: TelemetryService, private _router:Router) { }
+    private _adalService: AdalService, private _telemetryService: TelemetryService, private _router: Router) { }
 
   public get diagnosticApi(): string {
     return environment.production ? '' : this.localDiagnosticApi;
@@ -225,25 +225,27 @@ export class DiagnosticApiService {
     let url = `${this.diagnosticApi}api/invoke`
     let request: Observable<any>;
 
-    if(additionalHeaders == null) {
+    if (additionalHeaders == null) {
       additionalHeaders = new Map<string, string>();
     }
 
-    let requestId:string = Guid.newGuid();
-    if(!additionalHeaders.has('x-ms-request-id') || additionalHeaders.get('x-ms-request-id') == null || additionalHeaders.get('x-ms-request-id') == '' ) {
+    let requestId: string = Guid.newGuid();
+    if (!additionalHeaders.has('x-ms-request-id') || additionalHeaders.get('x-ms-request-id') == null || additionalHeaders.get('x-ms-request-id') == '') {
       additionalHeaders.set('x-ms-request-id', requestId);
     }
 
     let eventProps = {
-      'resourceId': path,            
+      'resourceId': path,
       'requestId': requestId,
       'requestUrl': url,
       'routerUrl': this._router.url,
       'targetRuntime': "Liberation"
     };
-    this._telemetryService.logEvent("RequestRoutingDetails", eventProps);
 
-    
+    let logData = {
+      eventMessage: "RequestRoutingDetails",
+      properties: eventProps
+    } as LogInfo;
 
     if (getFullResponse) {
       request = this._httpClient.post<T>(url, body, {
@@ -257,7 +259,7 @@ export class DiagnosticApiService {
     }
 
     let keyPostfix = internalClient === true ? "-true" : "-false";
-    return useCache ? this._cacheService.get(this.getCacheKey(method, path + keyPostfix), request, invalidateCache) : request;
+    return useCache ? this._cacheService.get(this.getCacheKey(method, path + keyPostfix), request, invalidateCache, logData) : request;
   }
 
   public get<T>(path: string, invalidateCache: boolean = false): Observable<T> {
@@ -296,9 +298,9 @@ export class DiagnosticApiService {
 
     if (this.GeomasterServiceAddress)
       headers = headers.set("x-ms-geomaster-hostname", this.GeomasterServiceAddress);
-      
+
     if (this.GeomasterName)
-      headers = headers.set("x-ms-geomaster-name", this.GeomasterName);      
+      headers = headers.set("x-ms-geomaster-name", this.GeomasterName);
 
     if (path) {
       headers = headers.set('x-ms-path-query', encodeURI(path));

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -1,5 +1,5 @@
 import { AdalService } from 'adal-angular4';
-import { DetectorMetaData, DetectorResponse, QueryResponse, TelemetryService } from 'diagnostic-data';
+import { DetectorMetaData, DetectorResponse, QueryResponse } from 'diagnostic-data';
 import { map, retry, catchError, tap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
@@ -7,9 +7,10 @@ import { Observable, throwError as observableThrowError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { HttpMethod } from '../models/http';
 import { Package } from '../models/package';
-import { CacheService, LogInfo } from './cache.service';
+import { CacheService } from './cache.service';
 import { Guid } from 'projects/app-service-diagnostics/src/app/shared/utilities/guid';
 import { Router } from '@angular/router';
+import { TelemetryPayload } from 'diagnostic-data';
 
 @Injectable()
 export class DiagnosticApiService {
@@ -19,8 +20,7 @@ export class DiagnosticApiService {
   public GeomasterName: string = null;
   public Location: string = null;
 
-  constructor(private _httpClient: HttpClient, private _cacheService: CacheService,
-    private _adalService: AdalService, private _telemetryService: TelemetryService, private _router: Router) { }
+  constructor(private _httpClient: HttpClient, private _cacheService: CacheService, private _adalService: AdalService, private _router: Router) { }
 
   public get diagnosticApi(): string {
     return environment.production ? '' : this.localDiagnosticApi;
@@ -243,9 +243,9 @@ export class DiagnosticApiService {
     };
 
     let logData = {
-      eventMessage: "RequestRoutingDetails",
-      properties: eventProps
-    } as LogInfo;
+      eventIdentifier: "RequestRoutingDetails",
+      eventPayload: eventProps
+    } as TelemetryPayload;
 
     if (getFullResponse) {
       request = this._httpClient.post<T>(url, body, {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -59,10 +59,17 @@ export const TelemetryEventNames = {
     CategoryNavItemClicked: 'CategoryNavItemClicked',
     DowntimeInteraction: 'DowntimeInteraction',
     DowntimeListPassedByDetector: 'DowntimePassedByDetector',
-    CrashMonitoringEnabled:'CrashMonitoringEnabled',
-    CrashMonitoringStopped:'CrashMonitoringStopped',
-    CrashMonitoringAgentDisabled:'CrashMonitoringAgentDisabled'
+    CrashMonitoringEnabled: 'CrashMonitoringEnabled',
+    CrashMonitoringStopped: 'CrashMonitoringStopped',
+    CrashMonitoringAgentDisabled: 'CrashMonitoringAgentDisabled'
 };
+
+export interface TelemetryPayload {
+    eventIdentifier: string,
+    eventPayload: {
+        [name: string]: string
+    }
+}
 
 export interface ITelemetryProvider {
     // Log a user action or other occurrence.


### PR DESCRIPTION
Move logging inside cache service when the call to API is actually made. Avoid logging when requests are served from in-flight observable or from cached response.