### PR TITLE
Enable CXP chat for function apps

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -91,7 +91,7 @@ export class WebSitesService extends ResourceService {
 
     public get isApplicableForLiveChat(): boolean {
         return this.resource
-            && (this.appType & AppType.WebApp) > 0 //Do not enable chat for Function apps
+            && (this.appType & (AppType.WebApp | AppType.FunctionApp)) > 0 //Enable chat for Function apps
             && (this.platform & (OperatingSystem.windows | OperatingSystem.linux)
             ) > 0;
     }


### PR DESCRIPTION
Enable CXP chat for function apps. CXP team will be able to manage which ST's to open up the chat for.