### PR TITLE
Deeplink redirect post temporary access

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.ts
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.ts
@@ -2,6 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import { DiagnosticApiService } from '../../services/diagnostic-api.service';
 import { Router } from '@angular/router';
 
+const postAuthRedirectKey = 'post_auth_redirect';
+
 @Component({
     selector: 'app-unauthorized',
     templateUrl: './unauthorized.component.html',
@@ -19,12 +21,23 @@ export class UnauthorizedComponent implements OnInit {
     ngOnInit(){
     }
 
+    navigateToRedirectUrl(){
+      var returnUrl = localStorage.getItem(postAuthRedirectKey);
+      if (returnUrl && returnUrl != '') {
+          this._router.navigateByUrl(returnUrl);
+          localStorage.removeItem(postAuthRedirectKey);
+      }
+      else{
+          this._router.navigateByUrl('/');
+      }
+    }
+
     requestTemporaryAccess(){
       this._diagnosticApiService.requestTemporaryAccess().subscribe(res => {
         this.temporaryAccessSuccessMessage = res;
         this.temporaryAccessSucceeded = true;
         setTimeout(() => {
-          this._router.navigateByUrl('/');
+          this.navigateToRedirectUrl();
         }, 2000);
       },
       (err) => {

--- a/ApplensBackend/Controllers/IncidentAssistanceController.cs
+++ b/ApplensBackend/Controllers/IncidentAssistanceController.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Caching.Memory;
 namespace AppLensV3.Controllers
 {
     [Route("api/icm/")]
-    [Authorize(Policy = "ApplensAccess")]
+    [Authorize(Policy = "DefaultAccess")]
     public class IncidentAssistanceController : Controller
     {
         private readonly IIncidentAssistanceService _incidentAssistanceService;


### PR DESCRIPTION
This PR is for two things:
1. In the current experience of getting temporary access, the user gets redirected to applens home page, and if they came with a deeplink, that is lost. This PR solves the problem by storing the deeplink in on localstorage and retreiving it once the user has gained temporary access. i.e. The user will be directed to the same page that they came for.
2. ICM Incident Assist currently follows Applens Access authorization. But since this is a wider feature and sometimes critical, we are allowing people within Microsoft to be able to interact with this even if they're not part of Applens access. i.e. The users will be authenticated against being in Microsoft tenant only.