### PR TITLE
Prevent forming bad route for metadata file for new detector creation

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/services/github-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/github-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DiagnosticApiService } from './diagnostic-api.service';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Commit } from '../models/commit';
 import { Dependency } from '../models/package';
 import { map } from 'rxjs/operators';
@@ -23,7 +23,9 @@ export class GithubApiService {
   }
 
   public getMetadataFile(id: string): Observable<string> {
-    return this._diagnosticApiService.get<string>(`api/github/package/${id}/metadata`, true);
+      if (id && id.length>0)
+        return this._diagnosticApiService.get<string>(`api/github/package/${id}/metadata`, true);
+      return of("");
   }
 
   public getSystemInvokerFile(id: string): Observable<string> {

--- a/ApplensBackend/nuget.config
+++ b/ApplensBackend/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
     <add key="Kusto" value="https://1essharedassets.pkgs.visualstudio.com/_packaging/Kusto/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
When a new detector is created, it doesn't have an id, which causes the UI to hit a wrong route to the backend.