### PR TITLE
Fix highchart type error: Cannot read property 'call' of undefined at SVGGElement.

### DIFF
--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -54,7 +54,7 @@
     "hammerjs": "^2.0.8",
     "highcharts": "^8.1.2",
     "highcharts-angular": "^2.4.0",
-    "highcharts-custom-events": "^2.2.2",
+    "highcharts-custom-events": "^3.0.9",
     "ie-shim": "^0.1.0",
     "jquery": "^3.4.1",
     "moment": "^2.22.1",

--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -1,19 +1,18 @@
 import * as momentNs from 'moment';
 import { Component, Input, OnInit, HostListener, ElementRef, Output, EventEmitter } from '@angular/core';
 import { TimeSeriesType } from '../../models/detector';
-import * as Highcharts from 'highcharts';
 import HC_exporting from 'highcharts/modules/exporting';
-import * as HC_customEvents_ from 'highcharts-custom-events';
 import AccessibilityModule from 'highcharts/modules/accessibility';
 import { DetectorControlService } from '../../services/detector-control.service';
 import { HighChartTimeSeries } from '../../models/time-series';
 import { xAxisPlotBand, xAxisPlotBandStyles, zoomBehaviors, XAxisSelection } from '../../models/time-series';
 import { KeyValue } from '@angular/common';
 
-const HC_customEvents = HC_customEvents_;
+declare var require: any
+var Highcharts = require('highcharts'),
+HighchartsCustomEvents = require('highcharts-custom-events')(Highcharts);
 HC_exporting(Highcharts);
 AccessibilityModule(Highcharts);
-HC_customEvents(Highcharts);
 
 const moment = momentNs;
 


### PR DESCRIPTION
This is a potential fix for this service health item
User Story 1513: [Diagnose and Solve Portal] Cannot read property 'call' of undefined at SVGGElement.<anonymous>

The exceptions are from this customEvents javascript in highchart library:

customEvents.js: line 370

**events[event].call(elemObj, e);**