### PR TITLE
Enable all ST's for web app windows and linux for CXP chat.

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -99,36 +99,14 @@ export class WebSitesService extends ResourceService {
     public get liveChatEnabledSupportTopicIds(): string[] {
         if (this.isApplicableForLiveChat) {
             if (this.appType === AppType.FunctionApp) {
-                return [];
+                return ['*']; //Enable all support topics for chat. CXP system, performs a check and they can independently enable/disable chats for specific ST's
             }
             else if (this.appType === AppType.WebApp) {
                 if (this.platform === OperatingSystem.windows) {
-                    return [
-                        '32583701', //Availability and Performance/Web App experiencing High CPU
-                        '32542218', //Availability and Performance/Web App Down
-                        '32581616', //Availability and Performance/Web App experiencing High Memory Usage
-                        '32457411', //Availability and Performance/Web App Slow
-                        '32570954', //Availability and Performance/Web App Restarted
-                        '32440123', //Configuration and Management/Configuring SSL
-                        '32440122', //Configuration and Management/Configuring custom domain names
-                        '32542210', //Configuration and Management/IP Configuration
-                        '32581615', //Configuration and Management/Deployment Slots
-                        '32542208', //Configuration and Management/Backup and Restore
-                        '32589277', //How Do I/Configure domains and certificates,
-                        '32589281', //How Do I/IP Configuration
-                        '32588774', // Deployment/Visual Studio
-                        '32589276' //How Do I/Backup and Restore
-                    ];
+                    return ['*']; //Enable all support topics for chat. CXP system, performs a check and they can independently enable/disable chats for specific ST's
                 }
                 else if (this.platform === OperatingSystem.linux) {
-                    return [
-                        '32542218', //Availability and Performance/Web App Down
-                        '32570954', //Availability and Performance/Web App Restarted
-                        '32440123', //Configuration and Management/Configuring SSL
-                        '32440122', //Configuration and Management/Configuring custom domain names
-                        '32542208', //Configuration and Management/Backup and Restore
-                        '32542210' //Configuration and Management/IP Configuration
-                    ];
+                    return ['*']; //Enable all support topics for chat. CXP system, performs a check and they can independently enable/disable chats for specific ST's
                 }
                 else {
                     return [];


### PR DESCRIPTION
Enable all ST's for web app windows and linux for CXP chat. CXT team can independently enable/disable chats within their system.