### PR TITLE
Fix the category id for service fabric

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
+++ b/AngularApp/projects/app-service-diagnostics/src/armResourceConfig/microsoft.servicefabric/clusters/config.json
@@ -17,7 +17,7 @@
         "supportTopicIds": []
     },
 	"categories": [{
-			"id": "ClusterAnalysis",
+			"id": "Cluster Insights",
 			"name": "Cluster Insights",
 			"description": "Get recommendations for your configuration, find common issues, and identify possible improvements for reliability.",
 			"keywords": ["Health", "Deployment", "Performance", "Scaling", "Upgrade", "Update", "Configuration", "Reliability", "Security"],

--- a/ApplensBackend/nuget.config
+++ b/ApplensBackend/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
     <add key="Kusto" value="https://1essharedassets.pkgs.visualstudio.com/_packaging/Kusto/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fix the category id for service fabric category so that the detector load as soon as a tile is clicked on.