### PR TITLE
Accessibility diag tools

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-memory-rule/autohealing-memory-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-memory-rule/autohealing-memory-rule.component.html
@@ -46,7 +46,7 @@
       <input aria-required="true" type="number" min="1" id="idPrivateBytes" aria-describedby="privateBytesHelp" placeholder="Enter private bytes in KB" min="1" max="4294967295"
         [(ngModel)]="ruleCopy">
       <span style="color:red">*</span>
-      <div *ngIf="ruleCopy !== null && ruleCopy !=0 && !isValid()" class="alert alert-danger" style="margin-top:5px">
+      <div *ngIf="ruleCopy !== null && ruleCopy !=0 && !isValid()" class="alert alert-danger" role="alert" style="margin-top:5px">
         Private should be > 102400 KB (100 MB) to 13631488 KB (13 GB)
       </div>
     </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-requests-rule/autohealing-requests-rule.component.html
@@ -49,7 +49,7 @@
     <div class="col-sm-4">
       <input aria-required="true" type="number" id="requestCount" placeholder="Enter count" [(ngModel)]="ruleCopy.count" min="1" max="4294967295">
       <span style="color:red">*</span>
-      <div *ngIf="ruleCopy.count <=0" class="alert alert-danger" style="margin-top:5px">
+      <div *ngIf="ruleCopy.count <=0" class="alert alert-danger" role="alert" style="margin-top:5px">
         Request count should be more than zero
       </div>
     </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -4,7 +4,7 @@
   a rule to mitigate the issue or collect diagnostic data to identify the root cause of the problem.
 
   <div class="rule-button">
-    <button type="button" class="btn btn-primary btn-sm" (click)="addNewRule()">
+    <button #addRuleButton type="button" class="btn btn-primary btn-sm" (click)="addNewRule()">
       Add Slow Request rule
     </button>
   </div>
@@ -36,8 +36,8 @@
             name="editRuleSlowRequest">
             <i class="fa fa-edit"></i>
           </button>
-          <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteSingeRule()" title="Delete rule"
-            name="deleteRuleSlowRequest">
+          <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteSingleRule();addRuleButton.focus()"
+            title="Delete rule" name="deleteRuleSlowRequest">
             <i class="fa fa-trash"></i>
           </button>
         </td>
@@ -52,8 +52,8 @@
             name="editRuleSlowRequestRange">
             <i class="fa fa-edit"></i>
           </button>
-          <button role="button" class="image-btn" *ngIf="!editMode" (click)="deleteSlowRequestRule(i)"
-            title="Delete rule" name="deleteRuleSlowRequest">
+          <button role="button" class="image-btn" *ngIf="!editMode"
+            (click)="deleteSlowRequestRule(i);addRuleButton.focus()" title="Delete rule" name="deleteRuleSlowRequest">
             <i class="fa fa-trash"></i>
           </button>
         </td>
@@ -92,9 +92,6 @@
       </div>
       <div class="col-sm-4">
         <timespan ControlId="durationSlow" [(timeSpan)]="currentRule.timeInterval" placeholder="e.g. 300"></timespan>
-        <div *ngIf="showIntervalRecommendation" class="alert alert-danger" role="alert" style="margin-top:5px" role="alert">
-          It is recommended that the time interval is higher than the minimum duration setting.
-        </div>
       </div>
     </div>
     <div class="row">
@@ -104,15 +101,21 @@
       <div class="col-sm-4">
         <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
           [(ngModel)]="currentRule.path">
-          <div *ngIf="!isValidUrlPattern(currentRule.path)" class="alert alert-danger" role="alert" style="margin-top:5px" role="alert">
-            Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
-          </div>
+        <div *ngIf="!isValidUrlPattern(currentRule.path)" class="alert alert-danger" role="alert" style="margin-top:5px"
+          role="alert">
+          Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
+        </div>
       </div>
     </div>
 
     <div class="row">
-      <div class="col-sm-4">
-        <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule()">Ok</button>
+      <div class="col-sm-6">
+        <div *ngIf="showIntervalRecommendation" class="alert alert-danger" role="alert" style="margin-top:5px"
+          role="alert">
+          Time interval should be higher than the minimum duration setting.
+        </div>
+        <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()"
+          (click)="saveRule();addRuleButton.focus()">Ok</button>
       </div>
     </div>
   </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.html
@@ -70,7 +70,7 @@
         <input aria-required="true" type="number" id="requestsCountSlow" placeholder="Enter count"
           [(ngModel)]="currentRule.count" min="1" max="4294967295">
         <span style="color:red">*</span>
-        <div *ngIf="currentRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+        <div *ngIf="currentRule.count <=0" class="alert alert-danger" role="alert" style="margin-top:5px" role="alert">
           Request count should be more than zero
         </div>
       </div>
