### PR TITLE
Fix Diagnose and Solve loading issue on IE

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
@@ -33,6 +33,7 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+import 'core-js/es7/object';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
@@ -35,18 +35,6 @@ import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 import 'core-js/es7/object';
 
-
-if (!Object.entries)
-  Object.entries = function( obj ){
-    var ownProps = Object.keys( obj ),
-        i = ownProps.length,
-        resArray = new Array(i); // preallocate the Array
-    while (i--)
-      resArray[i] = [ownProps[i], obj[ownProps[i]]];
-
-    return resArray;
-  };
-
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 

--- a/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
@@ -35,6 +35,18 @@ import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 import 'core-js/es7/object';
 
+
+if (!Object.entries)
+  Object.entries = function( obj ){
+    var ownProps = Object.keys( obj ),
+        i = ownProps.length,
+        resArray = new Array(i); // preallocate the Array
+    while (i--)
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
+  };
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 

--- a/AngularApp/projects/applens/src/polyfills.ts
+++ b/AngularApp/projects/applens/src/polyfills.ts
@@ -33,6 +33,7 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+import 'core-js/es7/object';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
There is a known issue on IE to find object.entries:
![image](https://user-images.githubusercontent.com/38216903/90291129-0b736900-de34-11ea-950b-1893799132a1.png)

https://stackoverflow.com/questions/42446062/object-doesnt-support-property-or-method-entries

Localhost IFrame doesn't work for IE, I have deployed the fix in staging:
https://ms.portal.azure.com/?websitesextension_ext=asd.env%3Dstaging#@microsoft.onmicrosoft.com/resource/subscriptions/c1972e9d-b3c7-4de4-acb3-681773b28ced/resourceGroups/cindybuggyapp/providers/Microsoft.Web/sites/cindybuggyapp20190611092617/troubleshoot