### PR TITLE
Autohealing updates for path and status code range

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/auto-healing.module.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/auto-healing.module.ts
@@ -11,6 +11,9 @@ import { AutohealingComponent } from './autohealing.component';
 import { ProactiveAutohealingComponent } from './proactive-autohealing/proactive-autohealing.component';
 import { AvailabilityModule } from '../availability/availability.module';
 import { DiagnosticDataModule } from 'diagnostic-data';
+import {
+  FabChoiceGroupModule
+} from '@angular-react/fabric';
 
 @NgModule({
   declarations: [
@@ -27,7 +30,8 @@ import { DiagnosticDataModule } from 'diagnostic-data';
   imports: [
     SharedModule,
     AvailabilityModule,
-    DiagnosticDataModule
+    DiagnosticDataModule,
+    FabChoiceGroupModule
   ],
   exports: [
     AutohealingComponent

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-config-summary/autohealing-config-summary.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-config-summary/autohealing-config-summary.component.ts
@@ -61,7 +61,7 @@ export class AutohealingConfigSummaryComponent implements OnInit, OnChanges {
 
           let requestPath = "";
           if (slowRequestRule.path) {
-            requestPath = " matching path '" + slowRequestRule.path + "' ";
+            requestPath = ` matching path '${slowRequestRule.path}' `;
           }
 
           conditions.push(slowRequestRule.count + ' requests ' + requestPath + 'take more than  ' + FormatHelper.timespanToSeconds(slowRequestRule.timeTaken) + ' seconds in a duration of  ' + FormatHelper.timespanToSeconds(slowRequestRule.timeInterval) + ' seconds');
@@ -99,7 +99,7 @@ export class AutohealingConfigSummaryComponent implements OnInit, OnChanges {
             requestPath = " matching path '" + statusCodeRule.path + "' ";
           }
 
-          conditions.push(statusCodeRule.count + ' requests ' + requestPath + 'end up with HTTP Status in range (' + statusCodeRule.statusCodes  + ') in a duration of  ' + FormatHelper.timespanToSeconds(statusCodeRule.timeInterval) + ' seconds');
+          conditions.push(statusCodeRule.count + ' requests ' + requestPath + 'end up with HTTP Status in range (' + statusCodeRule.statusCodes + ') in a duration of  ' + FormatHelper.timespanToSeconds(statusCodeRule.timeInterval) + ' seconds');
         }
       }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-config-summary/autohealing-config-summary.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-config-summary/autohealing-config-summary.component.ts
@@ -55,6 +55,19 @@ export class AutohealingConfigSummaryComponent implements OnInit, OnChanges {
         conditions.push(this.actualhealSettings.autoHealRules.triggers.slowRequests.count + ' requests take more than  ' + FormatHelper.timespanToSeconds(this.actualhealSettings.autoHealRules.triggers.slowRequests.timeTaken) + ' seconds in a duration of  ' + FormatHelper.timespanToSeconds(this.actualhealSettings.autoHealRules.triggers.slowRequests.timeInterval) + ' seconds');
       }
 
+      if (this.actualhealSettings.autoHealRules.triggers.slowRequestsWithPath != null) {
+        for (let index = 0; index < this.actualhealSettings.autoHealRules.triggers.slowRequestsWithPath.length; index++) {
+          const slowRequestRule = this.actualhealSettings.autoHealRules.triggers.slowRequestsWithPath[index];
+
+          let requestPath = "";
+          if (slowRequestRule.path) {
+            requestPath = " matching path '" + slowRequestRule.path + "' ";
+          }
+
+          conditions.push(slowRequestRule.count + ' requests ' + requestPath + 'take more than  ' + FormatHelper.timespanToSeconds(slowRequestRule.timeTaken) + ' seconds in a duration of  ' + FormatHelper.timespanToSeconds(slowRequestRule.timeInterval) + ' seconds');
+        }
+      }
+
       if (this.actualhealSettings.autoHealRules.triggers.statusCodes != null) {
         for (let index = 0; index < this.actualhealSettings.autoHealRules.triggers.statusCodes.length; index++) {
           const statusCodeRule = this.actualhealSettings.autoHealRules.triggers.statusCodes[index];
@@ -68,9 +81,26 @@ export class AutohealingConfigSummaryComponent implements OnInit, OnChanges {
             statusCodesString += ' and win-32 status ' + statusCodeRule.win32Status.toString();
           }
 
-          conditions.push(statusCodeRule.count + ' requests end up with HTTP Status ' + statusCodesString + ' in a duration of  ' + FormatHelper.timespanToSeconds(statusCodeRule.timeInterval) + ' seconds');
-        }
+          let requestPath = "";
+          if (statusCodeRule.path) {
+            requestPath = " matching path '" + statusCodeRule.path + "' ";
+          }
 
+          conditions.push(statusCodeRule.count + ' requests ' + requestPath + 'end up with HTTP Status ' + statusCodesString + ' in a duration of  ' + FormatHelper.timespanToSeconds(statusCodeRule.timeInterval) + ' seconds');
+        }
+      }
+
+      if (this.actualhealSettings.autoHealRules.triggers.statusCodesRange != null) {
+        for (let index = 0; index < this.actualhealSettings.autoHealRules.triggers.statusCodesRange.length; index++) {
+          const statusCodeRule = this.actualhealSettings.autoHealRules.triggers.statusCodesRange[index];
+
+          let requestPath = "";
+          if (statusCodeRule.path) {
+            requestPath = " matching path '" + statusCodeRule.path + "' ";
+          }
+
+          conditions.push(statusCodeRule.count + ' requests ' + requestPath + 'end up with HTTP Status in range (' + statusCodeRule.statusCodes  + ') in a duration of  ' + FormatHelper.timespanToSeconds(statusCodeRule.timeInterval) + ' seconds');
+        }
       }
 
       let action: string = '';

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-rule/autohealing-rule.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-rule/autohealing-rule.component.ts
@@ -11,7 +11,7 @@ export abstract class AutohealingRuleComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.rule) {
-      this.ruleCopy = { ...this.rule };
+      this.ruleCopy = this.getClone(this.rule);
     }
   }
 
