### PR TITLE
Forcing SAS URI as environment for Crash monitoring and validating SasURI

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
@@ -38,6 +38,9 @@
   </div>
   <div>
     <ul *ngIf="validateSasUriResponse.Exception">
+      <li *ngIf="validateSasUriResponse.StorageAccount">
+        Account: <strong>{{ validateSasUriResponse.StorageAccount }}</strong>
+      </li>
       <li>
         Exception:{{ validateSasUriResponse.Exception }}
       </li>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.html
@@ -3,7 +3,7 @@
   Checking for configured blob storage...
 </div>
 
-<div class="outline-box" *ngIf="!checkingBlobSasUriConfigured && !error">
+<div class="outline-box" *ngIf="!checkingBlobSasUriConfigured && !error && !validateSasUriResponse">
   <div *ngIf="chosenStorageAccount">
     <div tabindex="0">
       Storage account: <span class="highlight-blue">{{ chosenStorageAccount }}</span>
@@ -28,4 +28,29 @@
 
 <div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word" *ngIf="error">
   <strong>Error</strong> - {{ error }}
+</div>
+
+<div class="focus-box focus-box-warning" style="margin-top:20px;word-wrap: break-word" *ngIf="validateSasUriResponse">
+  <div class="mt-1 mb-3">
+    The Storage account configuration for this app is in an invalid state. This can happen if the SAS URI has expired or
+    the Storage account is deleted. The below information can help in identifying the problem with the configured
+    storage account
+  </div>
+  <div>
+    <ul *ngIf="validateSasUriResponse.Exception">
+      <li>
+        Exception:{{ validateSasUriResponse.Exception }}
+      </li>
+      <ng-container *ngIf="validateSasUriResponse.ExtendedError">
+        <ng-container *ngFor="let item of validateSasUriResponse.ExtendedError | keyvalue">
+          <li *ngIf="item.value">
+            {{item.key}}:{{ isString(item.value) ? item.value : JSON.stringify(item.value) }}
+          </li>
+        </ng-container>
+      </ng-container>
+    </ul>
+  </div>
+
+  <button tabindex="0" type="button" class="btn btn-primary btn-sm mt-3 mb-2" [disabled]="sessionInProgress"
+    (click)="toggleStorageAccountPanel()">Reconfigure Storage Account</button>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
@@ -33,12 +33,12 @@
 
               </div>
               <div class="col-md-2">
-                <span *ngIf="chosenStorageAccount"> {{ chosenStorageAccount }}
+                <span> {{ monitoringEnabled || storageConfiguredAsAppSetting ? chosenStorageAccount : ""}}
                 </span>
                 <div class="mt-1 mb-4" (click)="toggleStorageAccountPanel()"
                   (keyup.enter)="toggleStorageAccountPanel()">
                   <a role="button" name="Change storage account" aria-label="Change storage account">
-                    {{ chosenStorageAccount ? 'Change' : 'Select' }}</a>
+                    {{ chosenStorageAccount && (monitoringEnabled || storageConfiguredAsAppSetting) ? 'Change' : 'Select' }}</a>
                 </div>
               </div>
             </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
@@ -32,6 +32,7 @@ export class CrashMonitoringComponent implements OnInit {
       this.blobSasUriEnvironmentVariable = newStorageAccount.sasUri;
       if (this.chosenStorageAccount) {
         this.validationError = "";
+        this.storageConfiguredAsAppSetting = true;
       }
     })
   }
