### PR TITLE
Shows controls and keyboards when zooming into 400%

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.scss
@@ -1,9 +1,25 @@
- .body-content {
-        display: flex!important;
-      height: calc(100vh - 100px);
-    }
-
+ //Hide side nav and content take over whole page
   section.sidebar {
+    display: none;
+  }
+
+  section.content {
+    width: 100%;
+    top: 0px;
+    bottom: 0px;
+    left: 265px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .body-content {
+    display: flex!important;
+  }
+  
+  //display side nav for 100% zooming
+  @media(min-width: 640px) and (min-height: 500px) {
+    section.sidebar {
+      display: block;
       min-width: 265px;
       position: fixed;
       top: 0px;
@@ -13,16 +29,24 @@
       overflow-x: hidden;
     }
 
-  section.content {
-    position: fixed;
-    min-width: calc(100% - 265px);
-    width: 80%;
-    top: 0px;
-    bottom: 0px;
-    left: 265px;
-    overflow-y: auto;
-    overflow-x: hidden;
+    section.content {
+      position: fixed;
+      min-width: calc(100% - 265px);
+      width: 80%;
+      top: 0px;
+      bottom: 0px;
+      left: 265px;
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+
+    .body-content {
+      display: flex!important;
+      height: calc(100vh - 100px);
+    }
   }
+
+
 
   section.content-hide-nav{
     min-width: 100%;


### PR DESCRIPTION
Fixing for [7614078 - At zoom 400%,Controls and keyboard focus indicator are not appearing properly on the screen](https://msazure.visualstudio.com/Antares/_workitems/edit/7614078)

When zooming in, we will hide side-nav in category page and only show content. Like how side nav behavior for side-nav in home page

![image](https://user-images.githubusercontent.com/23129934/112354416-e5475e80-8c89-11eb-916d-4907d030c7e4.png)
