### PR TITLE
Add log for portal service

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
@@ -55,7 +55,7 @@ export interface Action {
 export interface Message {
     level: LogEntryLevel;
     message: string;
-    restArgs?: any[];
+    restArgs: any[];
 }
 
 export interface OpenBladeInfo {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal.ts
@@ -55,7 +55,7 @@ export interface Action {
 export interface Message {
     level: LogEntryLevel;
     message: string;
-    restArgs: any[];
+    restArgs?: any[];
 }
 
 export interface OpenBladeInfo {

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -7,8 +7,7 @@ import { BroadcastEvent } from '../models/broadcast-event';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { environment } from '../../../../src/environments/environment';
 import { catchError, map, retry } from 'rxjs/operators';
-import { Router } from '@angular/router';
-import { TelemetryEventNames } from 'diagnostic-data'
+import { TelemetryEventNames } from 'diagnostic-data';
 
 const publicOrigins = [
     'portal.azure.com'
@@ -36,7 +35,7 @@ export class PortalService {
     private origin: string;
     private acceptedOriginsSuffix: string[] = [];
 
-    constructor(private _broadcastService: BroadcastService, private _http: HttpClient, private _router: Router) {
+    constructor(private _broadcastService: BroadcastService, private _http: HttpClient) {
         this.sessionId = '';
 
         this.startupInfoObservable = new ReplaySubject<StartupInfo>(1);
@@ -338,7 +337,7 @@ export class PortalService {
         this.logAction('diagnostic-data', eventMessage, {
             ...properties,
             'measurements': measurements,
-            'url': this._router.url,
+            'url': window.location.href,
             'origin': this.origin
         });
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -165,7 +165,6 @@ export class PortalService {
 
         const data = event.data.data;
         const methodName = event.data.kind;
-        console.log(`portal.service, ${methodName}`);
 
         console.log('[iFrame] Received validated mesg: ' + methodName, event, event.srcElement, event.srcElement.location, event.srcElement.location.host);
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -95,7 +95,7 @@ export class PortalService {
             return this.setBladeReturnValueObservable;
         }
         else {
-            this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+            this.logEvent(TelemetryEventNames.PortalIFrameLoadingException, {
                 detail: 'NULL data cannot be set as blade return value.'
             });
             return null;
@@ -114,7 +114,7 @@ export class PortalService {
 
         this._broadcastService.subscribe<ErrorEvent>(BroadcastEvent.Error, error => {
             if (error.details) {
-                this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+                this.logEvent(TelemetryEventNames.PortalIFrameLoadingException, {
                     detail: 'broadcast get error',
                     error: error.details
                 });
@@ -277,7 +277,7 @@ export class PortalService {
                 }
                 return originList;
             }), retry(2), catchError(error => {
-                this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+                this.logEvent(TelemetryEventNames.PortalIFrameLoadingException, {
                     detail: "cannot get origin list from backend appsetting",
                     error: JSON.stringify(error)
                 });
@@ -310,7 +310,7 @@ export class PortalService {
         }
 
         if (!event.origin) {
-            this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+            this.logEvent(TelemetryEventNames.PortalIFrameLoadingException, {
                 detail: "iFrame event does not include origin property"
             });
             return of(false);
@@ -324,7 +324,7 @@ export class PortalService {
         return this._getAcceptOrigins(event).pipe(map(originsSuffix => {
             const originIndex = originsSuffix.findIndex(o => event.origin.toLowerCase().endsWith(o.toLowerCase()));
             if (originIndex === -1) {
-                this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+                this.logEvent(TelemetryEventNames.PortalIFrameLoadingException, {
                     detail: "cannot find origin from origin list"
                 });
             }

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -112,7 +112,7 @@ export class PortalService {
 
         this._broadcastService.subscribe<ErrorEvent>(BroadcastEvent.Error, error => {
             if (error.details) {
-                this.logException('broadcast get error',{error: error.details});
+                this.logException('broadcast get error', { error: error.details });
             }
         });
     }
@@ -154,8 +154,8 @@ export class PortalService {
             level: level,
             message: message
         }
-        if(properties) {
-             const restArgs  = Object.entries(properties).map(entry => {
+        if (properties) {
+            const restArgs = Object.entries(properties).map(entry => {
                 let obj = {};
                 obj[entry[0]] = JSON.stringify(entry[1]);
                 return obj;
@@ -197,7 +197,7 @@ export class PortalService {
                 this.logEvent(TelemetryEventNames.PortalIFrameLoadingSuccess, {
                     'portalSessionId': this.sessionId
                 });
-                this.logMessage(LogEntryLevel.Verbose,TelemetryEventNames.PortalIFrameLoadingSuccess,{
+                this.logMessage(LogEntryLevel.Verbose, TelemetryEventNames.PortalIFrameLoadingSuccess, {
                     'portalSessionId': this.sessionId
                 });
             } else if (methodName === Verbs.sendAppInsightsResource) {
@@ -292,7 +292,7 @@ export class PortalService {
                 }
                 return originList;
             }), retry(2), catchError(error => {
-                this.logException("cannot get origin list from backend appsetting",{error: JSON.stringify(error)});
+                this.logException("cannot get origin list from backend appsetting", { error: JSON.stringify(error) });
 
                 return throwError(error);
             }));
@@ -319,7 +319,7 @@ export class PortalService {
             this.logEvent(TelemetryEventNames.PortalIFrameLoadingStart, {
                 'portalSessionId': this.sessionId
             });
-            this.logMessage(LogEntryLevel.Verbose,TelemetryEventNames.PortalIFrameLoadingStart,{
+            this.logMessage(LogEntryLevel.Verbose, TelemetryEventNames.PortalIFrameLoadingStart, {
                 'portalSessionId': this.sessionId
             });
         }
@@ -362,6 +362,6 @@ export class PortalService {
             detail: exceptionMessage,
             ...properties
         });
-        this.logMessage(LogEntryLevel.Error, exceptionMessage,properties);
+        this.logMessage(LogEntryLevel.Error, exceptionMessage, properties);
     }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/portal.service.ts
@@ -114,8 +114,8 @@ export class PortalService {
 
         this._broadcastService.subscribe<ErrorEvent>(BroadcastEvent.Error, error => {
             if (error.details) {
-                this.logEvent(TelemetryEventNames.PortalIFrameLoadException,{
-                    detail:'broadcast get error',
+                this.logEvent(TelemetryEventNames.PortalIFrameLoadException, {
+                    detail: 'broadcast get error',
                     error: error.details
                 });
             }
@@ -182,7 +182,7 @@ export class PortalService {
                 info.isIFrameForCaseSubmissionSolution = isIFrameForCaseSubmissionSolution;
                 this.startupInfoObservable.next(info);
                 this.isIFrameForCaseSubmissionSolution.next(isIFrameForCaseSubmissionSolution);
-                this.logEvent(TelemetryEventNames.PortalIFrameLoadingSuccess,{
+                this.logEvent(TelemetryEventNames.PortalIFrameLoadingSuccess, {
                     'portalSessionId': this.sessionId
                 });
             } else if (methodName === Verbs.sendAppInsightsResource) {
@@ -334,11 +334,15 @@ export class PortalService {
 
     //log into Kusto for portal event
     private logEvent(eventMessage: string, properties: { [name: string]: string }, measurements?: any) {
-        this.logAction('diagnostic-data', eventMessage, {
+        const eventProp = {
             ...properties,
             'measurements': measurements,
             'url': window.location.href,
             'origin': this.origin
-        });
+        };
+        if (!eventProp["portalSessionId"] && this.sessionId !== "") {
+            eventProp["portalSessionId"] = this.sessionId;
+        }
+        this.logAction('diagnostic-data', eventMessage, eventProp);
     }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -81,7 +81,7 @@ export const TelemetryEventNames = {
     IncidentValidationCheck: 'IncidentValidationCheck',
     IncidentUpdateOperation: 'IncidentUpdateOperation',
     RiskAlertNotificationLoaded: 'RiskAlertNotificationLoaded',
-    PortalIFrameLoadException: 'PortalIFrameOpenException',
+    PortalIFrameLoadingException: 'PortalIFrameLoadingException',
     PortalIFrameLoadingSuccess: 'PortalIFrameLoadingSuccess',
     PortalIFrameLoadingStart: 'PortalIFrameLoadingStart'
 };

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -81,6 +81,9 @@ export const TelemetryEventNames = {
     IncidentValidationCheck: 'IncidentValidationCheck',
     IncidentUpdateOperation: 'IncidentUpdateOperation',
     RiskAlertNotificationLoaded: 'RiskAlertNotificationLoaded',
+    PortalIFrameLoadException: 'PortalIFrameOpenException',
+    PortalIFrameLoadingSuccess: 'PortalIFrameLoadingSuccess',
+    PortalIFrameLoadingStart: 'PortalIFrameLoadingStart'
 };
 
 export const TelemetrySource = {


### PR DESCRIPTION
This PR is [BUG 1744 AKS Resource cannot open D&S blade in Mooncake - Add Alert whenever Diag Solve Homepage doesnt load](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1744/) 

I add three events(**PortalIFrameLoadingException/PortalIFrameLoadingSuccess/PortalIFrameLoadingStart**) into kusto logging so we can get overall sessions opening iFrame, sessions open successfully, sessions have exception when opening iFrame 

