### PR TITLE
Warning in AutoHeal if SAS URI not in Env Vars

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
@@ -62,14 +62,15 @@
                       </td>
                     </tr>
                   </th>
-                  <tr>
-                    <td> You have chosen a tool option that does not restart the process. This can cause
-                      auto-healing actions to kick in multiple times thus generating a lot of data. It is
-                      recommended to choose <strong>CollectKillAnalyze</strong> option to ensure that the process gets
-                      restarted after collecting data.</td>
-                  </tr>
+                  <tbody>
+                    <tr>
+                      <td> You have chosen a tool option that does not restart the process. This can cause
+                        auto-healing actions to kick in multiple times thus generating a lot of data. It is
+                        recommended to choose <strong>CollectKillAnalyze</strong> option to ensure that the process gets
+                        restarted after collecting data.</td>
+                    </tr>
+                  </tbody>
                 </table>
-
               </div>
             </div>
           </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -163,6 +163,13 @@
         </table>
       </div>
       <div *ngIf="!retrievingAutohealSettings  && !errorMessage" class="saveSection autohealtile-content">
+        <div *ngIf="!saveEnabled && generateSasRecommendation()" class="error-details">
+          <i class="fa health-icon fa-times-circle unhealthy-icon-color" aria-hidden="true"></i>
+          Please reconfigure the storage account by clicking on the Custom Action section above. This 
+          ensures that SAS URI gets stored as an environment variable which is more secure than passing 
+          the SAS URI as a parameter to the DaaSConsole executable.
+        </div>
+
         <button type="button" class="btn btn-sm btn-primary" [disabled]="!saveEnabled" (click)="saveChanges()">Save</button>
         <button type="button" class="btn btn-sm btn-primary" [disabled]="!saveEnabled" (click)="reset()">Cancel</button>
         <button type="button" class="btn btn-sm btn-primary" (click)="toggleSessionPanel()">View All Sessions</button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.scss
@@ -141,3 +141,10 @@ label {
     background-color: rgba(0, 89, 173, 0.9);
     border-color: rgba(0, 89, 173, 0.9);
 }
+
+.error-details {
+    background-color: rgb(254, 240, 240);
+    padding: 5px;
+    width: 90%;
+    margin-bottom: 10px;
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -44,7 +44,7 @@ export class AutohealingComponent implements OnInit {
   statusCodeRules: StatusCodeRules = null;
   slowRequestRules: SlowRequestsRules = null;
 
-  constructor(private _siteService: SiteService, private _autohealingService: AutohealingService, 
+  constructor(private _siteService: SiteService, private _autohealingService: AutohealingService,
     private globals: Globals, private telemetryService: TelemetryService,
     private _logger: AvailabilityLoggingService, protected _route: ActivatedRoute) {
   }
@@ -337,7 +337,17 @@ export class AutohealingComponent implements OnInit {
     this.globals.openSessionPanel = !this.globals.openSessionPanel;
     this.telemetryService.logEvent("OpenSesssionsPanel");
     this.telemetryService.logPageView("SessionsPanelView");
-}
+  }
+
+  generateSasRecommendation() {
+    return this.originalAutoHealSettings && this.originalAutoHealSettings.autoHealEnabled &&
+      this.originalAutoHealSettings.autoHealRules && this.originalAutoHealSettings.autoHealRules.actions
+      && this.originalAutoHealSettings.autoHealRules.actions && this.originalAutoHealSettings.autoHealRules.actions.customAction
+      && this.originalAutoHealSettings.autoHealRules.actions.customAction.exe
+      && this.originalAutoHealSettings.autoHealRules.actions.customAction.exe.toLowerCase().indexOf("daasconsole.exe") > -1
+      && this.originalAutoHealSettings.autoHealRules.actions.customAction.parameters
+      && this.originalAutoHealSettings.autoHealRules.actions.customAction.parameters.toLowerCase().indexOf("blobsasuri") > -1
+  }
 
   validateAutoHealRules() {
     this.validationWarning = [];

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -61,7 +61,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
     this.checkingBlobSasUriConfigured = true;
 
     this._daasService.getBlobSasUri(this.siteToBeDiagnosed).subscribe(daasSasUri => {
-      if (daasSasUri.SasUri) {
+      if (daasSasUri.SasUri && daasSasUri.IsAppSetting) {
         this._daasService.validateSasUri(this.siteToBeDiagnosed).subscribe(resp => {
           this.checkingBlobSasUriConfigured = false;
           if (resp.IsValid) {


### PR DESCRIPTION
- Forcing to use SAS URI from environment variables everywhere
- Throwing a warning in AutoHeal page if SAS URI is not configured as an environment variable

@ShekharGupta1988  - Please check if this text looks ok

`Please reconfigure the storage account by clicking on the Custom Action section above. This 
          ensures that SAS URI gets stored as an environment variable which is more secure than passing 
          the SAS URI as a parameter to the DaaSConsole executable.`