### PR TITLE
[Genie Bug Bash 2021] - Keyboard Accessibility - Landing Page - Links inside the tiles are not accessible via keyboard tabs

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.html
@@ -8,7 +8,7 @@
       <h3 class="tile-title">{{category.name}}</h3>
       <p class="tile-description">{{category.description}}</p>
       <p class="tile-keywords">Ex: {{keywords}}</p>
-      <a>Troubleshoot</a>
+      <a tabindex="0">Troubleshoot</a>
     </div>
   </div>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/risk-tile/risk-tile.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/risk-tile/risk-tile.component.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="risk-section">
-      <a>{{linkText}}</a>
+      <a tabindex="0">{{linkText}}</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Bug fix for :
[Genie Bug Bash 2021] - Keyboard Accessibility - Landing Page - Links inside the tiles are not accessible via keyboard tabs