@@ -30,10 +30,27 @@ export abstract class AutohealingRuleComponent implements OnInit {
   }
 
   saveRule() {
-    // cloning the object
-    this.rule = { ...this.ruleCopy };
+    this.rule = this.getClone(this.ruleCopy);
     this.editMode = false;
     this.ruleChange.emit(this.rule);
+  }
+
+  getClone(obj: any) {
+    return (JSON.parse(JSON.stringify(obj)));
+  }
+
+  isValidUrlPattern(pattern: string): boolean {
+    if (!pattern) {
+      return true;
+    }
+
+    //
+    // Path should only allow 1-9, A-Z, period, forward slash, underscore, asterisk 
+    // '?' symbol is not allowed as the backend supports '*' wildcard only
+    // prohibiting '?' also ensures that no one can specify query strings
+    //
+    const regEx = new RegExp(/^[\*/\w-_.]*$/);
+    return regEx.test(pattern);
   }
 
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -1,11 +1,11 @@
-<div *ngIf="rule == null && !editMode">
+<div>
   If the performance of your application starts degrading and several pages start taking longer time to render, you can
   configure
   a rule to mitigate the issue or collect diagnostic data to identify the root cause of the problem.
 
   <div class="rule-button">
     <button type="button" class="btn btn-primary btn-sm" (click)="addNewRule()">
-      Configure Slow Request rule
+      Add Slow Request rule
     </button>
   </div>
   <div aria-live="polite" class="mt-1" [style.visibility]="displayDeleteRuleMessage ? 'visibile' : 'hidden'">
@@ -13,73 +13,107 @@
   </div>
 </div>
 
-<table class="table table-bordered" *ngIf="!editMode && rule != null">
-  <thead>
-    <tr>
-      <th tabindex="0">Request Count</th>
-      <th tabindex="0">Time Taken</th>
-      <th tabindex="0">Duration</th>
-      <th tabindex="0">Action</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td tabindex="0" scope="row">{{ rule.count }}</td>
-      <td tabindex="0">{{ rule.timeTaken }}</td>
-      <td tabindex="0">{{ rule.timeInterval }}</td>
-      <td tabindex="0">
-        <button role="button" class="image-btn" *ngIf="!editMode" (click)="editRule()" title="Edit rule" name="editRule">
-          <i class="fa fa-edit"></i>
-        </button>
-        <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteRule()" title="Delete rule" name="deleteRule">
-          <i class="fa fa-trash"></i>
-        </button>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div style="margin-top:20px">
+  <table class="table table-bordered"
+    *ngIf="rule != null && ((rule.slowRequests != null && rule.slowRequests.count != null && rule.slowRequests.count > 0) || (rule.slowRequestsWithPath !=null && rule.slowRequestsWithPath.length > 0))">
+    <thead>
+      <tr>
+        <th tabindex="0">Request Count</th>
+        <th tabindex="0">Time Taken</th>
+        <th tabindex="0">Duration</th>
+        <th tabindex="0">Path</th>
+        <th tabindex="0">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngIf="rule.slowRequests">
+        <td tabindex="0" scope="row">{{ rule.slowRequests.count }}</td>
+        <td tabindex="0">{{ rule.slowRequests.timeTaken }}</td>
+        <td tabindex="0">{{ rule.slowRequests.timeInterval }}</td>
+        <td tabindex="0">{{ rule.slowRequests.path }}</td>
+        <td tabindex="0">
+          <button role="button" class="image-btn" *ngIf="!editMode" (click)="editSingleRule()" title="Edit rule"
+            name="editRuleSlowRequest">
+            <i class="fa fa-edit"></i>
+          </button>
+          <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteSingeRule()" title="Delete rule"
+            name="deleteRuleSlowRequest">
+            <i class="fa fa-trash"></i>
+          </button>
+        </td>
+      </tr>
+      <tr *ngFor="let singleRule of rule.slowRequestsWithPath; let i = index">
+        <td tabindex="0" scope="row">{{ singleRule.count }}</td>
+        <td tabindex="0">{{ singleRule.timeTaken }}</td>
+        <td tabindex="0">{{ singleRule.timeInterval }}</td>
+        <td tabindex="0">{{ singleRule.path }}</td>
+        <td tabindex="0">
+          <button role="button" class="image-btn" *ngIf="!editMode" (click)="editSlowRequestRule(i)" title="Edit rule"
+            name="editRuleSlowRequestRange">
+            <i class="fa fa-edit"></i>
+          </button>
+          <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteSlowRequestRule(i)"
+            title="Delete rule" name="deleteRuleSlowRequest">
+            <i class="fa fa-trash"></i>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
-<div *ngIf="editMode" class="form-group">
-  <div class="row">
-    <div class="col-sm-6">
-      <label for="requestsCountSlow">After how many slow requests you want this condition to kick in?</label>
+  <div *ngIf="editMode" class="form-group">
+    <div class="row">
+      <div class="col-sm-6">
+        <label for="requestsCountSlow">After how many slow requests you want this condition to kick in?</label>
+      </div>
+      <div class="col-sm-4">
+        <input aria-required="true" type="number" id="requestsCountSlow" placeholder="Enter count"
+          [(ngModel)]="currentRule.count" min="1" max="4294967295">
+        <span style="color:red">*</span>
+        <div *ngIf="currentRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+          Request count should be more than zero
+        </div>
+      </div>
     </div>
