### PR TITLE
Updated web search component to make calls to Deep Search for specific support topics

### DIFF
--- a/AngularApp/npm-shrinkwrap.json
+++ b/AngularApp/npm-shrinkwrap.json
@@ -4477,6 +4477,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "char-props": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
+      "integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4="
+    },
     "charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -4669,6 +4674,11 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
     },
     "co": {
       "version": "4.6.0",
@@ -5670,6 +5680,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -8122,6 +8141,140 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "gulp-jsmin": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/gulp-jsmin/-/gulp-jsmin-0.1.5.tgz",
+      "integrity": "sha1-Uqa9ASkf+NDhoSJaPLX3Aj+O+Yc=",
+      "requires": {
+        "filesize": "~2.0.0",
+        "graceful-fs": "~2.0.0",
+        "gulp-rename": "~1.1.0",
+        "gulp-util": "~2.2.0",
+        "jsmin-sourcemap": "~0.16.0",
+        "map-stream": "0.0.4",
+        "temp-write": "~0.1.0"
+      },
+      "dependencies": {
+        "filesize": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-2.0.4.tgz",
+          "integrity": "sha1-eAWUHGD83+Y/RtfqNYxZreEcEyU="
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+        }
+      }
+    },
+    "gulp-rename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.1.0.tgz",
+      "integrity": "sha1-kwkKqvTThsB/IFOKaIjxXvunJ6E=",
+      "requires": {
+        "map-stream": ">=0.0.4"
+      }
+    },
+    "gulp-util": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+      "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
+      "requires": {
+        "chalk": "^0.5.0",
+        "dateformat": "^1.0.7-1.2.3",
+        "lodash._reinterpolate": "^2.4.1",
+        "lodash.template": "^2.4.1",
+        "minimist": "^0.2.0",
+        "multipipe": "^0.1.0",
+        "through2": "^0.5.0",
+        "vinyl": "^0.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "requires": {
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "requires": {
+            "ansi-regex": "^0.2.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimist": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "requires": {
+            "ansi-regex": "^0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+        },
+        "through2": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
+          }
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -8354,10 +8507,11 @@
       }
     },
     "highcharts-custom-events": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/highcharts-custom-events/-/highcharts-custom-events-3.0.10.tgz",
-      "integrity": "sha512-swD0v8qovr9tzW6wNdebJKWQS5xTUclU2XznZw7+U6zMpedzEw7nxMZCog+P3JBDvp2cLO8ySiy7EC29DayfFw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/highcharts-custom-events/-/highcharts-custom-events-2.2.2.tgz",
+      "integrity": "sha512-eb4fn6HlqsEUttKsDV4LEdySSQTQO0EMgJeDfzr7XgG/YRhbPP17ISgWBCHmLf7WMUd+RiXfg6S0o5pG4u9g5w==",
       "requires": {
+        "gulp-jsmin": "^0.1.5",
         "highcharts": ">=5.0.9"
       }
     },