@@ -92,7 +92,7 @@
       </div>
       <div class="col-sm-4">
         <timespan ControlId="durationSlow" [(timeSpan)]="currentRule.timeInterval" placeholder="e.g. 300"></timespan>
-        <div *ngIf="showIntervalRecommendation" class="alert alert-danger" style="margin-top:5px">
+        <div *ngIf="showIntervalRecommendation" class="alert alert-danger" role="alert" style="margin-top:5px" role="alert">
           It is recommended that the time interval is higher than the minimum duration setting.
         </div>
       </div>
@@ -104,7 +104,7 @@
       <div class="col-sm-4">
         <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
           [(ngModel)]="currentRule.path">
-          <div *ngIf="!isValidUrlPattern(currentRule.path)" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="!isValidUrlPattern(currentRule.path)" class="alert alert-danger" role="alert" style="margin-top:5px" role="alert">
             Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
           </div>
       </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-slowrequests-rule/autohealing-slowrequests-rule.component.ts
@@ -32,25 +32,21 @@ export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleCompone
   }
 
   isValid(): boolean {
-    this.showIntervalRecommendation = false;
     if (this.currentRule && this.currentRule.timeInterval && this.currentRule.timeInterval !== '' && this.currentRule.timeTaken && this.currentRule.timeTaken != '') {
       let isValid: boolean = this.currentRule.count > 0 && FormatHelper.timespanToSeconds(this.currentRule.timeInterval) > 0 && FormatHelper.timespanToSeconds(this.currentRule.timeTaken) > 0 && this.isValidUrlPattern(this.currentRule.path);
-      if (isValid) {
-        this.showIntervalRecommendation = this.currentRule.timeInterval < this.currentRule.timeTaken
-      }
       return isValid;
     } else {
       return false;
     }
   }
 