-    <div class="col-sm-4">
-      <input aria-required="true" type="number" id="requestsCountSlow" placeholder="Enter count"
-        [(ngModel)]="ruleCopy.count" min="1" max="4294967295">
-      <span style="color:red">*</span>
-      <div *ngIf="ruleCopy.count <=0" class="alert alert-danger" style="margin-top:5px">
-        Request count should be more than zero
+
+    <div class="row">
+      <div class="col-sm-6">
+        <label for="timeTakenSlow">What should be minimum duration (in seconds) for these slow requests?</label>
+      </div>
+      <div class="col-sm-4">
+        <timespan ControlId="timeTakenSlow" [(timeSpan)]="currentRule.timeTaken" placeholder="e.g. 60"></timespan>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-6">
+        <label for="durationSlow">What is the time interval (in seconds) in which the above condition should be
+          met?</label>
+      </div>
+      <div class="col-sm-4">
+        <timespan ControlId="durationSlow" [(timeSpan)]="currentRule.timeInterval" placeholder="e.g. 300"></timespan>
+        <div *ngIf="showIntervalRecommendation" class="alert alert-danger" style="margin-top:5px">
+          It is recommended that the time interval is higher than the minimum duration setting.
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <label for="requestPath">What is the request path (leave blank for all requests)?</label>
+      </div>
+      <div class="col-sm-4">
+        <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
+          [(ngModel)]="currentRule.path">
+          <div *ngIf="!isValidUrlPattern(currentRule.path)" class="alert alert-danger" style="margin-top:5px">
+            Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
+          </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-4">
+        <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule()">Ok</button>
       </div>
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-sm-6">
-      <label for="timeTakenSlow">What should be minimum duration (in seconds) for these slow requests?</label>
-    </div>
-    <div class="col-sm-4">
-      <timespan ControlId="timeTakenSlow" [(timeSpan)]="ruleCopy.timeTaken" placeholder="e.g. 60"></timespan>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-sm-6">
-      <label for="durationSlow">What is the time interval (in seconds) in which the above condition should be
-        met?</label>
-    </div>
-    <div class="col-sm-4">
-      <timespan ControlId="durationSlow" [(timeSpan)]="ruleCopy.timeInterval" placeholder="e.g. 300"></timespan>
-      <div *ngIf="showIntervalRecommendation" class="alert alert-danger" style="margin-top:5px">
-        It is recommended that the time interval is higher than the minimum duration setting.
-      </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-sm-4">
-      <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule()">Ok</button>
-    </div>
-  </div>
-
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AutohealingRuleComponent } from '../autohealing-rule/autohealing-rule.component';
-import { SlowRequestsBasedTrigger } from '../../shared/models/autohealing';
+import { SlowRequestsBasedTrigger, SlowRequestsRules } from '../../shared/models/autohealing';
 import { FormatHelper } from '../../shared/utilities/formattingHelper';
 
 @Component({
@@ -10,6 +10,10 @@ import { FormatHelper } from '../../shared/utilities/formattingHelper';
 })
 export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleComponent {
 
+  currentRule: SlowRequestsBasedTrigger;
+  slowRequestIndex: number = -1;
+  editingSingleRule: boolean = false;
+
   constructor() {
     super();
   }
@@ -17,21 +21,86 @@ export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleCompone
   showIntervalRecommendation: boolean = false;
 
   addNewRule() {
-    this.rule = new SlowRequestsBasedTrigger();
-    this.ruleCopy = new SlowRequestsBasedTrigger();
+    this.currentRule = new SlowRequestsBasedTrigger();
     this.editMode = true;
+    this.slowRequestIndex = -1;
+    this.editingSingleRule = (this.rule == null || this.rule.slowRequests == null);
+    if (this.rule == null) {
+      let slowRequestsArray: SlowRequestsBasedTrigger[] = [];
+      this.rule = new SlowRequestsRules(new SlowRequestsBasedTrigger(), slowRequestsArray)
+    }
   }
 
   isValid(): boolean {
     this.showIntervalRecommendation = false;
-    if (this.ruleCopy && this.ruleCopy.timeInterval && this.ruleCopy.timeInterval !== '' && this.ruleCopy.timeTaken && this.ruleCopy.timeTaken != '') {
-      let isValid: boolean = (this.ruleCopy.count > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeInterval) > 0 && FormatHelper.timespanToSeconds(this.ruleCopy.timeTaken) > 0);
+    if (this.currentRule && this.currentRule.timeInterval && this.currentRule.timeInterval !== '' && this.currentRule.timeTaken && this.currentRule.timeTaken != '') {
+      let isValid: boolean = this.currentRule.count > 0 && FormatHelper.timespanToSeconds(this.currentRule.timeInterval) > 0 && FormatHelper.timespanToSeconds(this.currentRule.timeTaken) > 0 && this.isValidUrlPattern(this.currentRule.path);
       if (isValid) {
-        this.showIntervalRecommendation = this.ruleCopy.timeInterval < this.ruleCopy.timeTaken
+        this.showIntervalRecommendation = this.currentRule.timeInterval < this.currentRule.timeTaken
       }
       return isValid;
     } else {
       return false;
     }
+  }
+
+  deleteSingeRule() {
+    this.rule.slowRequests = null;
+    this.ruleChange.emit(this.rule);
+  }
+
+  editSingleRule() {
+    this.currentRule = this.ruleCopy.slowRequests;
+    this.editMode = true;
+    this.editingSingleRule = true;
+  }
+
+  deleteSlowRequestRule(i: number) {
+    if (i > -1) {
+      this.rule.slowRequestsWithPath.splice(i, 1);
+      this.ruleChange.emit(this.rule);
+    }
+  }
+
+  editSlowRequestRule(i: number) {
+    if (i > -1) {
+      this.currentRule = { ...this.rule.slowRequestsWithPath[i] };
+      this.editMode = true;
+      this.slowRequestIndex = i;
+      this.editingSingleRule = false;
+    }
+  }
+
+  saveRule() {
+    this.editMode = false;
+
+    //
+    // Azure App Service backend doesn't allow saving path at the
+    // slowRequests node even though you see the path property in ARM
+    // If the user is editing the rule for statusCodes only, make sure
+    // he has not specified a path. If a path is specified, allow them
+    // to update slowRequestsWithPath instead
+    //
+    if (this.editingSingleRule && !this.currentRule.path) {
+      this.rule.slowRequests = this.getClone(this.currentRule);
+    } else {
+
+      //
+      // This is the case where a user is trying to specify a path on 
+      // an existing slowRequests rule. In this case, we need to clear the
+      // slowRequests rule to ensure that a duplicate rule doesn't get added
+      //
+      if (this.editingSingleRule) {
+        this.rule.slowRequests = null;
+      }
+
+      if (this.slowRequestIndex < 0) {
+        this.rule.slowRequestsWithPath.push(this.currentRule);
+      } else {
+        this.rule.slowRequestsWithPath[this.slowRequestIndex] = this.currentRule;
+      }
+    }
+
+    this.ruleChange.emit(this.rule);
   }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
@@ -1,5 +1,6 @@
 <div>
-  If your app is failing with HTTP Server errors, you can configure a rule to mitigate the issue or collect diagnostic data
+  If your app is failing with HTTP Server errors, you can configure a rule to mitigate the issue or collect diagnostic
+  data
   to identify the root cause of the problem. You can configure rules on more than one HTTP Status code condition.
 
   <div class="rule-button">
@@ -13,23 +14,22 @@
 </div>
 
 <div *ngIf="rule">
-  <table class="table table-bordered" *ngIf="rule!==null && rule.length > 0" style="margin-top:20px">
+  <table class="table table-bordered"
+    *ngIf="rule != null && ((rule.statusCodes != null && rule.statusCodes.length > 0) || (rule.statusCodesRange != null && rule.statusCodesRange.length > 0))"
+    style="margin-top:20px">
     <thead>
       <tr>
         <th tabindex="0">
           Count
         </th>
         <th tabindex="0">
-          Status Code
-        </th>
-        <th tabindex="0">
-          Sub-Status
-        </th>
-        <th tabindex="0">
-          Win32-Status
+          Status Code(s)
         </th>
         <th tabindex="0">
           Interval
+        </th>
+        <th tabindex="0">
+          Path
         </th>
         <th tabindex="0">
           Action
@@ -37,17 +37,36 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let singleRule of rule; let i = index">
+      <tr *ngFor="let singleRule of rule.statusCodes; let i = index">
         <td tabindex="0">{{ singleRule.count }}</td>
-        <td tabindex="0">{{ singleRule.status }}</td>
-        <td tabindex="0">{{ singleRule.subStatus === 0 ? 'any' : singleRule.subStatus }}</td>
-        <td tabindex="0">{{ singleRule.win32Status === 0 ? 'any': singleRule.win32Status }}</td>
+        <td tabindex="0">
+          {{ getStatusCodeWithSubStatus(singleRule) }}
+        </td>
         <td tabindex="0">{{ singleRule.timeInterval }}</td>
+        <td tabindex="0">{{ singleRule.path }}</td>
         <td tabindex="0">
           <button class="image-btn" *ngIf="!editMode" (click)="editStatusCodeRule(i)" title="Edit rule" name="editRule">
             <i class="fa fa-edit"></i>
           </button>
-          <button class="image-btn" *ngIf="!editMode" (click)="deleteStatusCodeRule(i)" title="Delete rule" name="deleteRule">
+          <button class="image-btn" *ngIf="!editMode" (click)="deleteStatusCodeRule(i)" title="Delete rule"
+            name="deleteStatusCodeRule">
+            <i class="fa fa-trash"></i>
+          </button>
+        </td>
+      </tr>
+      <tr *ngFor="let singleRule of rule.statusCodesRange; let i = index">
+        <td tabindex="0">{{ singleRule.count }}</td>
+        <td tabindex="0">
+          {{ singleRule.statusCodes }}
+        </td>
+        <td tabindex="0">{{ singleRule.timeInterval }}</td>
+        <td tabindex="0">{{ singleRule.path }}</td>
+        <td tabindex="0">
+          <button class="image-btn" *ngIf="!editMode" (click)="editRangeRule(i)" title="Edit rule" name="editRangeRule">
+            <i class="fa fa-edit"></i>
+          </button>
+          <button class="image-btn" *ngIf="!editMode" (click)="deleteRangeRule(i)" title="Delete rule"
+            name="deleteRangeRule">
             <i class="fa fa-trash"></i>
           </button>
         </td>
@@ -56,65 +75,146 @@
   </table>
 
   <div *ngIf="editMode" style="margin-top:20px" class="form-group">
-    <div class="row">
+
+    <div class="row" *ngIf="showRuleOptions">
       <div class="col-sm-6">
-        <label for="requestCountStatusCodes">After how many requests you want this condition to kick in?</label>
+        <label for="ruleOptions">Do you want to set this rule for a specific status code or a range of status
+          codes?</label>
       </div>
-      <div class="col-sm-4">
-        <input aria-required="true" type="number" id="requestCountStatusCodes" aria-describedby="requestCountStatusCodesHelp" placeholder="Enter request count"
-          [(ngModel)]="currentRule.count" min="1" max="4294967295">
-        <span style="color:red">*</span>
-        <div *ngIf="currentRule.count <=0" class="alert alert-danger" style="margin-top:5px">
-          Request count should be more than zero
+      <div class="col-sm-6">
+        <fab-choice-group id="ruleOptions" [options]="choiceGroupOptions" defaultSelectedKey="singleStatusRule">
+        </fab-choice-group>
+      </div>
+    </div>
+
+    <div *ngIf="!rangeRule ; else rangeRuleTemplate">
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="requestCount">After how many requests you want this condition to kick in?</label>
+        </div>
+        <div class="col-sm-4">
+          <input aria-required="true" type="number" id="requestCount" placeholder="Enter request count"
+            [(ngModel)]="currentStatusCodeRule.count" min="1" max="4294967295">
+          <span style="color:red">*</span>
+          <div *ngIf="currentStatusCodeRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+            Request count should be more than zero
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="statusCode">What should be the status code for these requests?</label>
+        </div>
+        <div class="col-sm-4">
+          <input aria-required="true" type="number" id="statusCode" placeholder="e.g. 500" min="100" max="500"
+            [(ngModel)]="currentStatusCodeRule.status">
+          <span style="color:red">*</span>
+          <div *ngIf="currentStatusCodeRule.status < 100 || currentStatusCodeRule.status > 530"
+            class="alert alert-danger" style="margin-top:5px">
+            Valid HTTP Status codes range from HTTP 100 to HTTP 530 only.
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="subStatusCode">What should be the sub-status code for these requests?</label>
+        </div>
+
+        <div class="col-sm-4">
+          <input aria-required="false" type="number" min="0" max="500" id="subStatusCode" placeholder="e.g. 0"
+            [(ngModel)]="currentStatusCodeRule.subStatus">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="win32StatusCode">What should be the win32-status code for these requests?</label>
+        </div>
+        <div class="col-sm-4">
+          <input aria-required="false" type="number" min="0" max="4294967295" id="win32StatusCode" placeholder="e.g. 0"
+            [(ngModel)]="currentStatusCodeRule.win32Status">
+          <span style="color:red">*</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="durationStatusCode">What is the time interval (in seconds) in which the above condition should be
+            met?</label>
+        </div>
+        <div class="col-sm-4">
+          <timespan ControlId="durationStatusCode" [(timeSpan)]="currentStatusCodeRule.timeInterval"
+            placeholder="e.g. 60">
+          </timespan>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="requestPath">What is the request path (leave blank for all requests)?</label>
+        </div>
+        <div class="col-sm-4">
+          <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
+            [(ngModel)]="currentStatusCodeRule.path">
+          <div *ngIf="!isValidUrlPattern(currentStatusCodeRule.path)" class="alert alert-danger" style="margin-top:5px">
+            Path can contain letters, alphabets, *, -, period, _ and forward slashes only
+          </div>
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <label for="statusCode">What should be the status code for these requests?</label>
-      </div>
-      <div class="col-sm-4">
-        <input aria-required="true" type="number" id="statusCode" placeholder="e.g. 500" min="100" max="500" [(ngModel)]="currentRule.status">
-        <span style="color:red">*</span>
-        <div *ngIf="currentRule.status < 100 || currentRule.status > 530" class="alert alert-danger" style="margin-top:5px">
-          Valid HTTP Status codes range from HTTP 100 to HTTP 530 only.
+
+    <ng-template #rangeRuleTemplate>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="requestCount">After how many requests you want this condition to kick in?</label>
+        </div>
+        <div class="col-sm-4">
+          <input aria-required="true" type="number" id="requestCount" placeholder="Enter request count"
+            [(ngModel)]="currentRangeRule.count" min="1" max="4294967295">
+          <span style="color:red">*</span>
+          <div *ngIf="currentRangeRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+            Request count should be more than zero
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="row">
-      <div class="col-sm-6">
-        <label for="subStatusCode">What should be the sub-status code for these requests?</label>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="statusCodesRange">What is the range of status codes for this rule?</label>
+        </div>
+        <div class="col-sm-4">
+          <input type="text" aria-required="true" id="statusCodesRange" placeholder="e.g. 400-500"
+            [(ngModel)]="currentRangeRule.statusCodes">
+          <span style="color:red">*</span>
+          <div *ngIf="statusCodeRangeError.length > 0" class="alert alert-danger" style="margin-top:5px">
+            {{statusCodeRangeError}}
+          </div>
+        </div>
       </div>
-
-      <div class="col-sm-4">
-        <input aria-required="false" type="number" min="0" max="500" id="subStatusCode" placeholder="e.g. 0" [(ngModel)]="currentRule.subStatus">
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="durationStatusCode">What is the time interval (in seconds) in which the above condition should be
+            met?</label>
+        </div>
+        <div class="col-sm-4">
+          <timespan ControlId="durationStatusCode" [(timeSpan)]="currentRangeRule.timeInterval" placeholder="e.g. 60">
+          </timespan>
+        </div>
       </div>
-    </div>
-
-    <div class="row">
-      <div class="col-sm-6">
-        <label for="win32StatusCode">What should be the win32-status code for these requests?</label>
+      <div class="row">
+        <div class="col-sm-6">
+          <label for="requestPath">What is the request path (leave blank for all requests)?</label>
+        </div>
+        <div class="col-sm-4">
+          <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
+            [(ngModel)]="currentRangeRule.path">
+          <div *ngIf="!isValidUrlPattern(currentRangeRule.path)" class="alert alert-danger" style="margin-top:5px">
+            Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
+          </div>
+        </div>
       </div>
-      <div class="col-sm-4">
-        <input aria-required="false" type="number" min="0" max="4294967295" id="win32StatusCode" placeholder="e.g. 0" [(ngModel)]="currentRule.win32Status">
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-sm-6">
-        <label for="durationStatusCode">What is the time interval (in seconds) in which the above condition should be met?</label>
-      </div>
-      <div class="col-sm-4">
-        <timespan ControlId="durationStatusCode" [(timeSpan)]="currentRule.timeInterval" placeholder="e.g. 60"></timespan>
-      </div>
-    </div>
+    </ng-template>
 
     <div class="row">
       <div class="col-sm-4">
         <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule()">Ok</button>
       </div>
     </div>
-
   </div>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component } from '@angular/core';
 import { AutohealingRuleComponent } from '../autohealing-rule/autohealing-rule.component';
