### PR TITLE
Fix:Genie is showing results from unintended sites

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -4,6 +4,7 @@ import { Observable, of, BehaviorSubject, Subject, ReplaySubject  } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ResourceService } from './resource.service';
 import { BackendCtrlService } from '../../shared/services/backend-ctrl.service';
+import {globalExcludedSites} from "diagnostics-data";
 
 @Injectable()
 export class ContentService {
@@ -31,7 +32,7 @@ export class ContentService {
     return of(searchResults);
   }
 
-  searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = []): Observable<any> {
+  searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = globalExcludedSites): Observable<any> {
 
     const searchSuffix = this._resourceService.searchSuffix;
 

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-content.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-content.service.ts
@@ -5,6 +5,7 @@ import 'rxjs/add/observable/of';
 import { HttpClient } from '@angular/common/http';
 import { mergeMap } from 'rxjs/operators';
 import { ResourceService } from '../../../shared/services/resource.service';
+import {globalExcludedSites} from "diagnostics-data";
 
 @Injectable()
 export class ApplensContentService {
@@ -40,7 +41,7 @@ export class ApplensContentService {
         return of(searchResults);
     }
 
-    public searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = []): Observable<any> {
+    public searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = globalExcludedSites): Observable<any> {
 
         const searchSuffix = this._resourceService.searchSuffix;
         var preferredSitesSuffix = preferredSites.map(site => `site:${site}`).join(" OR ");

--- a/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
@@ -5,7 +5,7 @@ interface PreferredSitesConfig {
 export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15551"];
 export var detectorSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170", "16450", "15791", "15551"];
 
-var globalExcludedSites = ["aws.amazon.com", "twitter.com"];
+export var globalExcludedSites = ["aws.amazon.com", "twitter.com"];
 
 var productPreferredSitesConfig: PreferredSitesConfig = {
     //WEB APP WINDOWS

--- a/AngularApp/projects/diagnostic-data/src/public_api.ts
+++ b/AngularApp/projects/diagnostic-data/src/public_api.ts
@@ -38,6 +38,7 @@ export * from './lib/models/compilation-properties';
 export * from './lib/models/solution-type-tag';
 export * from './lib/models/resource-descriptor';
 export * from './lib/models/documents-search-models';
+export * from './lib/models/search';
 export * from './lib/models/documents-search-config';
 export * from './lib/models/styles';
 


### PR DESCRIPTION
**Since genie does not use Project Shield for documentation search**, it is not using the functionality of excluded sites due to which AWS results pop up.
With this change we are making the list of excluded sites global for documentation search in the entire diagnostics project.
![image](https://user-images.githubusercontent.com/8492235/107102092-3bda0580-67ce-11eb-9f3c-a54fc2ca9050.png)