@@ -54,6 +55,7 @@ export class CrashMonitoringComponent implements OnInit {
   validationError: string = "";
   updatingStorageAccounts: boolean = false;
   chosenStorageAccount: string = "";
+  storageConfiguredAsAppSetting: boolean = false;
 
   chosenStartDateTime: Date;
   chosenEndDateTime: Date;
@@ -118,6 +120,7 @@ export class CrashMonitoringComponent implements OnInit {
   getStorageAccountName(): Observable<string> {
     return this._daasService.getBlobSasUri(this.siteToBeDiagnosed).pipe(
       map(daasSasUri => {
+        this.storageConfiguredAsAppSetting = daasSasUri.IsAppSetting;
         return this.getStorageAccountNameFromSasUri(daasSasUri.SasUri);
       }));
   }
@@ -152,6 +155,9 @@ export class CrashMonitoringComponent implements OnInit {
   }
 
   getStorageAccountNameFromSasUri(blobSasUri: string): string {
+    if (!blobSasUri) {
+      return blobSasUri;
+    }
     let blobUrl = new URL(blobSasUri);
     return blobUrl.host.split('.')[0];
   }
@@ -191,7 +197,7 @@ export class CrashMonitoringComponent implements OnInit {
   validateSettings(): boolean {
     this.validationError = ""
     let isValid: boolean = true;
-    if (!this.chosenStorageAccount) {
+    if (!this.chosenStorageAccount || !this.storageConfiguredAsAppSetting) {
       this.validationError = "Please choose a storage account to save the memory dumps";
       return false;
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -203,6 +203,7 @@ export class CrashMonitoringSettings {
 export interface ValidateSasUriResponse {
     Exception: string;
     IsValid: boolean;
+    StorageAccount:string;
     SpecifiedAt: string;
     ExtendedError: StorageExtendError;
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -199,3 +199,18 @@ export class CrashMonitoringSettings {
     MaxDumpCount: number;
     ExceptionFilter: string;
 }
+
+export interface ValidateSasUriResponse {
+    Exception: string;
+    IsValid: boolean;
+    SpecifiedAt: string;
+    ExtendedError: StorageExtendError;
+}
+
+export interface StorageExtendError {
+    HttpStatusCode: string;
+    HttpStatusMessage: string;
+    ErrorCode: string;
+    ErrorMessage: string;
+    AdditionalDetails: any;
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -7,7 +7,7 @@ import { SiteDaasInfo } from '../models/solution-metadata';
 import { ArmService } from './arm.service';
 import { AuthService } from '../../startup/services/auth.service';
 import { UriElementsService } from './urielements.service';
-import { Session, DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, DaasSasUri } from '../models/daas';
+import { Session, DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, DaasSasUri, ValidateSasUriResponse } from '../models/daas';
 import { SiteInfoMetaData } from '../models/site';
 import { SiteService } from './site.service';
 
@@ -185,6 +185,14 @@ export class DaasService {
                 } else {
                     return this._getSasUriFromDaasApi(site);
                 }
+            }));
+    }
+
+    validateSasUri(site: SiteDaasInfo): Observable<ValidateSasUriResponse> {
+        const resourceUri: string = this._uriElementsService.getValidateBlobSasUriUrl(site);
+        return this._armClient.getResourceWithoutEnvelope<ValidateSasUriResponse>(resourceUri, null, true).pipe(
+            map((resp: ValidateSasUriResponse) => {
+                return resp;
             }));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
@@ -62,6 +62,7 @@ export class UriElementsService {
     private _diagnosticsMonitoringSingleSession = this._diagnosticsMonitoringPath + "/{sessionId}";
     private _diagnosticsMonitoringAnalyzeSession = this._diagnosticsMonitoringPath + "/analyze?sessionId={sessionId}";
     private _diagnosticsSettingsPath = this._diagnosticsPath + 'settings';
+    private _diagnosticsValidateSasUriPath = this._diagnosticsSettingsPath + "/validatesasuri";
     private _networkTraceStartPath = '/networkTrace/start';
     private _webjobsPath: string = '/webjobs';
 
@@ -140,6 +141,10 @@ export class UriElementsService {
 
     getBlobSasUriUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsSettingsPath;
+    }
+
+    getValidateBlobSasUriUrl(site: SiteDaasInfo) {
+        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._diagnosticsValidateSasUriPath;
     }
 
     getStdoutSettingUrl(resourceUrl: string) {


### PR DESCRIPTION
With this PR
- Forcing SAS Uri to be configured as an App Setting for Crash Monitoring feature. This is required so that sites using Local Cache are configuring the SAS URI correctly
- Calling a DAAS API to validate if the configured SAS URI is accessible from DAAS. If not, we are giving a message right before you submit a session

![image](https://user-images.githubusercontent.com/5299838/108509086-c9dfe100-72e2-11eb-84a3-0b65917ff651.png)
