### PR TITLE
Update check to block ARM call

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/resolvers/resource.resolver.ts
@@ -48,16 +48,17 @@ export class ResourceResolver implements Resolve<Observable<{} | ArmResource>> {
 
     //All dependencies call from below Uri is returning 400, block ARM call
     private checkResourceUriMissingApiParam(resourceUri: string): boolean {
-        const missingApiParamUri = "management.azure.com/?clientOptimizations";
-        if(resourceUri.includes(missingApiParamUri)) {
+        const missingApiParamUri = "?clientOptimizations";
+        if(resourceUri.startsWith(missingApiParamUri) || resourceUri.startsWith(`/${missingApiParamUri}`)) {
             const error = new Error("MissingApiVersionParameter handled at resolver");
-            this.telemetryService.logException(
-                error,
-                "resource.resolver",
-                {
-                    "resourceUri" : resourceUri,  
-                }
-            );
+            if(this.telemetryService) {
+                this.telemetryService.logEvent(
+                    "MissingApiExceptionFromResolver",
+                    {
+                        "resourceUri" : resourceUri,  
+                    }
+                );
+            }
             return true;
         }
         return false;   


### PR DESCRIPTION
I checked Javirs dashboard and issue still happening after deployed last fix. Figure out the check logic for resource URI in resolver is not correct and cause error still throwing by arm service.

Update the logic to check only last part without arm endpoint, new logic should be able to block problematic ARM calls