### PR TITLE
Removed document-search.component from detector-list-analysis as DeepSearch is not enabled for Dynamic Analysis

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -278,15 +278,6 @@
     </web-search>
   </div>
 
-  <div *ngIf="!isPublic && ((!showPreLoader && getPendingDetectorCount() === 0) || showWebSearch )"
-    style="margin-left:80px;margin-top:20px;">
-    <documents-search   [searchTerm]="searchTerm"
-                        [searchId] = "searchId"
-                        [isChildComponent]="true"
-                        [numDocumentsExpanded] = 2>
-    </documents-search>
-  </div>
-
   <div class="list-wrapper" *ngIf="supportDocumentRendered">
     <div class="list-item-wrapper" *ngIf="supportDocumentRendered">
       <div class="stepper-circle stepper-circle-dark-blue">


### PR DESCRIPTION
Deep Search is currently not enabled for Dynamic Analysis. 
Further for Public portal, we search component takes care of the search. This removes the need for document-search.component