### PR TITLE
Accessibility bug fix for non-expandable insights

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -148,6 +148,7 @@ export class HighchartsGraphComponent implements OnInit {
                 var textStr = statusToSet ? "All": "None";
                 var ariaLabel= statusToSet ? "Select all the series" : "Deselect all the series";
                 this.attr({
+                    role: 'button',
                     text: textStr,
                     "aria-label": ariaLabel,
                 });

--- a/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/insights-v4/insights-v4.component.html
@@ -19,7 +19,7 @@
               <div style="display: table-cell;width:100%">
                 {{insight.title}}
               </div>
-              <div [hidden]="!hasContent(insight)" style="display: table-cell" class="pull-right">
+              <div *ngIf="hasContent(insight)" style="display: table-cell" class="pull-right">
                 <span tabindex="0" class="fa insight-expand-icon" [class.fa-angle-right]="hasContent(insight) && !insight.isExpanded"
                   [class.fa-angle-down]="hasContent(insight) && insight.isExpanded"></span>
               </div>


### PR DESCRIPTION
According to accessibility team, if the insight is not an interactive element, it should not be focused.