### PR TITLE
Updated Deep Search to be enabled only for specific Products

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
@@ -47,12 +47,12 @@ export class DocumentSearchService {
           this.featureEnabledForProduct = true;
     }
 
-   let deepSearchEnabled = this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
+    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
                             // Value in App Service Application Settings are returned as strings 
                             // converting this to boolean
                             .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForProduct) );    
     
-    return  deepSearchEnabled;
+    
   }
 
   private constructUrl(query: Query) : string{

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import {HttpClient, HttpHeaders} from "@angular/common/http"
 import { Observable } from 'rxjs';
-import { Query, Document } from 'diagnostic-data';
+import { Query, Document , DocumentSearchConfiguration } from 'diagnostic-data';
 import { BackendCtrlService } from '../../shared/services/backend-ctrl.service';
 
 
@@ -11,11 +11,17 @@ import { BackendCtrlService } from '../../shared/services/backend-ctrl.service';
 export class DocumentSearchService {
   private authKey: string = "";
   private url : string = "";
+  private _config : DocumentSearchConfiguration;
+  private featureEnabledForProduct: boolean = false;
+
   httpOptions = {}
 
   constructor(  private http: HttpClient,
-                private _backendApi :BackendCtrlService
+                private _backendApi :BackendCtrlService                
               ) { 
+      
+      this._config = new DocumentSearchConfiguration();;
+
       this._backendApi.get<string>(`api/appsettings/DeepSearch:Endpoint`).subscribe((value: string) =>{
         this.url = value;
       });
@@ -32,12 +38,21 @@ export class DocumentSearchService {
         
   }
   
-  public IsEnabled() : Observable<boolean> {
-    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
+  public IsEnabled(pesId : string, isPublic : boolean) : Observable<boolean> {
+    // featureEnabledForProduct is disabled by default
+    if ( pesId.length >0 && ( (isPublic && this._config.documentSearchEnabledPesIds.findIndex(x => x==pesId)>=0) || 
+                              (!isPublic && this._config.documentSearchEnabledPesIdsInternal.findIndex(x => x==pesId)>=0)
+                            ) 
+        ){
+          this.featureEnabledForProduct = true;
+    }
+
+   let deepSearchEnabled = this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
                             // Value in App Service Application Settings are returned as strings 
                             // converting this to boolean
-                            .map(status =>  ( status.toLowerCase() == "true") );    
-                            
+                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForProduct) );    
+    
+    return  deepSearchEnabled;
   }
 
   private constructUrl(query: Query) : string{

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
@@ -45,12 +45,12 @@ export class ApplensDocumentsSearchService {
           this.featureEnabledForProduct = true;
     }
 
-   let deepSearchEnabled = this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
+    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
                             // Value in App Service Application Settings are returned as strings 
                             // converting this to boolean
                             .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForProduct) );    
     
-    return  deepSearchEnabled;
+    
   }
 
   private constructUrl(query: Query) : string{

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import {HttpClient, HttpHeaders} from "@angular/common/http"
 import { Observable } from 'rxjs';
-import { Query, Document } from 'diagnostic-data';
+import { Query, Document, DocumentSearchConfiguration } from 'diagnostic-data';
 import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.service';
 
 @Injectable({
@@ -10,11 +10,16 @@ import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.se
 export class ApplensDocumentsSearchService {
   private authKey: string = "";
   private url : string = "";
+  private _config : DocumentSearchConfiguration;
+  private featureEnabledForProduct : boolean = false; 
+
   httpOptions = {}
 
   constructor(  private http: HttpClient,
-                private _backendApi : DiagnosticApiService 
+                private _backendApi : DiagnosticApiService                 
               ) { 
+    
+    this._config = new DocumentSearchConfiguration();
     this._backendApi.get<string>(`api/appsettings/DeepSearch:Endpoint`).subscribe((value: string) =>{
       this.url = value;
     });
@@ -31,12 +36,21 @@ export class ApplensDocumentsSearchService {
     
   }
 
-  public IsEnabled() : Observable<boolean> {
-    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
+  public IsEnabled(pesId : string, isPublic : boolean) : Observable<boolean> {
+    // featureEnabledForProduct is disabled by default
+    if ( pesId.length >0 && ( (isPublic && this._config.documentSearchEnabledPesIds.findIndex(x => x==pesId)>=0) || 
+                              (!isPublic && this._config.documentSearchEnabledPesIdsInternal.findIndex(x => x==pesId)>=0)
+                            ) 
+        ){
+          this.featureEnabledForProduct = true;
+    }
+
+   let deepSearchEnabled = this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
                             // Value in App Service Application Settings are returned as strings 
                             // converting this to boolean
-                            .map(status =>  ( status.toLowerCase() == "true") );    
-                            
+                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForProduct) );    
+    
+    return  deepSearchEnabled;
   }
 
   private constructUrl(query: Query) : string{

--- a/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
@@ -11,6 +11,7 @@ import { v4 as uuid } from 'uuid';
 import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagnostic-data-config';
 import { GenericDocumentsSearchService } from '../../services/generic-documents-search.service';
 import { Query } from '../../models/documents-search-models';
+import { GenericResourceService } from '../../services/generic-resource-service';
 
 
 @Component({
@@ -28,7 +29,7 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
   viewResultsFromCSSWikionly : boolean = true;
   viewRemainingDocuments : boolean = false;
   isPublic : boolean = true;
-
+  pesId : string = "";
   searchTermDisplay = ""
   preLoadingErrorMessage: string = "Some error occurred while fetching Deep Search results. "
   subscription: ISubscription;
@@ -45,12 +46,14 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
               private _documentsSearchService : GenericDocumentsSearchService,
               public telemetryService: TelemetryService,
               private _activatedRoute: ActivatedRoute ,
-              private _router: Router   ) {
+              private _router: Router,
+              private _resourceService: GenericResourceService   ) {
     super(telemetryService);
  
     this.isPublic = config && config.isPublic;
     const subscription = this._activatedRoute.queryParamMap.subscribe(qParams => {
       this.searchTerm = qParams.get('searchTerm') === null ? "" || this.searchTerm : qParams.get('searchTerm');
+      this.getPesId();
       this.checkIfEnabled();
   });
 
@@ -66,9 +69,16 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
     this.subscription.unsubscribe();
   }
 
+  getPesId(){
+    this._resourceService.getPesId().subscribe(pesId => {
+      this.pesId = pesId;
+    });
+    
+  }
+
   checkIfEnabled () {
     let checkStatusTask = this._documentsSearchService
-                         .IsEnabled()
+                         .IsEnabled(this.pesId, this.isPublic )
                          .pipe( map((res) => res), 
                                 retryWhen(errors => {
                                 let numRetries = 0;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
@@ -11,6 +11,7 @@ import { of, Observable } from 'rxjs';
 import { ISubscription } from "rxjs/Subscription";
 import { WebSearchConfiguration } from '../../models/search';
 import { GenericDocumentsSearchService } from '../../services/generic-documents-search.service';
+import { GenericResourceService } from '../../services/generic-resource-service';
 
 @Component({
     selector: 'web-search',
@@ -29,6 +30,7 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
     @Input() searchResults: any[] = [];
     @Input() numArticlesExpanded : number = 2;
     @Output() searchResultsChange: EventEmitter<any[]> = new EventEmitter<any[]>();
+    pesId : string = "";
 
     searchTermDisplay: string = '';
     showSearchTermPractices: boolean = false;
@@ -39,12 +41,14 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
     
     constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig, public telemetryService: TelemetryService,
         private _activatedRoute: ActivatedRoute, private _router: Router, private _contentService: GenericContentService,
-        private _documentsSearchService : GenericDocumentsSearchService,) {
+        private _documentsSearchService : GenericDocumentsSearchService,
+        private _resourceService: GenericResourceService  ) {
         super(telemetryService);
         this.isPublic = config && config.isPublic;
         const subscription = this._activatedRoute.queryParamMap.subscribe(qParams => {
             this.searchTerm = qParams.get('searchTerm') === null ? "" || this.searchTerm : qParams.get('searchTerm');
-            this.checkIfDeepSearchIsEnabled ();
+            this.getPesId();
+            this.checkIfDeepSearchIsEnabled();
             this.refresh();
         });
         this.subscription = subscription;
@@ -169,10 +173,17 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
     showRemainingArticles(){
         this.viewRemainingArticles =!this.viewRemainingArticles
       }
+
+    getPesId(){
+    this._resourceService.getPesId().subscribe(pesId => {
+        this.pesId = pesId;
+    });
+    
+    }
     
     checkIfDeepSearchIsEnabled () {
     let checkStatusTask = this._documentsSearchService
-                            .IsEnabled()
+                            .IsEnabled(this.pesId, this.isPublic )
                             .pipe( map((res) => res), 
                                 retryWhen(errors => {
                                 let numRetries = 0;

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
@@ -1,0 +1,4 @@
+export class DocumentSearchConfiguration{
+    documentSearchEnabledPesIds: string[] = ["14748", "16072", "16170"];
+    documentSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170"];
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
@@ -5,7 +5,7 @@ import { Query } from '../models/documents-search-models';
 @Injectable()
 export class GenericDocumentsSearchService {
 
-  public IsEnabled() : Observable<boolean> {
+  public IsEnabled(pesId:string, isPublic : boolean) : Observable<boolean> {
     return null;
   }
   public Search(query:Query): Observable<any> {

--- a/AngularApp/projects/diagnostic-data/src/public_api.ts
+++ b/AngularApp/projects/diagnostic-data/src/public_api.ts
@@ -37,6 +37,7 @@ export * from './lib/models/compilation-properties';
 export * from './lib/models/solution-type-tag';
 export * from './lib/models/resource-descriptor';
 export * from './lib/models/documents-search-models';
+export * from './lib/models/documents-search-config';
 
 export * from './lib/components/detector-list-analysis/detector-list-analysis.component'
 


### PR DESCRIPTION
- Added a new Config file which has a list of Products for which Deep Search is enabled
- Added methods in component to get PesId 
- Deep Search's IsEnabled method considers PesId and IsPublic 