### PR TITLE
Disable ThreadStacks in Autoheal and set time to 20d for CrashMon

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
@@ -20,7 +20,7 @@
             <div class="detail-cards">
               <ng-container *ngFor="let item of Diagnosers;let i = index">
                 <button class="detail-card" (click)="chooseDiagnoser(item)"
-                  [ngClass]="{'detail-card-active': item.Name === diagnoser.Name}">
+                  [ngClass]="{'detail-card-active': item.Name === diagnoser.Name && item.Enabled , 'detail-card-disabled': item.Enabled === false}">
                   <h4>{{item.Name}}</h4>
                   <p>{{ item.Description }}</p>
                 </button>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.scss
@@ -1,8 +1,8 @@
-.diagnoser-option{    
+.diagnoser-option {
     padding: 10px;
     border-radius: 5px;
     background-color: #eeeeee;
-    margin-top:10px;
+    margin-top: 10px;
 }
 
 .detail-card {
@@ -30,18 +30,28 @@
     color: whitesmoke;
 }
 
+.detail-card-disabled {
+    background-color: #0058ada8;
+    color: whitesmoke;
+    pointer-events: none;
+}
+
+.detail-card-disabled:hover {
+    border: none !important;
+}
+
 .diagnostic-options {
     border: 1px #0058ad solid;
     border-radius: 0px 0px 5px 5px;
     padding: 0px 0px 0px 10px;
-    margin-left:1px;
+    margin-left: 1px;
 }
 
 .text-muted {
     color: #666;
 }
 
-h4{
+h4 {
     font-size: 12px;
 }
 p {
@@ -49,13 +59,13 @@ p {
     font-size: 12px;
 }
 
-.diagnostic-options-heading{
-    margin-top:10px;  
+.diagnostic-options-heading {
+    margin-top: 10px;
     background-color: #0058ad;
-    width:100px;
+    width: 100px;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
-    color:white;
+    color: white;
     padding-left: 7px;
     margin-left: 1px;
 }
@@ -66,12 +76,12 @@ label {
     /* color: #595959; */
 }
 
-.final-action{
-    background-color:#eeeeee;
-    border-radius:5px;
+.final-action {
+    background-color: #eeeeee;
+    border-radius: 5px;
 }
 
-.custom-action-note{
+.custom-action-note {
     color: #0058ad;
     font-size: smaller;
     margin-top: 5px;

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
@@ -31,11 +31,11 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
   updatedCustomAction: AutoHealCustomAction = new AutoHealCustomAction();
 
 
-  Diagnosers = [{ Name: 'Memory Dump', Description: 'Collects memory dumps of the process and the child processes hosting your app and analyzes them for errors' },
-  { Name: 'CLR Profiler', Description: 'Profiles ASP.NET application code to identify exceptions and performance issues' },
-  { Name: 'CLR Profiler With Thread Stacks', Description: 'Profiles ASP.NET application code to identify exceptions and performance issues and dumps stacks to identify deadlocks' },
-  { Name: 'JAVA Memory Dump', Description: 'Collects a binary memory dump using jMap of all java.exe processes running for this web app' },
-  { Name: 'JAVA Thread Dump', Description: 'Collects jStack output of all java.exe processes running for this app and analyzes the same' }];
+  Diagnosers = [{ Name: 'Memory Dump', Enabled: true, Description: 'Collects memory dumps of the process and the child processes hosting your app and analyzes them for errors' },
+  { Name: 'CLR Profiler', Enabled: true, Description: 'Profiles ASP.NET application code to identify exceptions and performance issues' },
+  { Name: 'CLR Profiler With Thread Stacks', Enabled: false, Description: 'Profiles ASP.NET application code to identify exceptions and performance issues and dumps stacks to identify deadlocks' },
+  { Name: 'JAVA Memory Dump', Enabled: true, Description: 'Collects a binary memory dump using jMap of all java.exe processes running for this web app' },
+  { Name: 'JAVA Thread Dump', Enabled: true, Description: 'Collects jStack output of all java.exe processes running for this app and analyzes the same' }];
   DiagnoserOptions = [
     { option: 'CollectKillAnalyze', Description: 'With this option, the above selected tool\'s data will collected, analyzed and the process will be recycled.' },
     { option: 'CollectLogs', Description: 'With this option, only the above selected tool\'s data will collected. No analysis will be performed and process will not be restarted.' },
@@ -123,7 +123,7 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
   }
 
   chooseDiagnoser(val) {
-    if (val != null) {
+    if (val != null && val.Enabled) {
       this.diagnoser = val;
       this.daasValidatorRef.diagnoserName = this.diagnoser.Name;
       this.daasValidatorRef.validateDiagnoser();

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
@@ -40,8 +40,10 @@ export class CrashMonitoringComponent implements OnInit {
   today: Date = new Date(Date.now());
   memoryDumpOptions: IDropdownOption[] = [];
 
-  maxDate: Date = this.convertUTCToLocalDate(addMonths(this.today, 1))
-  minDate: Date = this.convertUTCToLocalDate(this.today)
+  // TODO: Revert this to 30 days after timer overflow issue is fixed
+  //maxDate: Date = this.convertUTCToLocalDate(addMonths(this.today, 1))
+  maxDate: Date = this.convertUTCToLocalDate(addDays(this.today, 20));
+  minDate: Date = this.convertUTCToLocalDate(this.today);
   startDate: Date = this.minDate;
   endDate: Date = addDays(this.startDate, 15);
   startClock: string;
@@ -127,7 +129,10 @@ export class CrashMonitoringComponent implements OnInit {
 
   resetGlobals() {
     this.today = new Date(Date.now());
-    this.maxDate = this.convertUTCToLocalDate(addMonths(this.today, 1))
+
+    // TODO: Revert this to 30 days after timer overflow issue is fixed
+    //this.maxDate = this.convertUTCToLocalDate(addMonths(this.today, 1))
+    this.maxDate = this.convertUTCToLocalDate(addDays(this.today, 20));
     this.minDate = this.convertUTCToLocalDate(this.today)
     this.startDate = this.minDate;
     this.endDate = addDays(this.startDate, 15);


### PR DESCRIPTION
- Disable CLR Profiler with ThreadStacks option in AutoHealing UI till the StackTracer issue is fully resolved
- Change the end time for Crash Monitoring from 30d to 20d to prevent a backend overflow bug when using Timer