@@ -9490,6 +9644,20 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
+    "jsmin-sourcemap": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jsmin-sourcemap/-/jsmin-sourcemap-0.16.0.tgz",
+      "integrity": "sha1-1Z6Iobc7umcPw7OYzZ+Wf0v8zKo=",
+      "requires": {
+        "jsmin2": "~1.1.1",
+        "source-map-index-generator": "~0.1.1"
+      }
+    },
+    "jsmin2": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/jsmin2/-/jsmin2-1.1.9.tgz",
+      "integrity": "sha1-qHyr7GatsX9RwMLvIkrvDGloaE8="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9974,6 +10142,56 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash._escapehtmlchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+      "requires": {
+        "lodash._htmlescapes": "~2.4.1"
+      }
+    },
+    "lodash._escapestringchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
+    },
+    "lodash._htmlescapes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
+    },
+    "lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+    },
+    "lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+    },
+    "lodash._reinterpolate": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+      "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
+    },
+    "lodash._reunescapedhtml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+      "requires": {
+        "lodash._htmlescapes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+      "requires": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -9986,10 +10204,78 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+      "requires": {
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "lodash.escape": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+      "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+      "requires": {
+        "lodash._escapehtmlchar": "~2.4.1",
+        "lodash._reunescapedhtml": "~2.4.1",
+        "lodash.keys": "~2.4.1"
+      }
+    },
+    "lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+      "requires": {
+        "lodash._objecttypes": "~2.4.1"
+      }
+    },
+    "lodash.keys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+      "requires": {
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
+      }
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
+    },
+    "lodash.template": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+      "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+      "requires": {
+        "lodash._escapestringchar": "~2.4.1",
+        "lodash._reinterpolate": "~2.4.1",
+        "lodash.defaults": "~2.4.1",
+        "lodash.escape": "~2.4.1",
+        "lodash.keys": "~2.4.1",
+        "lodash.templatesettings": "~2.4.1",
+        "lodash.values": "~2.4.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+      "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+      "requires": {
+        "lodash._reinterpolate": "~2.4.1",
+        "lodash.escape": "~2.4.1"
+      }
+    },
+    "lodash.values": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+      "requires": {
+        "lodash.keys": "~2.4.1"
+      }
     },
     "log4js": {
       "version": "2.11.0",
@@ -10451,6 +10737,11 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
+    "map-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz",
+      "integrity": "sha1-XsbekCE+9sey65Nn6a3o2k79tos="
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -10787,6 +11078,45 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "requires": {
+            "readable-stream": "~1.1.9"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -14146,6 +14476,25 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-index-generator": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/source-map-index-generator/-/source-map-index-generator-0.1.2.tgz",
+      "integrity": "sha1-e5IeTty3CG5IDcXNZKMshvnv+r0=",
+      "requires": {
+        "char-props": "~0.1.3",
+        "source-map": "~0.1.8"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "source-map-loader": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
@@ -14664,6 +15013,37 @@
         "block-stream": "*",
         "fstream": "^1.0.12",
         "inherits": "2"
+      }
+    },
+    "temp-write": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-0.1.1.tgz",
+      "integrity": "sha1-C2Rng43Xf79/YqDJPah5cy/9qTI=",
+      "requires": {
+        "graceful-fs": "~2.0.0",
+        "tempfile": "~0.1.2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+        }
+      }
+    },
+    "tempfile": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
+      "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
+      "requires": {
+        "uuid": "~1.4.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
+          "integrity": "sha1-RTAZ9oaWam34PNxSROfJkOzDMvw="
+        }
       }
     },
     "term-size": {
@@ -15516,6 +15896,14 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vinyl": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+      "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
+      "requires": {
+        "clone-stats": "~0.0.1"
       }
     },
     "vis": {

--- a/AngularApp/npm-shrinkwrap.json
+++ b/AngularApp/npm-shrinkwrap.json
@@ -4477,11 +4477,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "char-props": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
-      "integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4="
-    },
     "charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -4674,11 +4669,6 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
     },
     "co": {
       "version": "4.6.0",
@@ -5680,15 +5670,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
-    },
-    "dateformat": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -8141,140 +8122,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
-    "gulp-jsmin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/gulp-jsmin/-/gulp-jsmin-0.1.5.tgz",
-      "integrity": "sha1-Uqa9ASkf+NDhoSJaPLX3Aj+O+Yc=",
-      "requires": {
-        "filesize": "~2.0.0",
-        "graceful-fs": "~2.0.0",
-        "gulp-rename": "~1.1.0",
-        "gulp-util": "~2.2.0",
-        "jsmin-sourcemap": "~0.16.0",
-        "map-stream": "0.0.4",
-        "temp-write": "~0.1.0"
-      },
-      "dependencies": {
-        "filesize": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-2.0.4.tgz",
-          "integrity": "sha1-eAWUHGD83+Y/RtfqNYxZreEcEyU="
-        },
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
-        }
-      }
-    },
-    "gulp-rename": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.1.0.tgz",
-      "integrity": "sha1-kwkKqvTThsB/IFOKaIjxXvunJ6E=",
-      "requires": {
-        "map-stream": ">=0.0.4"
-      }
-    },
-    "gulp-util": {
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-      "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-      "requires": {
-        "chalk": "^0.5.0",
-        "dateformat": "^1.0.7-1.2.3",
-        "lodash._reinterpolate": "^2.4.1",
-        "lodash.template": "^2.4.1",
-        "minimist": "^0.2.0",
-        "multipipe": "^0.1.0",
-        "through2": "^0.5.0",
-        "vinyl": "^0.2.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
-          }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "requires": {
-            "ansi-regex": "^0.2.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "minimist": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "requires": {
-            "ansi-regex": "^0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-        },
-        "through2": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
-      }
-    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -8507,11 +8354,10 @@
       }
     },
     "highcharts-custom-events": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/highcharts-custom-events/-/highcharts-custom-events-2.2.2.tgz",
-      "integrity": "sha512-eb4fn6HlqsEUttKsDV4LEdySSQTQO0EMgJeDfzr7XgG/YRhbPP17ISgWBCHmLf7WMUd+RiXfg6S0o5pG4u9g5w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/highcharts-custom-events/-/highcharts-custom-events-3.0.10.tgz",
+      "integrity": "sha512-swD0v8qovr9tzW6wNdebJKWQS5xTUclU2XznZw7+U6zMpedzEw7nxMZCog+P3JBDvp2cLO8ySiy7EC29DayfFw==",
       "requires": {
-        "gulp-jsmin": "^0.1.5",
         "highcharts": ">=5.0.9"
       }
     },
