### PR TITLE
Fix null reference for homepageText attribute

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-arm-config.service.ts
@@ -140,8 +140,8 @@ export class GenericArmConfigService {
         //currConfig.homePageText.title
         try {
           if (
-            (this.overrideConfig.homePageText && this.overrideConfig.homePageText.title) ||
-            (this.resourceConfig.homePageText && this.resourceConfig.homePageText.title)
+            (this.overrideConfig && this.overrideConfig.homePageText && this.overrideConfig.homePageText.title) ||
+            (this.resourceConfig && this.resourceConfig.homePageText && this.resourceConfig.homePageText.title)
           ) {
             currConfig.homePageText.title = this.getValue(this.resourceConfig.homePageText.title, this.overrideConfig.homePageText.title);
           }
@@ -149,7 +149,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "homePageText.title" 
+            "field": "homePageText.title"
           });
           throw error;
         }
@@ -158,8 +158,8 @@ export class GenericArmConfigService {
         //currConfig.homePageText.description
         try {
           if (
-            (this.overrideConfig.homePageText && this.overrideConfig.homePageText.description) ||
-            (this.resourceConfig.homePageText && this.resourceConfig.homePageText.description)
+            (this.overrideConfig && this.overrideConfig.homePageText && this.overrideConfig.homePageText.description) ||
+            (this.resourceConfig && this.resourceConfig.homePageText && this.resourceConfig.homePageText.description)
           ) {
             currConfig.homePageText.description = this.getValue(this.resourceConfig.homePageText.description, this.overrideConfig.homePageText.description);
           }
@@ -167,16 +167,16 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "homePageText.description" 
-          });          
+            "field": "homePageText.description"
+          });
           throw error;
         }
 
         //currConfig.homePageText.searchBarPlaceHolder
         try {
           if (
-            (this.overrideConfig.homePageText && this.overrideConfig.homePageText.searchBarPlaceHolder) ||
-            (this.resourceConfig.homePageText && this.resourceConfig.homePageText.searchBarPlaceHolder)
+            (this.overrideConfig && this.overrideConfig.homePageText && this.overrideConfig.homePageText.searchBarPlaceHolder) ||
+            (this.resourceConfig && this.resourceConfig.homePageText && this.resourceConfig.homePageText.searchBarPlaceHolder)
           ) {
             currConfig.homePageText.searchBarPlaceHolder = this.getValue(this.resourceConfig.homePageText.searchBarPlaceHolder, this.overrideConfig.homePageText.searchBarPlaceHolder);
           }
@@ -184,7 +184,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "homePageText.searchBarPlaceHolder" 
+            "field": "homePageText.searchBarPlaceHolder"
           });
           throw error;
         }
@@ -198,7 +198,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "matchRegEx" 
+            "field": "matchRegEx"
           });
           throw error;
         }
@@ -213,8 +213,8 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "searchSuffix" 
-          });          
+            "field": "searchSuffix"
+          });
           throw error;
         }
 
@@ -228,7 +228,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "azureServiceName" 
+            "field": "azureServiceName"
           });
           throw error;
         }
@@ -263,7 +263,7 @@ export class GenericArmConfigService {
                   this.logException(error, null, {
                     "resourceUri": resourceUri,
                     "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-                    "field": "armApiConfig.armApiVersion" 
+                    "field": "armApiConfig.armApiVersion"
                   });
                   throw error;
                 }
@@ -278,7 +278,7 @@ export class GenericArmConfigService {
                   this.logException(error, null, {
                     "resourceUri": resourceUri,
                     "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-                    "field": "armApiConfig.isArmApiResponseBase64Encoded" 
+                    "field": "armApiConfig.isArmApiResponseBase64Encoded"
                   });
                   throw error;
                 }
@@ -291,7 +291,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "armApiConfig" 
+            "field": "armApiConfig"
           });
           throw error;
         }
@@ -306,7 +306,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "isSearchEnabled" 
+            "field": "isSearchEnabled"
           });
           throw error;
         }
@@ -321,7 +321,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "pesId" 
+            "field": "pesId"
           });
           throw error;
         }
@@ -398,7 +398,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "liveChatConfig" 
+            "field": "liveChatConfig"
           });
           throw error;
         }
@@ -545,7 +545,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "categories" 
+            "field": "categories"
           });
           throw error;
         }
@@ -560,7 +560,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "quickLinks" 
+            "field": "quickLinks"
           });
           throw error;
         }
@@ -574,7 +574,7 @@ export class GenericArmConfigService {
           this.logException(error, null, {
             "resourceUri": resourceUri,
             "reason": `${TelemetryEventNames.ArmConfigMergeError}: Error while merging armConfig.`,
-            "field": "keystoneDetectorId" 
+            "field": "keystoneDetectorId"
           });
           throw error;
         }
@@ -616,7 +616,7 @@ export class GenericArmConfigService {
       apiVersion = this.getArmApiConfig(resourceUri).armApiVersion;
     }
     return apiVersion;
-  }  
+  }
 
   isArmApiResponseBase64Encoded(resourceUri:string):boolean {
     if (!!this.getArmApiConfig(resourceUri) && !!this.getArmApiConfig(resourceUri).isArmApiResponseBase64Encoded) {


### PR DESCRIPTION
Seeing some null reference exception from Application insights occuring 13 times for 12 users. This PR is to fix the exception:

https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%2290731d56-7842-11eb-b036-e33ad64f9edf%22,%22timestamp%22:%222021-02-26T14:54:44.477Z%22%7D/ComponentId/%7B%22Name%22:%22DiagnoseAndSolvePortal%22,%22ResourceGroup%22:%22DiagnoseAndSolve%22,%22SubscriptionId%22:%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%7D

Uncaught (in promise): TypeError: Cannot read property 'homePageText' of undefined
TypeError: Cannot read property 'homePageText' of undefined
    at t.project (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:5781441)
    at t._next (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1724583)
    at t.next (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1242766)
    at t.notifyNext (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:5228684)
    at t._next (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1923108)
    at t.next (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1242766)
    at https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1294449
    at a (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1923430)
    at t.error (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:1545977)
    at t.notifyError (https://appservice-diagnostics.azurefd.net/main.3bb93b7fccfaccb9c294.js:1:5228748) 