### PR TITLE
Minor fix for collapsible for CPU Monitoring for IE11

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/collapsible-list/collapsible-list.component.scss
@@ -13,6 +13,8 @@
     -ms-user-select: none; /* IE10+ */
     -o-user-select: none;
     user-select: none;
+    background-color: transparent;
+    text-align: left;
 }
 .collapse-icon{
     /*float:right;*/


### PR DESCRIPTION
Currently in IE 11, this is how the CPU monitoring page is rendered. 


![image](https://user-images.githubusercontent.com/5299838/92641514-80837280-f2fc-11ea-9ad3-39fe8aba1344.png)

Fixing it to look like Edge

![image](https://user-images.githubusercontent.com/5299838/92641578-95f89c80-f2fc-11ea-9004-91d09d83966b.png)


