### PR TITLE
Add new error for investigation "MissingApiVersionParameter" exception

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -124,8 +124,17 @@ export class ArmService {
         if(!resourceUri || resourceUri === "/"){
             throw new Error("Empty ResourceUri for ARM Call");
         }
-        return `${this.armUrl}${resourceUri}${resourceUri.indexOf('?') >= 0 ? '&' : '?'}` +
-            `api-version=${this.getApiVersion(resourceUri, apiVersion)}`;
+
+        const uri = `${this.armUrl}${resourceUri}${resourceUri.indexOf('?') >= 0 ? '&' : '?'}` +
+        `api-version=${this.getApiVersion(resourceUri, apiVersion)}`
+        
+        //Temporary solution for checking dependency call for missing api version exception, will remove after resolve exception
+        const exceptionUri = "management.azure.com/?clientOptimizations=undefined&l=en.en-us&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#";
+        if(uri.includes(exceptionUri)){
+            throw new Error("ARM Call Cause MissingApiVersionParameter Exception");
+        }
+
+        return uri;
     }
 
     getResource<T>(resourceUri: string, apiVersion?: string, invalidateCache: boolean = false): Observable<{} | ResponseMessageEnvelope<T>> {


### PR DESCRIPTION
Please refer [Bug_1593](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1593) about my investigation so far.

Basically, all exceptions are from dependency calls like this,
 **"https://management.azure.com/?clientOptimizations=undefined&l=nl.nl-nl&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#02261aef02bc430fae3e00b4d31b28f1&api-version=2015-08-01"** 
and I have no idea about where we call this endpoint, so I throw new error as long as there is an ARM call with similar format.

I checked all calls with this format will be failed so we should no need to worry about performance impact.



[Go to Log Analytics and run query](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fc1972e9d-b3c7-4de4-acb3-681773b28ced%2FresourceGroups%2FDiagnoseAndSolve%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FDiagnoseAndSolvePortal/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA3WOQUsEMQyF7wPzH%252BqIwy7oDC6ehCoi7NWb99BmdgJtWpoUcfDHW1GYkxBIeHl873nMyB7ZEUrffZmPFQsapYiiELN5sgYu6XD%252F4I%252F7myGicYkViMUMq2qWx3mOwHDBiKwTbLXg5FKcn12gprzlxqQNlBKLrS1yIUY%252FBos8Id9VGbVUUfQvVddUSD%252FtL%252FfmdG6TU1EIO3eUFUN4xyINuPOuh5%252BWUmOEQhu2yzkUeU2V1djWuW1aDn%252ByubJmOEMQHI63C1D4z2d3X9%252F13TdpJaEVNQEAAA%253D%253D)
dependencies
| where timestamp >= ago(14d)
| where name contains "https://management.azure.com/?clientOptimizations=undefined&l=en.en-us&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#"
| summarize successCount = countif(success != "False"),failCount = countif(success == "False")


successCount | failCount
-- | --
0 | 599

