### PR TITLE
Allow users to 'Connect' when multiple apps connected to same AI resource

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.html
@@ -11,7 +11,7 @@
             <div *ngIf="isAppInsightsEnabled">
               <div *ngIf="!isAppInsightsConnected">
                 <div *ngIf="hasWriteAccess">
-                  <table *ngIf="hasWriteAccess && !isAppInsightsConnected">
+                  <table *ngIf="hasWriteAccess && !isAppInsightsConnected && canCreateApiKeys">
                     <tbody>
                       <tr>
                         <td><i class="fa fa-exclamation-triangle warning-icon-color mr-2"></i>
@@ -32,6 +32,11 @@
                       </tr>
                     </tbody>
                   </table>
+                  <div *ngIf="!canCreateApiKeys">
+                    <i class="fa fa-exclamation-triangle warning-icon-color mr-2 "></i>
+                    Application Insights is enabled for this app but there are already 10 API Keys generated for this
+                    App Insights resource and you cannot generate more API keys for the same AppInsights resource.
+                  </div>
                 </div>
                 <div *ngIf="!hasWriteAccess">
                   <i class="fa fa-exclamation-triangle warning-icon-color mr-2 "></i>

--- a/AngularApp/projects/diagnostic-data/src/lib/services/appinsights.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/appinsights.service.ts
@@ -54,5 +54,9 @@ export class AppInsightsQueryService {
     getAppInsightsArmTag(resourceUri: string): Observable<any> {
         return null;
     }
+
+    getAppInsightsApiKeysCount(): Observable<number> {
+        return null;
+    }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -55,6 +55,7 @@ export const TelemetryEventNames = {
     AppInsightsFromDifferentSubscription: 'AppInsightsFromDifferentSubscription',
     AppInsightsAccessCheckError: 'AppInsightsAccessCheckError',
     AppInsightsResourceMissingWriteAccess: 'AppInsightsResourceMissingWriteAccess',
+    AppInsightsMaxApiKeysExceeded: 'AppInsightsMaxApiKeysExceeded',
     AppInsightsConfigurationInvalid: 'AppInsightsConfigurationInvalid',
     SummaryCardClicked: 'SummaryCardClicked',
     ToolCardClicked: 'ToolCardClicked',


### PR DESCRIPTION
Currently we delete the existing APPSERVICEDIAGNOSTICS_READONLYKEY API key when someone tries to click Connect on our AI integration page. This causes problems when multiple apps are connected to same AI resource.


ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
[1532 ](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1532/)| ASD Integration with AppInsights breaks if same AI resource used on multiple web apps | app-service-diagnostics-portal\Backlog | New | Service Health | 1 | 9/24/2020, 7:16:07 PM

With this PR
1. We will not delete the existing APPSERVICEDIAGNOSTICS_READONLYKEY API keys
2. We will create a key with name like this `APPSERVICEDIAGNOSTICS_READONLYKEY_<SITENAME>_<RANDOMNUMBER>`
3. If there are already 10 API keys, the UI will throw a warning message and we will log telemetry event `AppInsightsMaxApiKeysExceeded`

`Application Insights is enabled for this app but there are already 10 API Keys generated for this App Insights resource and you cannot generate more API keys for the same AppInsights resource.`


Also, all the App Insights queries in detectors should explicitly check for **cloud_RoleName**. This field is combination of site name and slot name.