-import { StatusCodesBasedTrigger } from '../../shared/models/autohealing';
+import { StatusCodeRules, StatusCodesBasedTrigger, StatusCodesRangeBasedTrigger } from '../../shared/models/autohealing';
 import { FormatHelper } from '../../shared/utilities/formattingHelper';
+import { IChoiceGroupOption } from 'office-ui-fabric-react';
 
 @Component({
   selector: 'autohealing-statuscodes-rule',
@@ -10,56 +11,169 @@ import { FormatHelper } from '../../shared/utilities/formattingHelper';
 })
 export class AutohealingStatuscodesRuleComponent extends AutohealingRuleComponent {
 
-  currentRule: StatusCodesBasedTrigger;
-  currentEditIndex: number = -1;
+  showRuleOptions: boolean = true;
+  currentRangeRule: StatusCodesRangeBasedTrigger;
+  currentStatusCodeRule: StatusCodesBasedTrigger;
+  statusCodeIndex: number = -1;
+  rangeIndex: number = -1;
+  rangeRule: boolean = false;
+  statusCodeRangeError: string = '';
+
+  choiceGroupOptions: IChoiceGroupOption[] = [
+    { key: 'singleStatusRule', text: 'Single HTTP Status', defaultChecked: true, onClick: () => { this.rangeRule = false; this.updateInMemoryRules(this.rangeRule); } },
+    { key: 'rangeRule', text: 'HTTP Status Range', onClick: () => { this.rangeRule = true; this.updateInMemoryRules(this.rangeRule); } }
+  ];
 
   constructor() {
     super();
   }
 
   addNewRule() {
-    this.currentRule = new StatusCodesBasedTrigger();
-    if (!this.rule) {
-      this.rule = [];
+
+    //
+    // when someone is adding a new rule,
+    // default to a StatusCodeRule
+    //
+    this.rangeRule = false;
+    this.updateInMemoryRules(this.rangeRule);
+
+    if (this.rule == null) {
+      let statusCodesArray: StatusCodesBasedTrigger[] = [];
+      let statusCodesRangeArray: StatusCodesRangeBasedTrigger[] = [];
+      this.rule = new StatusCodeRules(statusCodesArray, statusCodesRangeArray);
     }
     this.editMode = true;
-    this.currentEditIndex = -1;
+  }
+
+  updateInMemoryRules(rangeRule: boolean) {
+    if (rangeRule) {
+      this.currentRangeRule = new StatusCodesRangeBasedTrigger();
+      this.statusCodeIndex = -1;
+    } else {
+      this.currentStatusCodeRule = new StatusCodesBasedTrigger();
+      this.rangeIndex = -1;
+    }
   }
 
   deleteStatusCodeRule(i: number) {
     if (i > -1) {
-      this.rule.splice(i, 1);
+      this.rule.statusCodes.splice(i, 1);
       this.ruleChange.emit(this.rule);
     }
   }
 
   editStatusCodeRule(i: number) {
     if (i > -1) {
-      this.currentRule = {...this.rule[i]};
+      this.currentStatusCodeRule = { ...this.rule.statusCodes[i] };
       this.editMode = true;
-      this.currentEditIndex = i;
+      this.statusCodeIndex = i;
+      this.showRuleOptions = false;
+      this.rangeRule = false;
     }
+  }
 
+  deleteRangeRule(i: number) {
+    if (i > -1) {
+      this.rule.statusCodesRange.splice(i, 1);
+      this.ruleChange.emit(this.rule);
+    }
+  }
+
+  editRangeRule(i: number) {
+    if (i > -1) {
+      this.currentRangeRule = { ...this.rule.statusCodesRange[i] };
+      this.editMode = true;
+      this.rangeIndex = i;
+      this.showRuleOptions = false;
+      this.rangeRule = true;
+    }
   }
 
   saveRule() {
     this.editMode = false;
-    if (this.currentRule.subStatus == null) {
-      this.currentRule.subStatus = 0;
-    }
-    if (this.currentRule.win32Status == null) {
-      this.currentRule.win32Status = 0;
-    }
-    if (this.currentEditIndex < 0) {
-      this.rule.push(this.currentRule);
+    this.showRuleOptions = true;
+    if (this.rangeRule) {
+      if (this.rangeIndex < 0) {
+        this.rule.statusCodesRange.push(this.currentRangeRule);
+      } else {
+        this.rule.statusCodesRange[this.rangeIndex] = this.currentRangeRule;
+      }
     } else {
-      this.rule[this.currentEditIndex] = this.currentRule;
+      if (this.currentStatusCodeRule.subStatus == null) {
+        this.currentStatusCodeRule.subStatus = 0;
+      }
+      if (this.currentStatusCodeRule.win32Status == null) {
+        this.currentStatusCodeRule.win32Status = 0;
+      }
+
+      if (this.statusCodeIndex < 0) {
+        this.rule.statusCodes.push(this.currentStatusCodeRule);
+      } else {
+        this.rule.statusCodes[this.statusCodeIndex] = this.currentStatusCodeRule;
+      }
     }
 
     this.ruleChange.emit(this.rule);
   }
 
   isValid(): boolean {
-    return (this.currentRule.count > 0 && this.currentRule.status > 100 && this.currentRule.status < 530 && (this.currentRule.timeInterval && FormatHelper.timespanToSeconds(this.currentRule.timeInterval) > 0));
+    if (this.rangeRule) {
+      if (!this.isValidUrlPattern(this.currentRangeRule.path)) {
+        return false;
+      }
+      return this.isValidStatusCodesRange(this.currentRangeRule.statusCodes) && this.currentRangeRule.count > 0 && FormatHelper.timespanToSeconds(this.currentRangeRule.timeInterval) > 0;
+    } else {
+      if (!this.isValidUrlPattern(this.currentStatusCodeRule.path)) {
+        return false;
+      }
+      return this.currentStatusCodeRule.count > 0 && this.currentStatusCodeRule.status > 100 && this.currentStatusCodeRule.status < 530 && (this.currentStatusCodeRule.timeInterval && FormatHelper.timespanToSeconds(this.currentStatusCodeRule.timeInterval) > 0);
+    }
+  }
+
+  getStatusCodeWithSubStatus(rule: StatusCodesBasedTrigger): string {
+    if (rule.subStatus == 0 && rule.win32Status == 0) {
+      return rule.status.toString();
+    } else {
+      if (rule.win32Status == 0) {
+        return rule.status.toString() + "." + rule.subStatus.toString();
+      } else {
+        return rule.status.toString() + "." + rule.subStatus + "." + rule.win32Status.toString();
+      }
+    }
+  }
+
+  isValidStatusCodesRange(range: string): boolean {
+    this.statusCodeRangeError = '';
+    if (range.indexOf('.') > -1) {
+      this.statusCodeRangeError = "HTTP Status code range cannot contain '.'";
+      return false;
+    }
+
+    let rangeArray = range.split('-');
+    if (rangeArray.length != 2) {
+      this.statusCodeRangeError = "HTTP Status code range must contain one '-'";
+      return false;
+    }
+
+    let start = Number(rangeArray[0]);
+    let end = Number(rangeArray[1]);
+
+    if (Number.isInteger(start) && Number.isInteger(end)) {
+      if (start >= 100 && end >= 100 && start <= 530 && end <= 530) {
+
+        if (start < end) {
+          this.statusCodeRangeError = "";
+          return true;
+        } else {
+          this.statusCodeRangeError = "HTTP Status start range cannot be lower than HTTP Status end range";
+        }
+
+      } else {
+        this.statusCodeRangeError = "Valid HTTP Status codes range from HTTP 100 to HTTP 530 only";
+      }
+    } else {
+      this.statusCodeRangeError = "HTTP Status code range specified is not a numberic value";
+    }
+    return false;
   }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -70,7 +70,7 @@
 
             <div class="forminput" *ngIf="triggerSelected >= 0">
               <autohealing-slowrequests-rule *ngIf="triggerSelected === 0"
-                [rule]="autohealingSettings.autoHealRules.triggers.slowRequests"
+                [rule]="slowRequestRules"
                 (ruleChange)="triggerRuleUpdated($event, triggerSelected)"></autohealing-slowrequests-rule>
               <autohealing-memory-rule *ngIf="triggerSelected === 1"
                 [rule]="autohealingSettings.autoHealRules.triggers.privateBytesInKB"
@@ -79,7 +79,7 @@
                 [rule]="autohealingSettings.autoHealRules.triggers.requests"
                 (ruleChange)="triggerRuleUpdated($event, triggerSelected)"></autohealing-requests-rule>
               <autohealing-statuscodes-rule *ngIf="triggerSelected === 3"
-                [rule]="autohealingSettings.autoHealRules.triggers.statusCodes"
+                [rule]="statusCodeRules"
                 (ruleChange)="triggerRuleUpdated($event, triggerSelected)"></autohealing-statuscodes-rule>
             </div>
           </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
@@ -19,7 +19,7 @@
     display: inline-block;
     margin: 0 2px;
     cursor: pointer;
-    margin-bottom: 10px
+    margin-bottom: 10px;
 }
 
 .autohealtile-selected {
@@ -31,14 +31,14 @@
     padding: 10px;
     width: 130px;
     height: 70px;
-    -webkit-box-shadow: 2px 2px 3px 0 rgba(0, 0, 0, .2);
-    box-shadow: 2px 2px 3px 0 rgba(0, 0, 0, .2);
+    -webkit-box-shadow: 2px 2px 3px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 2px 2px 3px 0 rgba(0, 0, 0, 0.2);
     text-align: center;
 }
 
 .autohealtile:hover {
-    -webkit-box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, .2);
-    box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, .2);
+    -webkit-box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 6px 6px 20px 0 rgba(0, 0, 0, 0.2);
 }
 
 .icon-template {
@@ -81,7 +81,7 @@
     padding: 5px;
     padding-right: 30px;
     border-radius: 10px;
-    width:90%;
+    width: 90%;
 }
 
 .saveSection {
@@ -89,7 +89,8 @@
     margin-bottom: 10px;
 }
 