@@ -9644,20 +9490,6 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
-    "jsmin-sourcemap": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jsmin-sourcemap/-/jsmin-sourcemap-0.16.0.tgz",
-      "integrity": "sha1-1Z6Iobc7umcPw7OYzZ+Wf0v8zKo=",
-      "requires": {
-        "jsmin2": "~1.1.1",
-        "source-map-index-generator": "~0.1.1"
-      }
-    },
-    "jsmin2": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/jsmin2/-/jsmin2-1.1.9.tgz",
-      "integrity": "sha1-qHyr7GatsX9RwMLvIkrvDGloaE8="
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -10142,56 +9974,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash._escapehtmlchar": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-      "requires": {
-        "lodash._htmlescapes": "~2.4.1"
-      }
-    },
-    "lodash._escapestringchar": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
-    },
-    "lodash._htmlescapes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
-    },
-    "lodash._isnative": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-    },
-    "lodash._objecttypes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-    },
-    "lodash._reinterpolate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-      "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
-    },
-    "lodash._reunescapedhtml": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-      "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash._shimkeys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -10204,78 +9986,10 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.defaults": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash.escape": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-      "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-      "requires": {
-        "lodash._escapehtmlchar": "~2.4.1",
-        "lodash._reunescapedhtml": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "lodash.keys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-      "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash._shimkeys": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
-    },
-    "lodash.template": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-      "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-      "requires": {
-        "lodash._escapestringchar": "~2.4.1",
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.defaults": "~2.4.1",
-        "lodash.escape": "~2.4.1",
-        "lodash.keys": "~2.4.1",
-        "lodash.templatesettings": "~2.4.1",
-        "lodash.values": "~2.4.1"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-      "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-      "requires": {
-        "lodash._reinterpolate": "~2.4.1",
-        "lodash.escape": "~2.4.1"
-      }
-    },
-    "lodash.values": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-      "requires": {
-        "lodash.keys": "~2.4.1"
-      }
     },
     "log4js": {
       "version": "2.11.0",
@@ -10737,11 +10451,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
-    "map-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz",
-      "integrity": "sha1-XsbekCE+9sey65Nn6a3o2k79tos="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -11078,45 +10787,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
-    },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "requires": {
-        "duplexer2": "0.0.2"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "requires": {
-            "readable-stream": "~1.1.9"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -14476,25 +14146,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
-    "source-map-index-generator": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/source-map-index-generator/-/source-map-index-generator-0.1.2.tgz",
-      "integrity": "sha1-e5IeTty3CG5IDcXNZKMshvnv+r0=",
-      "requires": {
-        "char-props": "~0.1.3",
-        "source-map": "~0.1.8"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "source-map-loader": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
@@ -15013,37 +14664,6 @@
         "block-stream": "*",
         "fstream": "^1.0.12",
         "inherits": "2"
-      }
-    },
-    "temp-write": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-0.1.1.tgz",
-      "integrity": "sha1-C2Rng43Xf79/YqDJPah5cy/9qTI=",
-      "requires": {
-        "graceful-fs": "~2.0.0",
-        "tempfile": "~0.1.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
-        }
-      }
-    },
-    "tempfile": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
-      "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
-      "requires": {
-        "uuid": "~1.4.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
-          "integrity": "sha1-RTAZ9oaWam34PNxSROfJkOzDMvw="
-        }
       }
     },
     "term-size": {
@@ -15896,14 +15516,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vinyl": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-      "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-      "requires": {
-        "clone-stats": "~0.0.1"
       }
     },
     "vis": {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -4,7 +4,7 @@ import { Observable, of, BehaviorSubject, Subject, ReplaySubject  } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ResourceService } from './resource.service';
 import { BackendCtrlService } from '../../shared/services/backend-ctrl.service';
