### PR TITLE
Extend partner config to indicate whether the response returned by arm api is base64 encoded.

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/arm/armResourceConfig.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/arm/armResourceConfig.ts
@@ -6,7 +6,7 @@ export class ArmResourceConfig {
 	matchRegEx?: string;
 	searchSuffix?: string;
 	azureServiceName?: string;
-	armApiVersion?: string;
+	armApiConfig?: ArmApiConfig;
 	isSearchEnabled?: boolean;
 	liveChatConfig?: LiveChatConfig
 	categories?: Array<Category>;
@@ -14,6 +14,11 @@ export class ArmResourceConfig {
     liabilityCheckConfig?: LiabilityCheckConfig;
     quickLinks?: string[];
     keystoneDetectorId?: string;
+}
+
+export interface ArmApiConfig {
+	armApiVersion?:string;
+	isArmApiResponseBase64Encoded?:boolean;
 }
 
 export interface LiveChatConfig {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
@@ -620,14 +620,14 @@ export class GenericArmConfigService {
 
   getApiVersion(resourceUri: string): string {
     let apiVersion = '';
-    if (!!this.getArmApiConfig(resourceUri) && !!this.getArmApiConfig(resourceUri).armApiVersion && this.getArmApiConfig(resourceUri).armApiVersion !== '') {
+    if (!!this.getArmApiConfig(resourceUri) && !!this.getArmApiConfig(resourceUri).armApiVersion) {
       apiVersion = this.getArmApiConfig(resourceUri).armApiVersion;
     }
     return apiVersion;
   }  
 
   isArmApiResponseBase64Encoded(resourceUri:string):boolean {
-    if (!!this.getArmApiConfig(resourceUri) && !!this.getArmApiConfig(resourceUri).isArmApiResponseBase64Encoded && this.getArmApiConfig(resourceUri).isArmApiResponseBase64Encoded === true) {
+    if (!!this.getArmApiConfig(resourceUri) && !!this.getArmApiConfig(resourceUri).isArmApiResponseBase64Encoded) {
        return true;
     }
     else {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
@@ -521,6 +521,20 @@ export class GenericArmConfigService {
           throw error;
         }
 
+        //currConfig.keystoneDetectorId
+        try {
+          if (this.getValue(this.resourceConfig.keystoneDetectorId, this.overrideConfig.keystoneDetectorId) != null) {
+            currConfig.keystoneDetectorId = this.getValue(this.resourceConfig.keystoneDetectorId, this.overrideConfig.keystoneDetectorId);
+          }
+        } catch (error) {
+          this.logException(error, null, {
+            "resourceUri": resourceUri,
+            "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
+            "field": "keystoneDetectorId" 
+          });
+          throw error;
+        }
+
         this.resourceMap.push(currConfig);
         return currConfig;
       })

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
@@ -543,18 +543,18 @@ export class GenericArmConfigService {
 
 
   getArmResourceConfig(resourceUri: string, recurse?: boolean): ArmResourceConfig {
-    let returlValue: ArmResourceConfig = new ArmResourceConfig();
+    let returnValue: ArmResourceConfig = new ArmResourceConfig();
     if (this.resourceMap.length > 0) {
       this.resourceMap.some((resource: ArmResourceConfig) => {
         const matchPattern: RegExp = new RegExp(`${resource.matchRegEx.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}`, "i");
         var result = resourceUri.match(matchPattern);
         if (result && result.length > 0) {
-          returlValue = resource;
+          returnValue = resource;
           return true;
         }
       });
     }
-    return returlValue;
+    return returnValue;
   }
 
   getApiVersion(resourceUri: string): string {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.ApiManagement/service/",
 	"searchSuffix": "AZURE API MANAGEMENT SERVICE",
 	"azureServiceName": "Azure API Management Service",
-	"armApiVersion": "2018-06-01-preview",
+	"armApiConfig": {
+		"armApiVersion": "2018-06-01-preview"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Azure API Management Service",
 	"armApiVersion": "2018-06-01-preview",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.apimanagement/service/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.ApiManagement/service/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Azure Spring Cloud",
 	"armApiVersion": "2019-05-01-preview",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.AppPlatform/Spring/",
 	"searchSuffix": "Spring",
 	"azureServiceName": "Azure Spring Cloud",
-	"armApiVersion": "2019-05-01-preview",
+	"armApiConfig": {
+		"armApiVersion": "2019-05-01-preview"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.AppPlatform/Spring/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.appplatform/spring/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "App Service Certificates",
 	"armApiVersion": "2020-06-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.CertificateRegistration/certificateOrders/",
 	"searchSuffix": "certs",
 	"azureServiceName": "App Service Certificates",
-	"armApiVersion": "2020-06-01",
+	"armApiConfig": {
+		"armApiVersion": "2020-06-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.CertificateRegistration/certificateOrders/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.certificateregistration/certificateorders/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.ContainerInstance/containerGroups/",
 	"searchSuffix": "ACI",
 	"azureServiceName": "Azure Container Instances",
-	"armApiVersion": "2019-12-01",
+	"armApiConfig": {
+		"armApiVersion": "2019-12-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Azure Container Instances",
 	"armApiVersion": "2019-12-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.ContainerInstance/containerGroups/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerinstance/containergroups/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Azure Container Registry",
 	"armApiVersion": "2019-12-01-preview",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.ContainerRegistry/registries/",
 	"searchSuffix": "ACR",
 	"azureServiceName": "Azure Container Registry",
-	"armApiVersion": "2019-12-01-preview",
+	"armApiConfig": {
+		"armApiVersion": "2019-12-01-preview"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "Microsoft.ContainerRegistry/registries/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerregistry/registries/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.ContainerService/managedClusters/",
 	"searchSuffix": "AKS",
 	"azureServiceName": "Azure Kubernetes Service",
-	"armApiVersion": "2019-04-01",
+	"armApiConfig": {
+		"armApiVersion": "2019-04-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Azure Kubernetes Service",
 	"armApiVersion": "2019-04-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.ContainerService/managedClusters/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.containerservice/managedclusters/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.Logic/integrationServiceEnvironments/",
 	"searchSuffix": "ISE",
 	"azureServiceName": "Integration Service Environments",
-	"armApiVersion": "2016-06-01",
+	"armApiConfig": {
+		"armApiVersion": "2016-06-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Integration Service Environments",
 	"armApiVersion": "2016-06-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.Logic/integrationServiceEnvironments/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/integrationServiceEnvironments/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Logic Apps",
 	"armApiVersion": "2016-06-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.Logic/workflows/",
 	"searchSuffix": "AZURE LOGIC APPS",
 	"azureServiceName": "Logic Apps",
-	"armApiVersion": "2016-06-01",
+	"armApiConfig": {
+		"armApiVersion": "2016-06-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.Logic/workflows/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.logic/workflows/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
 		"isApplicableForLiveChat": false,
 		"supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
@@ -7,7 +7,9 @@
 	"matchRegEx": "/Microsoft.ServiceFabric/clusters/",
 	"searchSuffix": "SF",
 	"azureServiceName": "Service Fabric",
-	"armApiVersion": "2020-03-01",
+	"armApiConfig": {
+		"armApiVersion": "2020-03-01"
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "Service Fabric",
 	"armApiVersion": "2020-03-01",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
         "isApplicableForLiveChat": false,
         "supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/override.json
@@ -7,7 +7,10 @@
 	"matchRegEx": "/Microsoft.ServiceFabric/clusters/",
 	"searchSuffix": "",
 	"azureServiceName": "",
-	"armApiVersion": "",
+	"armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
 	"isSearchEnabled": true,
 	"keystoneDetectorId": "",
 	"liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/override.json
@@ -9,6 +9,7 @@
 	"azureServiceName": "",
 	"armApiVersion": "",
 	"isSearchEnabled": true,
+	"keystoneDetectorId": "",
 	"liveChatConfig": {
         "isApplicableForLiveChat": false,
         "supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/config.json
@@ -8,7 +8,9 @@
     "matchRegEx": "/Microsoft.SignalRService/SignalR/",
     "searchSuffix": "signalr",
     "azureServiceName": "Azure SignalR Services",
-    "armApiVersion": "2020-05-01",
+    "armApiConfig": {
+		"armApiVersion": "2020-05-01"
+	},
     "isSearchEnabled": true,
 	"keystoneDetectorId": "",
     "liveChatConfig": {

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/config.json
@@ -10,6 +10,7 @@
     "azureServiceName": "Azure SignalR Services",
     "armApiVersion": "2020-05-01",
     "isSearchEnabled": true,
+	"keystoneDetectorId": "",
     "liveChatConfig": {
         "isApplicableForLiveChat": false,
         "supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/override.json
@@ -9,6 +9,7 @@
     "azureServiceName": "",
     "armApiVersion": "",
     "isSearchEnabled": true,
+	"keystoneDetectorId": "",
     "liveChatConfig": {
         "isApplicableForLiveChat": false,
         "supportTopicIds": []

--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/override.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.signalrservice/signalr/override.json
@@ -7,7 +7,10 @@
     "matchRegEx": "/Microsoft.SignalRService/SignalR/",
     "searchSuffix": "",
     "azureServiceName": "",
-    "armApiVersion": "",
+    "armApiConfig": {
+		"armApiVersion": "",
+		"isArmApiResponseBase64Encoded": false
+	},
     "isSearchEnabled": true,
 	"keystoneDetectorId": "",
     "liveChatConfig": {


### PR DESCRIPTION
Extend partner config to indicate whether the response returned by arm api is base64 encoded.
Also add support for keystoneDetectorId.
Update partner configs to reflect updated schema.