### PR TITLE
Open panel for homepage risk tile

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.ts
@@ -279,7 +279,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
             {
                 title: "Availability",
                 action: () => {
-                    this._portalService.openBladeDiagnoseDetectorId("RiskAssessments","ParentAvailabilityAndPerformance");
+                    this.globals.openRiskAlertsPanel = true;
+                    this._telemetryService.logEvent(TelemetryEventNames.OpenRiskAlertPanel,{
+                        "Location" : TelemetrySource.LandingPage
+                    });
                 },
                 linkText: "Click here to run all checks",
                 infoObserverable: this.globals.reliabilityChecksDetailsBehaviorSubject.pipe(map(info => RiskHelper.convertToRiskInfo(info))),

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-notification/risk-alerts-notification.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-notification/risk-alerts-notification.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { TelemetryService } from 'diagnostic-data';
+import { TelemetryEventNames, TelemetryService,TelemetrySource } from 'diagnostic-data';
 import { MessageBarType, IMessageBarProps, IMessageBarStyles } from 'office-ui-fabric-react';
 import { throwError } from 'rxjs';
 import { catchError, filter, map } from 'rxjs/operators';
@@ -177,7 +177,9 @@ export class RiskAlertsNotificationComponent implements OnInit {
 
     openRiskAlertsPanel() {
         this.globals.openRiskAlertsPanel = true;
-        this.telemetryService.logEvent("openRiskAlertsPanel");
+        this.telemetryService.logEvent(TelemetryEventNames.OpenRiskAlertPanel,{
+            'Location': TelemetrySource.CaseSubmissionFlow
+        });
     }
 }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-panel/risk-alerts-panel.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-panel/risk-alerts-panel.component.html
@@ -59,6 +59,13 @@
       </fab-message-bar>
       <br />
     </ng-container>
+    <ng-container *ngIf="!isInCaseSubmissionFlow">
+      <fab-message-bar [messageBarType]="summaryType" dismissButtonAriaLabel="Close" [truncated]="true" overflowButtonAriaLabel="See more">
+        <b>Run All Checks For Risks Alerts</b>
+        <a href="" (click)="openRiskAlertDetector($event)"> Check Recommendations for App Availability</a>
+      </fab-message-bar>
+      <br />
+    </ng-container>
     <fab-message-bar [messageBarType]="summaryType" dismissButtonAriaLabel="Close" [truncated]="true"
       overflowButtonAriaLabel="See more">
       <b>Learn about more configurations for high availability:</b>

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -75,11 +75,13 @@ export const TelemetryEventNames = {
     RiskTileClicked: 'RiskTileClicked',
     RiskTileLoaded: 'RiskTileLoaded',
     ArmConfigMergeError: 'ArmConfigMergeError',
+    OpenRiskAlertPanel: 'openRiskAlertsPanel'
 };
 
 export const TelemetrySource = {
     LandingPage: 'LandingPage',
-    CategoryPage: 'CategoryPage'
+    CategoryPage: 'CategoryPage',
+    CaseSubmissionFlow: 'CaseSubmissionFlow'
 }
 
 export interface TelemetryPayload {


### PR DESCRIPTION
This PR is for changing action for risk tile in homepage,

When clicking availability tile in risk alert section, it will open risk alert panel in right side so user can get thorough insights about these 4 basic checks. When scroll to bottom, there is a "Run All Check" link, it will navigate to risk alert detector to get all checks.

![image](https://user-images.githubusercontent.com/23129934/105555337-086f8500-5cbe-11eb-9ca1-a6ba6fa38b61.png)