-  deleteSingeRule() {
+  deleteSingleRule() {
     this.rule.slowRequests = null;
     this.ruleChange.emit(this.rule);
   }
 
   editSingleRule() {
-    this.currentRule = this.ruleCopy.slowRequests;
+    this.currentRule = this.getClone(this.ruleCopy.slowRequests);
     this.editMode = true;
     this.editingSingleRule = true;
   }
@@ -72,6 +68,12 @@ export class AutohealingSlowrequestsRuleComponent extends AutohealingRuleCompone
   }
 
   saveRule() {
+
+    this.showIntervalRecommendation = this.currentRule.timeInterval < this.currentRule.timeTaken;
+    if (this.showIntervalRecommendation) {
+      return;
+    }
+
     this.editMode = false;
 
     //

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-startup-time/autohealing-startup-time.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-startup-time/autohealing-startup-time.component.html
@@ -1,5 +1,6 @@
 <div *ngIf="!editMode">
-  Override the minimum time the process must execute before excecuting the auto-healing action. This is useful in scenarios where
+  Override the minimum time the process must execute before excecuting the auto-healing action. This is useful in
+  scenarios where
   the app has high startup time and you don't want the mitigation action to kick in during app startup.
   <div class="rule-button">
     <button type="button" class="btn btn-primary btn-sm" (click)="configureMinProcessExecutionTime()">
@@ -11,11 +12,14 @@
 <div class="form-group" *ngIf="editMode">
   <div class="row">
     <div class="col-sm-6">
-      <label for="minProcessExecutionTime">Specify the time (in seconds) after process startup after which autohealing should kick in ?</label>
+      <label for="minProcessExecutionTime">Specify the time (in seconds) after process startup after which autohealing
+        should kick in ?</label>
     </div>
     <div class="col-sm-4">
-      <input aria-required="true" type="number" [(ngModel)]="localMinProcessExecutionTime" id="minProcessExecutionTime" placeholder="e.g. 600" min="1" max="7200">
-      <div style="margin-top:5px" *ngIf="localMinProcessExecutionTime < 0 || localMinProcessExecutionTime > 7200" class="alert alert-danger">
+      <input aria-required="true" type="number" [(ngModel)]="localMinProcessExecutionTime" id="minProcessExecutionTime"
+        placeholder="e.g. 600" min="1" max="7200">
+      <div style="margin-top:5px" *ngIf="localMinProcessExecutionTime < 0 || localMinProcessExecutionTime > 7200"
+        class="alert alert-danger" role="alert">
         Duration should be >= 0 seconds and below 2 hours
       </div>
     </div>
@@ -23,7 +27,7 @@
 
   <div class="row">
     <div class="col-sm-4">
-      <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveConfig()">Ok</button>      
+      <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveConfig()">Ok</button>
     </div>
   </div>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
@@ -4,7 +4,7 @@
   to identify the root cause of the problem. You can configure rules on more than one HTTP Status code condition.
 
   <div class="rule-button">
-    <button type="button" class="btn btn-primary btn-sm" (click)="addNewRule()">
+    <button type="button" #addRuleButton class="btn btn-primary btn-sm" (click)="addNewRule()">
       Add Status Codes rule
     </button>
   </div>
@@ -48,7 +48,7 @@
           <button class="image-btn" *ngIf="!editMode" (click)="editStatusCodeRule(i)" title="Edit rule" name="editRule">
             <i class="fa fa-edit"></i>
           </button>
-          <button class="image-btn" *ngIf="!editMode" (click)="deleteStatusCodeRule(i)" title="Delete rule"
+          <button class="image-btn" *ngIf="!editMode" (click)="deleteStatusCodeRule(i);addRuleButton.focus()" title="Delete rule"
             name="deleteStatusCodeRule">
             <i class="fa fa-trash"></i>
           </button>
@@ -65,7 +65,7 @@
           <button class="image-btn" *ngIf="!editMode" (click)="editRangeRule(i)" title="Edit rule" name="editRangeRule">
             <i class="fa fa-edit"></i>
           </button>
-          <button class="image-btn" *ngIf="!editMode" (click)="deleteRangeRule(i)" title="Delete rule"
+          <button class="image-btn" *ngIf="!editMode" (click)="deleteRangeRule(i);addRuleButton.focus()" title="Delete rule"
             name="deleteRangeRule">
             <i class="fa fa-trash"></i>
           </button>
@@ -212,7 +212,7 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule()">Ok</button>
+        <button type="button" class="btn btn-primary btn-sm" [disabled]="!isValid()" (click)="saveRule();addRuleButton.focus()">Ok</button>
       </div>
     </div>
   </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-statuscodes-rule/autohealing-statuscodes-rule.component.html
@@ -96,7 +96,7 @@
           <input aria-required="true" type="number" id="requestCount" placeholder="Enter request count"
             [(ngModel)]="currentStatusCodeRule.count" min="1" max="4294967295">
           <span style="color:red">*</span>
-          <div *ngIf="currentStatusCodeRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="currentStatusCodeRule.count <=0" class="alert alert-danger" role="alert" style="margin-top:5px">
             Request count should be more than zero
           </div>
         </div>
@@ -110,7 +110,7 @@
             [(ngModel)]="currentStatusCodeRule.status">
           <span style="color:red">*</span>
           <div *ngIf="currentStatusCodeRule.status < 100 || currentStatusCodeRule.status > 530"
-            class="alert alert-danger" style="margin-top:5px">
+            class="alert alert-danger" role="alert" style="margin-top:5px">
             Valid HTTP Status codes range from HTTP 100 to HTTP 530 only.
           </div>
         </div>
@@ -152,7 +152,7 @@
         <div class="col-sm-4">
           <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
             [(ngModel)]="currentStatusCodeRule.path">
-          <div *ngIf="!isValidUrlPattern(currentStatusCodeRule.path)" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="!isValidUrlPattern(currentStatusCodeRule.path)" role="alert" class="alert alert-danger" style="margin-top:5px">
             Path can contain letters, alphabets, *, -, period, _ and forward slashes only
           </div>
         </div>
@@ -168,7 +168,7 @@
           <input aria-required="true" type="number" id="requestCount" placeholder="Enter request count"
             [(ngModel)]="currentRangeRule.count" min="1" max="4294967295">
           <span style="color:red">*</span>
-          <div *ngIf="currentRangeRule.count <=0" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="currentRangeRule.count <=0" class="alert alert-danger" role="alert" style="margin-top:5px">
             Request count should be more than zero
           </div>
         </div>
@@ -181,7 +181,7 @@
           <input type="text" aria-required="true" id="statusCodesRange" placeholder="e.g. 400-500"
             [(ngModel)]="currentRangeRule.statusCodes">
           <span style="color:red">*</span>
-          <div *ngIf="statusCodeRangeError.length > 0" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="statusCodeRangeError.length > 0" class="alert alert-danger" role="alert" style="margin-top:5px">
             {{statusCodeRangeError}}
           </div>
         </div>
@@ -203,7 +203,7 @@
         <div class="col-sm-4">
           <input type="text" aria-required="false" id="requestPath" placeholder="e.g. /default*.aspx"
             [(ngModel)]="currentRangeRule.path">
-          <div *ngIf="!isValidUrlPattern(currentRangeRule.path)" class="alert alert-danger" style="margin-top:5px">
+          <div *ngIf="!isValidUrlPattern(currentRangeRule.path)" class="alert alert-danger" role="alert" style="margin-top:5px">
             Path can contain letters, alphabets, asterisk, dashes, period, underscore and forward slashes only
           </div>
         </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -41,7 +41,7 @@
         Retrieving autoHealing settings...
       </div>
 
-      <div *ngIf="errorMessage" class="alert alert-danger" style="margin-top:5px">
+      <div *ngIf="errorMessage" class="alert alert-danger" role="alert" style="margin-top:5px">
         {{ errorMessage }}
       </div>
 
@@ -177,7 +177,7 @@
           <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
           Saving AutoHeal settings...
         </div>
-        <div *ngIf="errorMessageSaving" class="alert alert-danger" style="margin-top:5px">
+        <div *ngIf="errorMessageSaving" class="alert alert-danger" role="alert" style="margin-top:5px">
           {{ errorMessageSaving }}
         </div>
         <div *ngIf="changesSaved" class="inline" style="color:#0058ad">

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/proactive-autohealing/proactive-autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/proactive-autohealing/proactive-autohealing.component.html
@@ -10,7 +10,7 @@
     <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
     Retrieving proactive autoheal settings...
   </div>
-  <div *ngIf="errorMessage" class="alert alert-danger" style="margin-top:5px">
+  <div *ngIf="errorMessage" class="alert alert-danger" role="alert" style="margin-top:5px">
     {{ errorMessage }}
   </div>
   <div *ngIf="!retrievingProactiveSettings">

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/section-divider/section-divider.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/section-divider/section-divider.component.html
@@ -1,4 +1,4 @@
-<div [id]="label" class="section-divider" tabindex="0" (keyup.enter)="sectionHeaderClick()" [attr.aria-label]="label" role="button" [class.overview-header]="isOverview" [class.not-expandable]="!collapsible" [class.selected]="isSelected()"
+<div [id]="label" class="section-divider" tabindex="0" (keyup.enter)="sectionHeaderClick()" [attr.aria-label]="label" [class.overview-header]="isOverview" [class.not-expandable]="!collapsible" [class.selected]="isSelected()"
   (click)="sectionHeaderClick()" >
   <div>
     <ng-content select=".menu-icon"></ng-content>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-main/daas-main.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-main/daas-main.component.html
@@ -62,7 +62,7 @@
     </div>
 
     <div *ngIf="platform !=null && platform === operatingSystem.linux">
-        <div class="alert alert-danger">
+        <div class="alert alert-danger" role="alert">
             Diagnostics as a Service is supported on Windows Platform only.
         </div>
     </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.html
@@ -103,7 +103,7 @@
                 </div>
                 <div class="panel-body" *ngIf="session.Expanded">
                     <div>
-                        <div *ngIf="session.DeletingFailure" class="alert alert-danger">
+                        <div *ngIf="session.DeletingFailure" class="alert alert-danger" role="alert">
                             {{ session.DeletingFailure}}
                         </div>
                         <div class="table-responsive">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/timespan/timespan.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/timespan/timespan.component.html
@@ -1,6 +1,6 @@
 <input id="{{ ControlId }}" aria-required="true" type="number" min="1" max="3600" [ngModel]="Seconds" [placeholder]="placeholder" 
 (ngModelChange)="updateTimeSpan($event)" [attr.aria-label]="label">
 <span style="color:red">*</span>
-<div style="margin-top:5px" *ngIf="Seconds <=0" class="alert alert-danger">
+<div style="margin-top:5px" *ngIf="Seconds <=0" class="alert alert-danger" role="alert">
     Duration should be greater than 0 seconds
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
@@ -37,7 +37,7 @@
                 </span>
                 <div class="mt-1 mb-4" (click)="toggleStorageAccountPanel()"
                   (keyup.enter)="toggleStorageAccountPanel()">
-                  <a role="button" name="Change storage account" aria-label="Change storage account">
+                  <a tabindex="0" role="button" name="Change storage account" aria-label="Change storage account">
                     {{ chosenStorageAccount && (monitoringEnabled || storageConfiguredAsAppSetting) ? 'Change' : 'Select' }}</a>
                 </div>
               </div>


### PR DESCRIPTION
Fixes for these bugs

ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
1726 | [Genie Bug Bash 2021] - Screen Reader - Diagnostic Tools - Reads 'Proactive Tools' as a button | app-service-diagnostics-portal\2101-1 | New | Accessibility; Screen Reader | 2 | 3/25/2021, 10:09:24 PM
1720 | [Genie Bug Bash 2021] - Keyboard Accessibility - Select button in Crash Monitoring is not accessible | app-service-diagnostics-portal\2101-1 | New | Accessibility; Keyboard | 1 | 3/25/2021, 10:03:23 PM



9584705 | Bug | [Screen Reader - App Services -   Diagnose and solve problems]: Screen reader is not reading the error message   shown after deleting the value from required edit field on the page.
-- | -- | --
9584781 | Bug | [Keyboard Navigation - App   Services - Diagnose and solve problems]: Focus is moving to top of the window   after selecting ‘Delete’ button on ‘Request Duration’ page.

