### PR TITLE
Remove duplicate tools in category-nav

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
@@ -127,7 +127,7 @@ export class CategoryNavComponent implements OnInit {
             stack: '',
             item: {
                 title: 'Proactive Tools',
-                tools: this.siteFeatureService.proactiveTools.map(tool => {
+                tools: this.siteFeatureService.proactiveTools.filter(tool => this.stackMatchedForTools(tool)).map(tool => {
                     let isSelected = () => {
                         return this._route.url.endsWith("/" + tool.item.id);
                     };

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
@@ -145,7 +145,7 @@ export class CategoryNavComponent implements OnInit {
             stack: '',
             item: {
                 title: 'Diagnostic Tools',
-                tools: this.siteFeatureService.diagnosticTools.map(tool => {
+                tools: this.siteFeatureService.diagnosticTools.filter(tool => this.stackMatchedForTools(tool)).map(tool => {
                     let isSelected = () => {
                         return this._route.url.endsWith("/" + tool.item.id);
                     };
@@ -163,7 +163,7 @@ export class CategoryNavComponent implements OnInit {
             stack: '',
             item: {
                 title: 'Support Tools',
-                tools: this.siteFeatureService.supportTools.map(tool => {
+                tools: this.siteFeatureService.supportTools.filter(tool => this.stackMatchedForTools(tool)).map(tool => {
                     let isSelected = () => {
                         return this._route.url.endsWith("/" + tool.item.id);
                     };
@@ -261,5 +261,13 @@ export class CategoryNavComponent implements OnInit {
     private getIconImagePath(name: string) {
         const fileName = icons.has(name) ? name : 'default';
         return `${this.imageRootPath}/${fileName}.svg`;
+    }
+
+    private stackMatchedForTools(item: SiteFilteredItem<any>): boolean {	
+        return (item.appType & this._webSiteService.appType) > 0 &&	
+            (item.platform & this._webSiteService.platform) > 0 &&	
+            (item.sku & this._webSiteService.sku) > 0 &&	
+            (item.hostingEnvironmentKind & this._webSiteService.hostingEnvironmentKind) > 0 &&	
+            (!this.toolsAlreadyAdded(item.item));	
     }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -162,7 +162,7 @@ export class WebSitesService extends ResourceService {
 
         this.appType = site.kind.toLowerCase().indexOf('functionapp') >= 0 ? AppType.FunctionApp : AppType.WebApp;
         this.platform = site.kind.toLowerCase().indexOf('xenon') >= 0 ? OperatingSystem.HyperV : site.kind.toLowerCase().indexOf('linux') >= 0 ? OperatingSystem.linux : OperatingSystem.windows;
-        this.sku = Sku[site.sku];
+        this.sku = Sku[site.sku] ? Sku[site.sku] : this.sku;
         this.hostingEnvironmentKind = this.getHostingEnvirontmentKind(site);
     }
 


### PR DESCRIPTION
This is for fixing duplicate tools in category-nav component. 

This is caused by not filtering stack for tools and I added **stackMatchedForTools()** method back to resolve issue.

Before fixing,
![image](https://user-images.githubusercontent.com/23129934/97640725-a117a100-19fe-11eb-9068-e9f54bdf4533.png)

After fixing,
![image](https://user-images.githubusercontent.com/23129934/97640973-1c795280-19ff-11eb-8475-ddd2a64ba561.png)