-import {globalExcludedSites} from "diagnostic-data";
+import {DocumentSearchConfiguration, globalExcludedSites, Query} from "diagnostic-data";
 
 @Injectable()
 export class ContentService {
@@ -14,6 +14,12 @@ export class ContentService {
   private ocpApimKeySubject: Subject<string> = new ReplaySubject<string>(1);
   private ocpApimKey: string = '';
   private allowedStacks: string[] = ["net", "net core", "asp", "php", "python", "node", "docker", "java", "tomcat", "kube", "ruby", "dotnet", "static"];
+  private authKey: string = "";
+  private deepSearchEndpoint : string = "";
+  private _config : DocumentSearchConfiguration;
+  private featureEnabledForSupportTopic: boolean = false;
+  httpOptions = {}
+
   
   constructor(private _http: HttpClient, private _resourceService: ResourceService, private _backendApi: BackendCtrlService) { 
 
@@ -21,6 +27,10 @@ export class ContentService {
       this.ocpApimKey = value;
       this.ocpApimKeySubject.next(value);
     });
+
+    this._config = new DocumentSearchConfiguration();
+    this.fetchAppSettingsNeededForDeepSearch();
+
   }
 
   getContent(searchString?: string): Observable<any[]> {
@@ -73,6 +83,76 @@ export class ContentService {
     const query = encodeURIComponent(`${questionString}${useStack ? stackTypeSuffix : ''} AND ${searchSuffix}${preferredSitesSuffix}${excludedSitesSuffix}`);
     return query;
   }
+
+  
+  private fetchAppSettingsNeededForDeepSearch() {
+    this._backendApi.get<string>(`api/appsettings/DeepSearch:Endpoint`).subscribe((value: string) => {
+      this.deepSearchEndpoint = value;
+    });
+
+    this._backendApi.get<string>(`api/appsettings/DeepSearch:AuthKey`).subscribe((value: string) => {
+      this.authKey = value;
+      this.httpOptions = {
+        headers: new HttpHeaders({
+          "Content-Type": "application/json",
+          "authKey": this.authKey
+        })
+      };
+    });
+  }
+
+  public IsDeepSearchEnabled(pesId : string, supportTopicId : string) : Observable<boolean> {
+    // featureEnabledForProduct is disabled by default
+    var isPesIdValid = pesId && pesId.length >0 ;
+    var isSupportTopicIdValid = supportTopicId && supportTopicId.length > 0;
+    if( isPesIdValid && isSupportTopicIdValid)
+    {
+      pesId = pesId.trim();
+      supportTopicId = supportTopicId.trim();
+
+      var listOfEnabledSupportTopics =  this._config.documentSearchEnabledSupportTopicIds[pesId];
+    
+      var isDeepSearchEnabledForThisSupportTopic = listOfEnabledSupportTopics && (listOfEnabledSupportTopics.findIndex( x => x == supportTopicId ) > -1)
+      this.featureEnabledForSupportTopic = isDeepSearchEnabledForThisSupportTopic ;
+    }
+   
+    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
+                            // Value in App Service Application Settings are returned as strings
+                            // converting this to boolean
+                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForSupportTopic) );
+
+
+  }
+
+  public fetchResultsFromDeepSearch(query : Query): Observable<any>
+  {
+    if(query.bingSearchEnabled){
+      query.customFilterConditionsForBing = this.constructQueryParameters(query.searchTerm, query.useStack, query.preferredSitesFromBing, query.excludedSitesFromBing);
+      // Removing preferredSitesFromBing, excludedSitesFromBing, useStack as it is merged into customFilterConditionsForBing.
+      query.preferredSitesFromBing = null;
+      query.excludedSitesFromBing = null;
+      query.useStack = null;
+    }
+    let queryString = this.constructUrl(query);
+    return this._http.get<any>(this.deepSearchEndpoint+ "?" +queryString   , this.httpOptions)
+  }
+
+  private constructUrl(query: Query) : string{
+    let  queryString = Object.keys(query).map(key => {
+      if(query[key]){
+        if(typeof (query[key] ) === "object" ){
+          return query[key].map( value => {
+            if (value != "")
+              return key + "=" + value
+            }).join("&");
+        }
+        else
+          return key + '=' + query[key]
+      }      
+    }).filter(queryParam => queryParam!=null ).join("&");
+    return queryString;
+  }
+
 }
 
 export interface SearchResults {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -34,29 +34,7 @@ export class ContentService {
 
   searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = globalExcludedSites): Observable<any> {
 
-    const searchSuffix = this._resourceService.searchSuffix;
-
-    //Decide the stack type to use with query
-    var stackTypeSuffix = this._resourceService["appStack"]? ` ${this._resourceService["appStack"]}`: "";
-    stackTypeSuffix = stackTypeSuffix.toLowerCase();
-    if (stackTypeSuffix && stackTypeSuffix.length>0 && stackTypeSuffix == "static only") {
-      stackTypeSuffix = "static content";
-    }
-    if(!this.allowedStacks.some(stack => stackTypeSuffix.includes(stack))){
-      stackTypeSuffix = "";
-    }
-
-    var preferredSitesSuffix = preferredSites.map(site => `site:${site}`).join(" OR ");
-    if (preferredSitesSuffix && preferredSitesSuffix.length>0){
-      preferredSitesSuffix = ` AND (${preferredSitesSuffix})`;
-    }
-    
-    var excludedSitesSuffix = excludedSites.map(site => `NOT (site:${site})`).join(" AND ");
-    if (excludedSitesSuffix && excludedSitesSuffix.length>0){
-      excludedSitesSuffix = ` AND (${excludedSitesSuffix})`;
-    }
-
-    const query = encodeURIComponent(`${questionString}${useStack? stackTypeSuffix: ''} AND ${searchSuffix}${preferredSitesSuffix}${excludedSitesSuffix}`);
+    const query = this.constructQueryParameters(questionString, useStack,preferredSites, excludedSites);
     const url = `https://api.cognitive.microsoft.com/bing/v7.0/search?q='${query}'&count=${resultsCount}`;
 
     return this.ocpApimKeySubject.pipe(mergeMap((key:string)=>{
@@ -68,6 +46,32 @@ export class ContentService {
         })
       })
     );
+  }
+
+  public constructQueryParameters(questionString: string, useStack: boolean, preferredSites: string[], excludedSites: string[],) : string {
+    const searchSuffix = this._resourceService.searchSuffix;
+    //Decide the stack type to use with query
+    var stackTypeSuffix = this._resourceService["appStack"] ? ` ${this._resourceService["appStack"]}` : "";
+    stackTypeSuffix = stackTypeSuffix.toLowerCase();
+    if (stackTypeSuffix && stackTypeSuffix.length > 0 && stackTypeSuffix == "static only") {
+      stackTypeSuffix = "static content";
+    }
+    if (!this.allowedStacks.some(stack => stackTypeSuffix.includes(stack))) {
+      stackTypeSuffix = "";
+    }
+
+    var preferredSitesSuffix = preferredSites.map(site => `site:${site}`).join(" OR ");
+    if (preferredSitesSuffix && preferredSitesSuffix.length > 0) {
+      preferredSitesSuffix = ` AND (${preferredSitesSuffix})`;
+    }
+
+    var excludedSitesSuffix = excludedSites.map(site => `NOT (site:${site})`).join(" AND ");
+    if (excludedSitesSuffix && excludedSitesSuffix.length > 0) {
+      excludedSitesSuffix = ` AND (${excludedSitesSuffix})`;
+    }
+
+    const query = encodeURIComponent(`${questionString}${useStack ? stackTypeSuffix : ''} AND ${searchSuffix}${preferredSitesSuffix}${excludedSitesSuffix}`);
+    return query;
   }
 }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
