### PR TITLE
Fixing top 3 service health items from Diagnose and Solve client

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-chat/category-chat.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-chat/category-chat.component.ts
@@ -20,7 +20,8 @@ export class CategoryChatComponent implements OnInit {
       this._categoryService.categories.subscribe(categories => {
         this.category = categories.find(category => category.id === this._activatedRoute.snapshot.params.category);
         this._chatState.category = this.category;
-        this.startingKey = `welcome-${this.category.id}`;
+        let categoryId = this.category != undefined && this.category.id != undefined ? this.category.id : "";
+        this.startingKey = `welcome-${categoryId}`;
       });
     });
   }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -103,7 +103,7 @@ export class SupportTopicService {
                             catchError(err => {
                                 // If there is an error getting keystone detector, render the matched dector without key stone solution
                                 this._telemetryService.logEvent("KeystoneLoadingFailed", {
-                                    "details": err.ToString()
+                                    "details": JSON.stringify(err)
                                 });
 
                                 return observableOf({ path: detectorPath, queryParams: queryParamsDic });

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -686,11 +686,15 @@ export class DetectorViewComponent implements OnInit {
     }
   }
   protected logEvent(eventMessage: string, eventProperties?: any, measurements?: any) {
-    for (const id of Object.keys(this.detectorEventProperties)) {
-      if (this.detectorEventProperties.hasOwnProperty(id)) {
-        eventProperties[id] = String(this.detectorEventProperties[id]);
-      }
+    if (!!this.detectorEventProperties)
+    {
+        for (const id of Object.keys(this.detectorEventProperties)) {
+            if (this.detectorEventProperties.hasOwnProperty(id)) {
+              eventProperties[id] = String(this.detectorEventProperties[id]);
+            }
+          }
     }
+
     this.telemetryService.logEvent(eventMessage, eventProperties, measurements);
   }
 


### PR DESCRIPTION
Bug 1654: [Diagnose and Solve Client] Cannot convert undefined or null to object in logging properties
Bug 1653: [Diagnose and Solve Client] TypeError: e.ToString is not a function in error logging
Bug 1654: [Diagnose and Solve Client] Cannot convert undefined or null to object in logging properties