### PR TITLE
Completely Block Calls that causing MissingApiParam exception

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
@@ -21,9 +21,12 @@ export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
             .filter(x => x.path !== 'new' && x.path !== 'categories')
             .map(x => x.path)
             .join('/');
-
         
-        if (this.checkResourceUriIsEmpty(resourceUri) || this.checkResourceUriMissingApiParam(resourceUri)) {
+        if(this.checkResourceUriMissingApiParam(resourceUri)) {
+            return of({});
+        }
+        
+        if (this.checkResourceUriIsEmpty(resourceUri)) {
             const url = state.url;
             const startIndex = url.indexOf("subscriptions/") > -1 ? url.indexOf("subscriptions/") : 0;
             let endIndex = url.length;


### PR DESCRIPTION
In my last fix, I was trying to extract the right resource uri from Angular route and send ARM request to fix this exception. But that fix looks like not working as the exception still throwing by **createurl** method in arm service. 

In this PR, I am going to block these requests which will cause MissingApiParam exception since from my previous investigation, exceptions are caused by dependency calls make to "https://management.azure.com/?clientOptimizations..." return with 400.



[App Insight](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fc1972e9d-b3c7-4de4-acb3-681773b28ced%2FresourceGroups%2FDiagnoseAndSolve%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FDiagnoseAndSolvePortal/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0XMQQrCQAxA0X3BO4Su2k2L4EpQFx6gZ4gzoQ00mWGSQSwe3nbl9n94kTJpJA1Mdmq%252B8F6oEDgLmaNkuN8A59SdL7H%252Fb0UhCEkdWQ3axT3bdRwFFWcSUh9wq4WGkGR8hJX3MuXd5A2dk1p7UFZFsPB2SFW96%252BH1gUJWV3%252BmSM0Plj8CB5oAAAA%253D)
dependencies
| where timestamp >= ago(14d)
| where name contains "https://management.azure.com/?clientOptimizations"
| summarize count() by resultCode


resultCode | count_
-- | --
400 | 169
0 | 13