@@ -38,19 +38,16 @@ export class DocumentSearchService {
 
   }
 
-  public IsEnabled(pesId : string, supportTopicId : string, isPublic : boolean) : Observable<boolean> {
+  public IsEnabled(pesId : string) : Observable<boolean> {
     // featureEnabledForProduct is disabled by default
 
     var isPesIdValid = pesId && pesId.length >0 ;
-    var isSupportTopicIdValid = supportTopicId && supportTopicId.length > 0;
-    if( isPesIdValid && isSupportTopicIdValid)
+    if( isPesIdValid )
     {
       pesId = pesId.trim();
-      supportTopicId = supportTopicId.trim();
-
-      var listOfEnabledSupportTopics =  this._config.documentSearchEnabledSupportTopicIds[pesId] ;    
-      var isDeepSearchEnabledForThisSupportTopic = listOfEnabledSupportTopics && (listOfEnabledSupportTopics.findIndex( x => x == supportTopicId ) > -1)
-      this.featureEnabledForPesId = isDeepSearchEnabledForThisSupportTopic ;
+      var listOfEnabledPesIds =  this._config.documentSearchEnabledSupportTopicIds[pesId] ;    
+      var isDeepSearchEnabledForThisPesId = listOfEnabledPesIds && (listOfEnabledPesIds.findIndex( x => x == pesId ) > -1)
+      this.featureEnabledForPesId = isDeepSearchEnabledForThisPesId ;
     }
    
     return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
@@ -81,12 +78,4 @@ export class DocumentSearchService {
     var baseUrl = this.url
     return this.http.get<Document[]>(baseUrl  + "?" +queryString, this.httpOptions)
   }
-
-  public searchWeb(query : Query): Observable<any>
-  {
-    let queryString = this.constructUrl(query);
-    var baseUrl = this.url
-    return this.http.get<any>(baseUrl+ "?" +queryString   , this.httpOptions)
-  }
-
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
@@ -12,7 +12,7 @@ export class DocumentSearchService {
   private authKey: string = "";
   private url : string = "";
   private _config : DocumentSearchConfiguration;
-  private featureEnabledForSupportTopic: boolean = false;
+  private featureEnabledForPesId  : boolean = false;
 
   httpOptions = {}
 
@@ -48,17 +48,15 @@ export class DocumentSearchService {
       pesId = pesId.trim();
       supportTopicId = supportTopicId.trim();
 
-      var listOfEnabledSupportTopics =  isPublic ? this._config.documentSearchEnabledSupportTopicIds[pesId] :
-                                                   this._config.documentSearchEnabledSupportTopicIdsInternal[pesId];
-    
+      var listOfEnabledSupportTopics =  this._config.documentSearchEnabledSupportTopicIds[pesId] ;    
       var isDeepSearchEnabledForThisSupportTopic = listOfEnabledSupportTopics && (listOfEnabledSupportTopics.findIndex( x => x == supportTopicId ) > -1)
-      this.featureEnabledForSupportTopic = isDeepSearchEnabledForThisSupportTopic ;
+      this.featureEnabledForPesId = isDeepSearchEnabledForThisSupportTopic ;
     }
    
     return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
                             // Value in App Service Application Settings are returned as strings
                             // converting this to boolean
-                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForSupportTopic) );
+                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForPesId) );
 
 
   }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
