### PR TITLE
Rendering table cell with markdown

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -20,7 +20,14 @@
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>
             <ng-template let-item="item" let-column="column" let-rowIndex="index">
-              <div [innerHTML]="item[column.name]"></div>
+              <!-- <ng-container *ngIf="isMarkdown(item[column.name]) else embedHTML">
+                <markdown-text [markdownData]="item[column.name]"></markdown-text>
+              </ng-container> -->
+              <ng-container 
+                [ngTemplateOutlet]="isMarkdown(item[column.name]) ? markdownText : embeddedHTML"
+                [ngTemplateOutletContext]="{data:item[column.name]}"
+              >
+              </ng-container>
             </ng-template>
           </render>
         </fab-details-list-column>
@@ -36,4 +43,12 @@
   <div tabindex="0" class="table-footer">
     <p>No Data to Display</p>
   </div>
+</ng-template>
+
+<ng-template #markdownText let-data='data'>
+  <markdown-text [markdownData]="data"></markdown-text>
+</ng-template>
+
+<ng-template #embeddedHTML let-data='data'>
+  <div [innerHTML]="data"></div>
 </ng-template>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -20,9 +20,6 @@
           [isResizable]="col.isResizable" [isMultiline]="col.isMultiline" [ariaLabel]="col.name">
           <render>
             <ng-template let-item="item" let-column="column" let-rowIndex="index">
-              <!-- <ng-container *ngIf="isMarkdown(item[column.name]) else embedHTML">
-                <markdown-text [markdownData]="item[column.name]"></markdown-text>
-              </ng-container> -->
               <ng-container 
                 [ngTemplateOutlet]="isMarkdown(item[column.name]) ? markdownText : embeddedHTML"
                 [ngTemplateOutletContext]="{data:item[column.name]}"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -271,6 +271,11 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     const columns = this.diagnosticData.table.columns;
     return columns.findIndex(col => col.columnName === option.name) > -1;
   }
+
+  isMarkdown(s: any) {
+    const str = `${s}`;
+    return str.trim().startsWith('<markdown>') && str.endsWith('</markdown>');
+  }
 }
 
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -273,8 +273,9 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
   }
 
   isMarkdown(s: any) {
-    const str = `${s}`;
-    return str.trim().startsWith('<markdown>') && str.endsWith('</markdown>');
+    let str = `${s}`;
+    str = str.trim();
+    return str.startsWith('<markdown>') && str.endsWith('</markdown>');
   }
 }
 


### PR DESCRIPTION
This PR is to enable datable to support data-table to rending cells with markdown. For now, if you want  to render some logs with highlight or customized text style, I recommend to use markdown(<markdown></markdown>) instead of embedded HTML, since some styles will not show up for embedded HTML