-input[type="text"], input[type="number"] {
+input[type="text"],
+input[type="number"] {
     border: 1px solid #d8e1e6;
     position: relative;
     vertical-align: middle;
@@ -98,11 +99,13 @@ input[type="text"], input[type="number"] {
     background-color: #fff;
     color: inherit;
     font-size: 12px;
+    width:80%;
 }
 
-input[type=text]:focus, input[type=number]:focus {
+input[type="text"]:focus,
+input[type="number"]:focus {
     border: 1px solid #0058ad;
-    outline: 0
+    outline: 0;
 }
 
 label {
@@ -124,7 +127,7 @@ label {
     line-height: 25px;
 }
 
-.topmenu-button{
+.topmenu-button {
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
 }
@@ -134,7 +137,7 @@ label {
     border-color: #0058ad;
 }
 
-.btn.btn-primary:disabled{
+.btn.btn-primary:disabled {
     background-color: rgba(0, 89, 173, 0.9);
     border-color: rgba(0, 89, 173, 0.9);
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -140,8 +140,7 @@ export class AutohealingComponent implements OnInit {
       || (triggers.slowRequests != null && triggers.slowRequests.count > 0)
       || (triggers.statusCodes != null && triggers.statusCodes.length > 0)
       || (triggers.statusCodesRange != null && triggers.statusCodesRange.length > 0)
-      || (triggers.slowRequestsWithPath != null && triggers.slowRequestsWithPath.length > 0))
-       {
+      || (triggers.slowRequestsWithPath != null && triggers.slowRequestsWithPath.length > 0)) {
       isValid = true;
     }
     return isValid;
@@ -318,13 +317,13 @@ export class AutohealingComponent implements OnInit {
     this.minProcessExecutionTimeExpanded = false;
   }
 
-  getStatusCodeRules() : StatusCodeRules {
+  getStatusCodeRules(): StatusCodeRules {
     if (this.autohealingSettings != null && this.autohealingSettings.autoHealRules != null && this.autohealingSettings.autoHealRules.triggers != null) {
       return new StatusCodeRules(this.autohealingSettings.autoHealRules.triggers.statusCodes, this.autohealingSettings.autoHealRules.triggers.statusCodesRange);
     }
   }
 
-  getSlowRequestRules():SlowRequestsRules{
+  getSlowRequestRules(): SlowRequestsRules {
     if (this.autohealingSettings != null && this.autohealingSettings.autoHealRules != null && this.autohealingSettings.autoHealRules.triggers != null) {
       return new SlowRequestsRules(this.autohealingSettings.autoHealRules.triggers.slowRequests, this.autohealingSettings.autoHealRules.triggers.slowRequestsWithPath);
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -4,7 +4,7 @@ import { SiteInfoMetaData } from '../shared/models/site';
 import { SiteService } from '../shared/services/site.service';
 import { AutohealingService } from '../shared/services/autohealing.service';
 import { FormatHelper } from '../shared/utilities/formattingHelper';
-import { AutoHealSettings, AutoHealCustomAction, AutoHealRules, AutoHealActions, AutoHealTriggers, AutoHealActionType } from '../shared/models/autohealing';
+import { AutoHealSettings, AutoHealCustomAction, AutoHealRules, AutoHealActions, AutoHealTriggers, AutoHealActionType, StatusCodeRules, SlowRequestsRules } from '../shared/models/autohealing';
 import { AvailabilityLoggingService } from '../shared/services/logging/availability.logging.service';
 
 @Component({
@@ -39,6 +39,8 @@ export class AutohealingComponent implements OnInit {
   detectorHasData: boolean = false;
   validationWarning: string[];
   selectedTab: string = 'autoHealing';
+  statusCodeRules: StatusCodeRules = null;
+  slowRequestRules: SlowRequestsRules = null;
 
   constructor(private _siteService: SiteService, private _autohealingService: AutohealingService, private _logger: AvailabilityLoggingService, protected _route: ActivatedRoute) {
   }
@@ -66,6 +68,8 @@ export class AutohealingComponent implements OnInit {
     this.originalAutoHealSettings = JSON.parse(this.originalSettings);
     this.updateConditionsAndActions();
     this.updateSummaryText();
+    this.statusCodeRules = this.getStatusCodeRules();
+    this.slowRequestRules = this.getSlowRequestRules();
   }
 
   updateConditionsAndActions() {
@@ -132,9 +136,12 @@ export class AutohealingComponent implements OnInit {
   checkTriggersValid(triggers: AutoHealTriggers): boolean {
     let isValid = false;
     if ((triggers.privateBytesInKB != null && triggers.privateBytesInKB > 0)
-      || triggers.requests != null && triggers.requests.count > 0
-      || triggers.slowRequests != null && triggers.slowRequests.count > 0
-      || triggers.statusCodes != null && triggers.statusCodes.length > 0) {
+      || (triggers.requests != null && triggers.requests.count > 0)
+      || (triggers.slowRequests != null && triggers.slowRequests.count > 0)
+      || (triggers.statusCodes != null && triggers.statusCodes.length > 0)
+      || (triggers.statusCodesRange != null && triggers.statusCodesRange.length > 0)
+      || (triggers.slowRequestsWithPath != null && triggers.slowRequestsWithPath.length > 0))
+       {
       isValid = true;
     }
     return isValid;
@@ -246,7 +253,8 @@ export class AutohealingComponent implements OnInit {
   triggerRuleUpdated(ruleEvent, triggerRule: number) {
     switch (triggerRule) {
       case 0: {
-        this.autohealingSettings.autoHealRules.triggers.slowRequests = ruleEvent;
+        this.autohealingSettings.autoHealRules.triggers.slowRequests = ruleEvent.slowRequests;
+        this.autohealingSettings.autoHealRules.triggers.slowRequestsWithPath = ruleEvent.slowRequestsWithPath;
         break;
       }
       case 1: {
@@ -259,7 +267,8 @@ export class AutohealingComponent implements OnInit {
       }
 
       case 3: {
-        this.autohealingSettings.autoHealRules.triggers.statusCodes = ruleEvent;
+        this.autohealingSettings.autoHealRules.triggers.statusCodes = ruleEvent.statusCodes;
+        this.autohealingSettings.autoHealRules.triggers.statusCodesRange = ruleEvent.statusCodesRange;
         break;
       }
     }
@@ -274,10 +283,10 @@ export class AutohealingComponent implements OnInit {
     this.actions = [];
     const self = this;
 
-    this.triggers.push({ Name: 'Request Duration', Icon: 'fa fa-hourglass-half', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && self.autohealingSettings.autoHealRules.triggers.slowRequests != null, IsConfigured: false });
+    this.triggers.push({ Name: 'Request Duration', Icon: 'fa fa-hourglass-half', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && (self.autohealingSettings.autoHealRules.triggers.slowRequests != null || (self.autohealingSettings.autoHealRules.triggers.slowRequestsWithPath != null && self.autohealingSettings.autoHealRules.triggers.slowRequestsWithPath.length > 0)), IsConfigured: false });
     this.triggers.push({ Name: 'Memory Limit', Icon: 'fa fa-microchip', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && self.autohealingSettings.autoHealRules.triggers.privateBytesInKB > 0, IsConfigured: false });
     this.triggers.push({ Name: 'Request Count', Icon: 'fa fa-bar-chart', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && self.autohealingSettings.autoHealRules.triggers.requests != null, IsConfigured: false });
-    this.triggers.push({ Name: 'Status Codes', Icon: 'fa fa-list', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && self.autohealingSettings.autoHealRules.triggers.statusCodes && this.autohealingSettings.autoHealRules.triggers.statusCodes.length > 0, IsConfigured: false });
+    this.triggers.push({ Name: 'Status Codes', Icon: 'fa fa-list', checkRuleConfigured: () => self.autohealingSettings != null && self.autohealingSettings.autoHealRules != null && self.autohealingSettings.autoHealRules.triggers != null && ((self.autohealingSettings.autoHealRules.triggers.statusCodes && this.autohealingSettings.autoHealRules.triggers.statusCodes.length > 0) || (self.autohealingSettings.autoHealRules.triggers.statusCodesRange && this.autohealingSettings.autoHealRules.triggers.statusCodesRange.length > 0)), IsConfigured: false });
 
     this.triggers.forEach(triggerRule => {
       triggerRule.IsConfigured = triggerRule.checkRuleConfigured();
@@ -307,6 +316,18 @@ export class AutohealingComponent implements OnInit {
     this.triggerSelected = -1;
     this.actionCollapsed = true;
     this.minProcessExecutionTimeExpanded = false;
+  }
+
+  getStatusCodeRules() : StatusCodeRules {
+    if (this.autohealingSettings != null && this.autohealingSettings.autoHealRules != null && this.autohealingSettings.autoHealRules.triggers != null) {
+      return new StatusCodeRules(this.autohealingSettings.autoHealRules.triggers.statusCodes, this.autohealingSettings.autoHealRules.triggers.statusCodesRange);
+    }
+  }
+
+  getSlowRequestRules():SlowRequestsRules{
+    if (this.autohealingSettings != null && this.autohealingSettings.autoHealRules != null && this.autohealingSettings.autoHealRules.triggers != null) {
+      return new SlowRequestsRules(this.autohealingSettings.autoHealRules.triggers.slowRequests, this.autohealingSettings.autoHealRules.triggers.slowRequestsWithPath);
+    }
   }
 
   validateAutoHealRules() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/timespan/timespan.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/timespan/timespan.component.scss
@@ -7,6 +7,7 @@ input[type="number"] {
     background-color: #fff;
     color: inherit;
     font-size:12px;
+    width: 80%;
 }
 
 input[type=text]:focus,input[type=number]:focus

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/autohealing.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/autohealing.ts
@@ -22,7 +22,9 @@ export class AutoHealTriggers {
     requests: RequestsBasedTrigger;
     privateBytesInKB: number;
     statusCodes: StatusCodesBasedTrigger[];
+    statusCodesRange: StatusCodesRangeBasedTrigger[];
     slowRequests: SlowRequestsBasedTrigger;
+    slowRequestsWithPath: SlowRequestsBasedTrigger[];
 
 }
 
@@ -32,14 +34,20 @@ export class RequestsBasedTrigger {
 }
 
 export class StatusCodesBasedTrigger extends RequestsBasedTrigger {
-
     status: number;
     subStatus: number;
     win32Status: number;
+    path: string;
+}
+
+export class StatusCodesRangeBasedTrigger extends RequestsBasedTrigger {
+    path: string;
+    statusCodes: string;
 }
 
 export class SlowRequestsBasedTrigger extends RequestsBasedTrigger {
     timeTaken: string;
+    path: string;
 }
 
 export class AutoHealActions {
@@ -52,4 +60,24 @@ export class AutoHealActions {
 export class AutoHealCustomAction {
     exe: string;
     parameters: string;
+}
+
+export class StatusCodeRules {
+    statusCodes: StatusCodesBasedTrigger[];
+    statusCodesRange: StatusCodesRangeBasedTrigger[];
+
+    constructor(_statusCodes: StatusCodesBasedTrigger[], _statusCodesRange: StatusCodesRangeBasedTrigger[]) {
+        this.statusCodes = _statusCodes;
+        this.statusCodesRange = _statusCodesRange;
+    }
+}
+
+export class SlowRequestsRules {
+    slowRequests: SlowRequestsBasedTrigger;
+    slowRequestsWithPath: SlowRequestsBasedTrigger[];
+
+    constructor(_slowRequests: SlowRequestsBasedTrigger, _slowRequestsWithPath: SlowRequestsBasedTrigger[]) {
+        this.slowRequests = _slowRequests;
+        this.slowRequestsWithPath = _slowRequestsWithPath;
+    }
 }


### PR DESCRIPTION
With this PR, we are updating the AutoHeal UI to have this functionality
- Support for adding multiple rules for Slow Requests (Request Duration) based on request path
- Support for specifying a path for the Status Codes rules
- Support for specifying a range of HTTP status codes

![image](https://user-images.githubusercontent.com/5299838/107234183-65529580-6a49-11eb-953a-939fc9c7bfcc.png)

Choose a single HTTP Status Code rule or a range of Status codes

![image](https://user-images.githubusercontent.com/5299838/107234247-7a2f2900-6a49-11eb-9aec-ab62bdd64008.png)


![image](https://user-images.githubusercontent.com/5299838/107234288-85825480-6a49-11eb-9338-ffb5d72ea605.png)
