### PR TITLE
Fix the formatting of AKS detector view

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.html
@@ -1,5 +1,5 @@
 <detector-control *ngIf="(!hideDetectorControl && !hideTimerPicker && detectorResponse && !analysisMode) || isPopoutFromAnalysis"></detector-control>
-<div [ngStyle]="{'padding-top': hideTimerPicker? '10px': '0px'}" style="padding-left: 20px; padding-right: 20px; min-height: 240px;"  >
+<div [ngStyle]="{'padding-top': hideTimerPicker? '10px': '0px', 'min-height.px': isPublic? '0': '240'}" style="padding-left: 20px; padding-right: 20px;"  >
   <detector-view [analysisMode]="analysisMode" [isAnalysisView]="isAnalysisView" [detectorResponse]="detectorResponse" [error]="error" [startTime]="getStartTime" [endTime]="getEndTime"
    [developmentMode]="false" [detector]="detectorName" (downTimeChanged)="onDowntimeChanged($event)" (XAxisSelection)="onXAxisSelection($event)" [hideDetectorHeader]="hideDetectorControl"
    [isCategoryOverview]="isCategoryOverview" [isPopoutFromAnalysis]="isPopoutFromAnalysis">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -8,6 +8,8 @@ import { VersionService } from '../../services/version.service';
 import { Moment } from 'moment';
 import * as momentNs from 'moment';
 import { XAxisSelection } from '../../models/time-series';
+import { DiagnosticDataConfig, DIAGNOSTIC_DATA_CONFIG } from 'diagnostic-data';
+import { Inject } from '@angular/core';
 const moment = momentNs;
 
 @Component({
@@ -31,6 +33,8 @@ export class DetectorContainerComponent implements OnInit {
   detectorName: string;
   detectorRefreshSubscription: any;
   refreshInstanceIdSubscription: any;
+  isPublic: boolean = true;
+
 
   @Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
@@ -50,7 +54,8 @@ export class DetectorContainerComponent implements OnInit {
   isCategoryOverview: boolean = false;
   private isLegacy: boolean
   constructor(private _route: ActivatedRoute, private _diagnosticService: DiagnosticService,
-    public detectorControlService: DetectorControlService, private versionService: VersionService) {
+    public detectorControlService: DetectorControlService, private versionService: VersionService, @Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
+        this.isPublic = config && config.isPublic;
   }
 
   get isPopoutFromAnalysis(): boolean {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -8,7 +8,7 @@ import { VersionService } from '../../services/version.service';
 import { Moment } from 'moment';
 import * as momentNs from 'moment';
 import { XAxisSelection } from '../../models/time-series';
-import { DiagnosticDataConfig, DIAGNOSTIC_DATA_CONFIG } from 'diagnostic-data';
+import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagnostic-data-config';
 import { Inject } from '@angular/core';
 const moment = momentNs;
 


### PR DESCRIPTION
This is regarding to the issue that we are seeing a blank space for AKS detector, because of no detector view was rendered within an analysis:

![image](https://user-images.githubusercontent.com/38216903/96637757-fb648380-12d3-11eb-9b29-9578dbb1de88.png)
