### PR TITLE
Attempt to fix IE angular react issue

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/polyfills.ts
@@ -34,6 +34,8 @@ import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 import 'core-js/es7/object';
+import 'core-js/es7/array';
+import 'core-js/es7/string';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/AngularApp/projects/applens/src/polyfills.ts
+++ b/AngularApp/projects/applens/src/polyfills.ts
@@ -34,6 +34,8 @@ import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 import 'core-js/es7/object';
+import 'core-js/es7/array';
+import 'core-js/es7/string';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
In IE browser, includes() method is not supported:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes

We got exceptions when includes() method is used in our code or dependancy library:

https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%224c544eb0-e1e7-11ea-88dc-f1a0491e8ea5%22,%22timestamp%22:%222020-08-19T06:43:30.598Z%22%7D/ComponentId/%7B%22Name%22:%22DiagnoseAndSolvePortal%22,%22ResourceGroup%22:%22DiagnoseAndSolve%22,%22SubscriptionId%22:%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%7D