### PR TITLE
Fix diagnostic tools not showing up for premium v3 and other new onboarded skus

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/pipes/site-filter.pipe.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/pipes/site-filter.pipe.ts
@@ -14,7 +14,7 @@ export class WebSiteFilter implements PipeTransform {
             .filter(item =>
                 (item.appType & this._webSiteService.appType) > 0 &&
                 (item.platform & this._webSiteService.platform) > 0 &&
-                (item.sku == Sku.All || item.sku & this._webSiteService.sku) > 0 &&
+                (item.sku === Sku.All || item.sku === Sku.NotDynamic && this._webSiteService.sku != Sku.Dynamic || item.sku & this._webSiteService.sku) > 0 &&
                 (item.hostingEnvironmentKind & this._webSiteService.hostingEnvironmentKind) > 0 &&
                 (item.stack === ''
                     || (overrideStack && (overrideStack === '' || overrideStack.toLowerCase() === 'all'))


### PR DESCRIPTION
Right now whenever there is a new sku onboarded, we need to add a new value to serverfarm.ts for the new sku, and change the values for "Paid", "NotDynamic", "All"

export enum Sku {
    Free = 1 << 0,
    Shared = 1 << 1,
    Dynamic = 1 << 2,
    Basic = 1 << 3,
    Standard = 1 << 4,
    Premium = 1 << 5,
    PremiumV2 = 1 << 6,
    Isolated = 1 << 7,
    PremiumContainer = 1 << 8,
    Paid = 504,         // 111111000
    NotDynamic = 507,   // 111111011
    All = 511           // 111111111
}

Adding the logic in filter to allow "Diagnostic Tools " showing up for all the non-dynamic sku without add new sku enum