### PR TITLE
Enabled detector search for APIM in public portal

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
@@ -2,7 +2,7 @@ interface PreferredSitesConfig {
     [index: string]: string[];
 }
 
-export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170"];
+export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15551"];
 export var detectorSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170", "16450", "15791", "15551"];
 
 var globalExcludedSites = ["aws.amazon.com", "twitter.com"];


### PR DESCRIPTION
APIM is currently passing the text parameter in /detectors route in their RP, so the detector search works.