### PR TITLE
Enable DaaS sessions link on ILB ASE

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -39,7 +39,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     constructor(private _windowService: WindowService, private _serverFarmService: ServerFarmDataService, private _daasService: DaasService, protected _route: ActivatedRoute, public globals: Globals, public telemetryService: TelemetryService) {
         this._serverFarmService.siteServerFarm.subscribe(serverFarm => {
             if (serverFarm) {
-                if (serverFarm.sku.tier === 'Standard' || serverFarm.sku.tier === 'Basic' || serverFarm.sku.tier.indexOf('Premium') > -1) {
+                if (serverFarm.sku.tier === 'Standard' || serverFarm.sku.tier === 'Basic' || serverFarm.sku.tier === 'Isolated' ||  serverFarm.sku.tier.indexOf('Premium') > -1) {
                     this.supportedTier = true;
                 }
             }


### PR DESCRIPTION
The View All Sessions link is not coming in the tools today for ILB ASE 

![image](https://user-images.githubusercontent.com/5299838/95092418-39df3780-0745-11eb-9566-d05063cc5fe3.png)

Earlier customers had a way to get to Diagnostic Sessions from other places so maybe that's why no one reported this issue earlier.