### PR TITLE
Fix for MissingApiVersionParameter

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/fabric-search-results/fabric-search-results.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/fabric-search-results/fabric-search-results.component.ts
@@ -41,7 +41,7 @@ export class FabricSearchResultsComponent {
     } else {
       searchResultAriaLabel = `No results were found.`;
     }
-    return `${searchResultAriaLabel}, Press Escape to clear search result`;
+    return `${searchResultAriaLabel} Press Escape to clear search result`;
   }
 
   @HostListener('mousedown', ['$event.target'])

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
@@ -1,13 +1,13 @@
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { ResourceService } from '../../shared-v2/services/resource.service';
 import { ArmResource } from '../../shared-v2/models/arm';
-import { DetectorControlService } from 'diagnostic-data';
+import { DetectorControlService, TelemetryService } from 'diagnostic-data';
 
 @Injectable()
 export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
-    constructor(private _resourceService: ResourceService, private _detectorControlService: DetectorControlService) { }
+    constructor(private _resourceService: ResourceService, private _detectorControlService: DetectorControlService,private telemetryService: TelemetryService) { }
     // Live Chat Service is included here so that we ensure an instance is created
 
     resolve(activatedRouteSnapshot: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<{} | ArmResource> {
@@ -16,11 +16,26 @@ export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
             this._detectorControlService.setDefault();
         }
 
-        //Try get resourceUri from activatedRoute,if not then get from routerstate
+        //Try get resourceUri from activatedRoute,if not then get from Routerstate
         let resourceUri = activatedRouteSnapshot.parent.url
             .filter(x => x.path !== 'new' && x.path !== 'categories')
             .map(x => x.path)
             .join('/');
+
+        //All dependencies call from below Uri is returning 400, block ARM call
+        const missingApiParamUri = "management.azure.com/?clientOptimizations=undefined&l=en.en-us&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#";
+        if(resourceUri.includes(missingApiParamUri)) {
+            const error = new Error("MissingApiVersionParameter handled at resolver");
+            this.telemetryService.logException(
+                error,
+                "resource.resolver",
+                {
+                    "resourceUri" : resourceUri,  
+                }
+            );
+            return of({});
+        }
+        
         if (!this.checkResourceUri(resourceUri)) {
             const url = state.url;
             const startIndex = url.indexOf("subscriptions/") > -1 ? url.indexOf("subscriptions/") : 0;
@@ -28,10 +43,7 @@ export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
 
             resourceUri = url.substring(startIndex, endIndex);
         }
-        if (!this.checkResourceUri(resourceUri)) {
-            const urlFromActivatedRoute = activatedRouteSnapshot.parent.url.join('/');
-            throw new Error(`Empty ResourceUri from resource.resolver;Activated Route: ${urlFromActivatedRoute}; State Url: ${state.url}`);
-        }
+        
 
         return this._resourceService.registerResource(resourceUri);
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
@@ -41,7 +41,7 @@ export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
 
     //All dependencies call from below Uri is returning 400, block ARM call
     private checkResourceUriMissingApiParam(resourceUri: string): boolean {
-        const missingApiParamUri = "management.azure.com/?clientOptimizations=undefined&l=en.en-us&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#";
+        const missingApiParamUri = "management.azure.com/?clientOptimizations";
         if(resourceUri.includes(missingApiParamUri)) {
             const error = new Error("MissingApiVersionParameter handled at resolver");
             this.telemetryService.logException(


### PR DESCRIPTION
From stack trace issue is caused by **registerResource** passing wrong resourceUri, I added logic to extract resourceUri if in this scenario

I checked in last 14 days all dependency call were failing so I think we should either block this call or modify the resourceUri to get the right ARM call

dependencies
| where timestamp >= ago(14d)
| where name contains "management.azure.com/?clientOptimizations=undefined&l=en.en-us&trustedAuthority=https:%2F%2Fportal.azure.com&shellVersion=undefined#"
| summarize count() by resultCode

resultCode | count_
-- | --
400 | 243
0 | 19







Here is the stack trace,

Error: Uncaught (in promise): Error: ARM Call Cause MissingApiVersionParameter Exception
Error: ARM Call Cause MissingApiVersionParameter Exception
    at e.createUrl (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:6344586)
    at e.getArmResource (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:6346001)
    at t.e.registerResource (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:1157674)
    at e.resolve (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:5425321)
    at Ht (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:856728)
    at https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:865712
    at https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:865980
    at t.project (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:866116)
    at t._tryNext (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:407046)
    at t._next (https://appservice-diagnostics.azurefd.net/main.952181b031b318a7c4fa.js:1:406948)
    at e.createUrl (webpack:///src/app/shared/services/arm.service.ts:134:18)
    at createUrl (webpack:///src/app/shared/services/arm.service.ts:209:25)
    at getArmResource (webpack:///src/app/shared-v2/services/resource.service.ts:162:30)
    at **registerResource** (webpack:///src/app/home/resolvers/resource.resolver.ts:36:37)
    at resolve (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@angular/router/fesm5/router.js.pre-build-optimizer.js:3509:58)
    at webpack:///home/vsts/work/1/s/AngularApp/node_modules/@angular/router/fesm5/router.js.pre-build-optimizer.js:3491:15
    at webpack:///home/vsts/work/1/s/AngularApp/node_modules/@angular/router/fesm5/router.js.pre-build-optimizer.js:3476:18
    at check (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@angular/router/fesm5/router.js.pre-build-optimizer.js:3471:69)
    at project (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/operators/mergeMap.js.pre-build-optimizer.js:60:26)
    at _tryNext (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/operators/mergeMap.js.pre-build-optimizer.js:50:17)
    at P (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:831:30)
    at resolvePromise (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:788:16)
    at webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:892:16
    at apply (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:423:30)
    at invokeTask (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@angular/core/fesm5/core.js.pre-build-optimizer.js:24340:32)
    at onInvokeTask (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:422:59)
    at invokeTask (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:195:46)
    at runTask (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:601:34)
    at drainMicroTaskQueue (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:502:20)
    at call (webpack:///home/vsts/work/1/s/AngularApp/node_modules/zone.js/dist/zone.js.pre-build-optimizer.js:487:47)