### PR TITLE
Enable detector search for logic apps

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
@@ -2,7 +2,7 @@ interface PreferredSitesConfig {
     [index: string]: string[];
 }
 
-export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15551"];
+export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15791", "15551"];
 export var detectorSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170", "16450", "15791", "15551"];
 
 export var globalExcludedSites = ["aws.amazon.com", "twitter.com"];


### PR DESCRIPTION
Logic apps RP is now passing the "text" parameter to diagnostics backend. Hence enabling detector search feature in project shield.