### PR TITLE
Fix null reference in autohealing rules

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -61,7 +61,7 @@
     </tbody>
   </table>
 
-  <div *ngIf="editMode && currentRule" class="form-group">
+  <div *ngIf="editMode && currentRule!=null" class="form-group">
     <div class="row">
       <div class="col-sm-6">
         <label for="requestsCountSlow">After how many slow requests you want this condition to kick in?</label>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -61,7 +61,7 @@
     </tbody>
   </table>
 
-  <div *ngIf="editMode" class="form-group">
+  <div *ngIf="editMode && currentRule" class="form-group">
     <div class="row">
       <div class="col-sm-6">
         <label for="requestsCountSlow">After how many slow requests you want this condition to kick in?</label>


### PR DESCRIPTION
We are seeing increasing number of exceptions from this page for last 3 days:

https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%22e4caa611-8586-11eb-88db-2f334d048792%22,%22timestamp%22:%222021-03-15T12:06:37.494Z%22%7D/ComponentId/%7B%22Name%22:%22DiagnoseAndSolvePortal%22,%22ResourceGroup%22:%22DiagnoseAndSolve%22,%22SubscriptionId%22:%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%7D