### PR TITLE
Disabling detector search for logic apps and apim

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
@@ -41,7 +41,7 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
     @ViewChild ('charAlertRef', {static: false}) charAlertRef: ElementRef;
     @ViewChild ('searchInputBox', {static: false}) searchInputBox: ElementRef;
     @ViewChild ('searchResultsSection', {static: false}) searchResultsSection: ElementRef;
-    detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15791", "15551"];
+    detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170"];
     detectorSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170", "16450", "15791", "15551"];
     startTime: Moment;
     endTime: Moment;


### PR DESCRIPTION
It seems for logic apps and apim, the geomaster is not passing over the query term to Runtime host api due to which search is not fired.
Will disable the detector search for logic apps and apim for now and work on enabling the geomaster flow.