### PR TITLE
Adding event message body to integrate with case submission flow

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -147,9 +147,8 @@ export class PortalService {
     }
 
     private iframeReceivedMsg(event: Event): void {
-        console.log("[iFrame] Receiving messsage", event);
+        console.log("[iFrame] Received messsage", event);
         if (!event || !event.data || event.data.signature !== this.portalSignature) {
-            console.log("[iFrame] validation failed, return event", event);
             return;
         }
 
@@ -161,8 +160,6 @@ export class PortalService {
             const info = <StartupInfo>data;
             this.sessionId = info.sessionId;
             this.startupInfoObservable.next(info);
-            console.log("[iFrame] Received send-startupinfo, event", event);
-            console.log("[iFrame] Sending log message now, event", event);
             this.logMessage(LogEntryLevel.Warning, 'Sending log message from Iframe');
         } else if (methodName === Verbs.sendAppInsightsResource) {
             const aiResource = data;
@@ -197,7 +194,6 @@ export class PortalService {
                 kind: verb,
                 data: data
             }, this.shellSrc);
-            console.log("[IFrame] post message", verb, data);
         }
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -147,7 +147,6 @@ export class PortalService {
     }
 
     private iframeReceivedMsg(event: Event): void {
-        console.log("[iFrame] Received messsage", event);
         if (!event || !event.data || event.data.signature !== this.portalSignature) {
             return;
         }

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -89,8 +89,8 @@ export class PortalService {
         window.addEventListener(Verbs.message, this.iframeReceivedMsg.bind(this), false);
 
         // This is a required message. It tells the shell that your iframe is ready to receive messages.
-        this.postMessage(Verbs.ready, null);
-        this.postMessage(Verbs.getStartupInfo, null);
+        this.postMessage(Verbs.ready, JSON.stringify({eventType: "ready"}));
+        this.postMessage(Verbs.getStartupInfo, JSON.stringify({eventType: "get-startup-info"}));
 
         this._broadcastService.subscribe<ErrorEvent>(BroadcastEvent.Error, error => {
             if (error.details) {
@@ -118,7 +118,8 @@ export class PortalService {
     }
 
     logAction(subcomponent: string, action: string, data?: any): void {
-        const actionStr = JSON.stringify(<Action>{
+        const actionStr = JSON.stringify({
+            eventType: "log-action",
             subcomponent: subcomponent,
             action: action,
             data: data

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -154,13 +154,12 @@ export class PortalService {
 
         const data = event.data.data;
         const methodName = event.data.kind;
-        console.log('[iFrame] Received mesg: ' + methodName, event);
+        console.log('[iFrame] Received validated mesg: ' + methodName, event);
 
         if (methodName === Verbs.sendStartupInfo) {
             const info = <StartupInfo>data;
             this.sessionId = info.sessionId;
             this.startupInfoObservable.next(info);
-            this.logMessage(LogEntryLevel.Warning, 'Sending log message from Iframe');
         } else if (methodName === Verbs.sendAppInsightsResource) {
             const aiResource = data;
             this.appInsightsResourceObservable.next(aiResource);

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -160,6 +160,9 @@ export class PortalService {
             const info = <StartupInfo>data;
             this.sessionId = info.sessionId;
             this.startupInfoObservable.next(info);
+            console.log("[iFrame] Received send-startupinfo, event", event);
+            console.log("[iFrame] Sending log message now, event", event);
+            this.logMessage(LogEntryLevel.Warning, 'Sending log message from Iframe');
         } else if (methodName === Verbs.sendAppInsightsResource) {
             const aiResource = data;
             this.appInsightsResourceObservable.next(aiResource);
@@ -193,6 +196,7 @@ export class PortalService {
                 kind: verb,
                 data: data
             }, this.shellSrc);
+            console.log("[IFrame] post message", verb, data);
         }
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -146,8 +146,9 @@ export class PortalService {
     }
 
     private iframeReceivedMsg(event: Event): void {
-
+        console.log("[iFrame] Receiving messsage", event);
         if (!event || !event.data || event.data.signature !== this.portalSignature) {
+            console.log("[iFrame] validation failed, return event", event);
             return;
         }
 


### PR DESCRIPTION
Currently the new Frame control from case submission team won't be able to get the message if there is not message object payload. Adding the payload with event type so they can register listener on these events.