@@ -36,12 +36,9 @@ export class ApplensDocumentsSearchService {
     
   }
 
-  public IsEnabled(pesId : string, isPublic : boolean) : Observable<boolean> {
+  public IsEnabled(pesId : string) : Observable<boolean> {
     // featureEnabledForProduct is disabled by default
-    if ( pesId.length >0 && ( (isPublic && this._config.documentSearchEnabledPesIds.findIndex(x => x==pesId)>=0) || 
-                              (!isPublic && this._config.documentSearchEnabledPesIdsInternal.findIndex(x => x==pesId)>=0)
-                            ) 
-        ){
+    if ( pesId.length >0 && this._config.documentSearchEnabledPesIdsInternal.findIndex(x => x==pesId)>=0){
           this.featureEnabledForProduct = true;
     }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -278,7 +278,7 @@
     </web-search>
   </div>
 
-  <div *ngIf="isDynamicAnalysis && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch)"
+  <div *ngIf="!isPublic && isDynamicAnalysis && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch)"
     style="margin-left:80px;margin-top:20px;">
     <documents-search   [searchTerm]="searchTerm"
                         [searchId] = "searchId"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -278,7 +278,7 @@
     </web-search>
   </div>
 
-  <div *ngIf="!isPublic && isDynamicAnalysis && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch)"
+  <div *ngIf="!isPublic && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch )"
     style="margin-left:80px;margin-top:20px;">
     <documents-search   [searchTerm]="searchTerm"
                         [searchId] = "searchId"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.html
@@ -177,13 +177,14 @@
     </web-search>
 </div>
 
-<div style="margin-left:20px;margin-top:20px;" *ngIf="searchConfiguration.WebSearchEnabled">
+<div style="margin-left:20px;margin-top:20px;" *ngIf="!isPublic && searchConfiguration.WebSearchEnabled">
     <documents-search   [searchTerm]="searchTerm"
                         [searchId] = "searchId"
                         [isChildComponent]="true"
                         [numDocumentsExpanded] = 2>
     </documents-search>
 </div>
+
 <div *ngIf="isPublic && showScrollButton && (detectors.length>0 || !(!webSearchResults || webSearchResults.length==0))" class="more-results-button">
     <fab-primary-button
         text='More Results' [iconProps]="moreResultsIconProps" [styles]="moreResultsButtonStyles" (onClick)="scrollToResults()">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
@@ -12,6 +12,7 @@ import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagn
 import { GenericDocumentsSearchService } from '../../services/generic-documents-search.service';
 import { Query } from '../../models/documents-search-models';
 import { GenericResourceService } from '../../services/generic-resource-service';
+import { GenericSupportTopicService } from '../../services/generic-support-topic.service';
 
 
 @Component({
@@ -30,6 +31,7 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
   viewRemainingDocuments : boolean = false;
   isPublic : boolean = true;
   pesId : string = "";
+  supportTopicId : string = "";
   searchTermDisplay = ""
   preLoadingErrorMessage: string = "Some error occurred while fetching Deep Search results. "
   subscription: ISubscription;
@@ -44,6 +46,8 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
  
   constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig, 
               private _documentsSearchService : GenericDocumentsSearchService,
+
+              private _supportTopicService: GenericSupportTopicService,
               public telemetryService: TelemetryService,
               private _activatedRoute: ActivatedRoute ,
               private _router: Router,
@@ -51,6 +55,7 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
     super(telemetryService);
  
     this.isPublic = config && config.isPublic;
+    this.supportTopicId = this._supportTopicService.supportTopicId;
     const subscription = this._activatedRoute.queryParamMap.subscribe(qParams => {
       this.searchTerm = qParams.get('searchTerm') === null ? "" || this.searchTerm : qParams.get('searchTerm');
       this.getPesId();
@@ -78,7 +83,7 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
 
   checkIfEnabled () {
     let checkStatusTask = this._documentsSearchService
-                         .IsEnabled(this.pesId, this.isPublic )
+                         .IsEnabled(this.pesId, this.supportTopicId, this.isPublic )
                          .pipe( map((res) => res), 
                                 retryWhen(errors => {
                                 let numRetries = 0;
@@ -136,16 +141,19 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
     if (!this.isChildComponent || !this.searchId || this.searchId.length <1)
       this.searchId = uuid();
     
-    
-    let query: Query = {
-      "searchId" : this.searchId,
-      "searchTerm" : this.searchTerm,
-      "productName" : "App Services" ,
-      "documentType" : this.isPublic ? "External" : "Internal" ,
-      "documentSource" : [],
-      "numberOfDocuments" : 5  
-
-    };
+    var query = new Query();
+    query.searchTerm = this.searchTerm;
+    query.searchId = this.searchId;
+    query.numberOfDocuments = 5;
+    query.productName = "App Services";
+    query.documentType = this.isPublic ? "External" : "Internal" ;
+    query.documentSource = []
+    query.bingSearchEnabled = false;
+    query.deepSearchEnabled = true;
+    query.pesId = this.pesId;
+    if(this.supportTopicId) {
+      query.supportTopicId= this.supportTopicId;
+    }
 
     if(! this.isPublic && this.viewResultsFromCSSWikionly){
       query.documentSource.push("supportability.visualstudio.com")

--- a/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
@@ -10,7 +10,7 @@ import { v4 as uuid } from 'uuid';
 
 import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagnostic-data-config';
 import { GenericDocumentsSearchService } from '../../services/generic-documents-search.service';
-import { Query } from '../../models/documents-search-models';
+import { AvailableDocumentTypes, Query } from '../../models/documents-search-models';
 import { GenericResourceService } from '../../services/generic-resource-service';
 import { GenericSupportTopicService } from '../../services/generic-support-topic.service';
 
@@ -145,12 +145,11 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
     query.searchTerm = this.searchTerm;
     query.searchId = this.searchId;
     query.numberOfDocuments = 5;
-    query.productName = "App Services";
-    query.documentType = this.isPublic ? "External" : "Internal" ;
+    query.pesId = this.pesId;
+    query.documentType = AvailableDocumentTypes.Internal;
     query.documentSource = []
     query.bingSearchEnabled = false;
     query.deepSearchEnabled = true;
-    query.pesId = this.pesId;
     if(this.supportTopicId) {
       query.supportTopicId= this.supportTopicId;
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/documents-search/documents-search.component.ts
@@ -83,7 +83,7 @@ export class DocumentsSearchComponent extends DataRenderBaseComponent  implement
 
   checkIfEnabled () {
     let checkStatusTask = this._documentsSearchService
-                         .IsEnabled(this.pesId, this.supportTopicId, this.isPublic )
+                         .IsEnabled(this.pesId)
                          .pipe( map((res) => res), 
                                 retryWhen(errors => {
                                 let numRetries = 0;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
@@ -61,3 +61,7 @@
 a{
     cursor: pointer;
 }
+
+br{
+   display : none ;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.scss
@@ -42,6 +42,7 @@
     padding: 10px;
     background-color: white;
     margin: 10px 0px;
+    overflow-wrap: break-word;
 }
 
 .article > h5 {

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
@@ -1,4 +1,16 @@
 export class DocumentSearchConfiguration{
     documentSearchEnabledPesIds: string[] = ["14748", "16072", "16170"];
     documentSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170"];
+
+    documentSearchEnabledSupportTopicIds = {
+        "14748" : ["32542209"],
+        "16072" : ["32542209"],
+        "16170" : ["32542209"]
+    }
+
+    documentSearchEnabledSupportTopicIdsInternal = {
+        "14748" : ["32542209"],
+        "16072" : ["32542209"],
+        "16170" : ["32542209"]
+    }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
@@ -1,24 +1,8 @@
 export class DocumentSearchConfiguration{
     documentSearchEnabledSupportTopicIds = {
         "14748" : ["32542209"],
-        "16072" : ["32542209"],
-        "16170" : ["32542209"]
+        "16072" : ["32542209"]
     };
 
     documentSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170"];
-
-    
-    private pesId_ProductName_Map = {
-        "14748" : "App Services",
-        "16072" : "App Services",
-        "16170" : "App Services",
-    }
-
-    public getProductName(pesId : string): string {
-        if(pesId in this.pesId_ProductName_Map){
-            return this.pesId_ProductName_Map[pesId]
-        }
-        return "";
-    }
-
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-config.ts
@@ -1,16 +1,24 @@
 export class DocumentSearchConfiguration{
-    documentSearchEnabledPesIds: string[] = ["14748", "16072", "16170"];
-    documentSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170"];
-
     documentSearchEnabledSupportTopicIds = {
         "14748" : ["32542209"],
         "16072" : ["32542209"],
         "16170" : ["32542209"]
+    };
+
+    documentSearchEnabledPesIdsInternal: string[] = ["14748", "16072", "16170"];
+
+    
+    private pesId_ProductName_Map = {
+        "14748" : "App Services",
+        "16072" : "App Services",
+        "16170" : "App Services",
     }
 
-    documentSearchEnabledSupportTopicIdsInternal = {
-        "14748" : ["32542209"],
-        "16072" : ["32542209"],
-        "16170" : ["32542209"]
+    public getProductName(pesId : string): string {
+        if(pesId in this.pesId_ProductName_Map){
+            return this.pesId_ProductName_Map[pesId]
+        }
+        return "";
     }
+
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-models.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-models.ts
@@ -9,9 +9,11 @@ export class Query {
     bingSearchEnabled : boolean;
 
     customFilterConditionsForBing : string;
+    preferredSitesFromBing : string[];
+    excludedSitesFromBing : string[];
+    useStack : boolean;
 
     pesId : string;
-
     supportTopicId : string;
 }
 
@@ -22,4 +24,9 @@ export class Document{
     description : string ;
     documentType : string;
     documentSource : string
+}
+
+export enum AvailableDocumentTypes{
+    External = "External",
+    Internal = "Internal"
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-models.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/documents-search-models.ts
@@ -4,7 +4,15 @@ export class Query {
     productName : string ;
     documentType : string ;
     documentSource : string[];
-    numberOfDocuments : number;    
+    numberOfDocuments : number; 
+    deepSearchEnabled : boolean;
+    bingSearchEnabled : boolean;
+
+    customFilterConditionsForBing : string;
+
+    pesId : string;
+
+    supportTopicId : string;
 }
 
 export class Document{

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Query } from 'diagnostic-data';
+import { Query } from '../models/documents-search-models';
 import { Observable} from 'rxjs';
 
 @Injectable()

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
@@ -11,4 +11,8 @@ export class GenericContentService {
   public searchWeb(questionString: string, resultsCount: string = '3', useStack: boolean = true, preferredSites: string[] = [], excludedSites: string[] = []): Observable<any> {
     return null;
   }
+
+  public constructQueryParameters(questionString: string, useStack: boolean, preferredSites: string[], excludedSites: string[],) : string {
+    return null;
+  }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-content.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Query } from 'diagnostic-data';
 import { Observable} from 'rxjs';
 
 @Injectable()
@@ -15,4 +16,12 @@ export class GenericContentService {
   public constructQueryParameters(questionString: string, useStack: boolean, preferredSites: string[], excludedSites: string[],) : string {
     return null;
   }
+
+  public IsDeepSearchEnabled(pesId : string, supportTopicId : string) : Observable<boolean> {
+    return null;
+  }
+  public fetchResultsFromDeepSearch(query : Query): Observable<any>{
+    return null;
+  }
+
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
@@ -5,7 +5,7 @@ import { Query } from '../models/documents-search-models';
 @Injectable()
 export class GenericDocumentsSearchService {
 
-  public IsEnabled(pesId:string, supportTopicId:string, isPublic : boolean) : Observable<boolean> {
+  public IsEnabled(pesId:string) : Observable<boolean> {
     return null;
   }
   public Search(query:Query): Observable<any> {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-documents-search.service.ts
@@ -5,10 +5,14 @@ import { Query } from '../models/documents-search-models';
 @Injectable()
 export class GenericDocumentsSearchService {
 
-  public IsEnabled(pesId:string, isPublic : boolean) : Observable<boolean> {
+  public IsEnabled(pesId:string, supportTopicId:string, isPublic : boolean) : Observable<boolean> {
     return null;
   }
   public Search(query:Query): Observable<any> {
+    return null;
+  }
+
+  public searchWeb(query:Query): Observable<any> {
     return null;
   }
 }


### PR DESCRIPTION
For support topics where Deep Search is enabled for consumption from Azure Portal, the web search component makes a call to Deep Search API instead of Bing.

This ensures that the existing experience is unaltered.
![image](https://user-images.githubusercontent.com/4495262/114694548-48338f00-9d38-11eb-816c-a2f977577782.png)
 
