### PR TITLE
Update AzureActiveDirectory to latest

### DIFF
--- a/ApplensBackend/AppLensV3.csproj
+++ b/ApplensBackend/AppLensV3.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="Sendgrid" Version="9.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.108" />


### PR DESCRIPTION
- Update AzureAd from 3.17 to 5.2 to factor for new clouds otherwise we will get WinHttpExceptions with server name not resolved errors.