### PR TITLE
Reducing the delay on web results 10 to 3 seconds

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -498,7 +498,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         if (this.showWebSearchTimeout) {
             clearTimeout(this.showWebSearchTimeout);
         }
-        this.showWebSearchTimeout = setTimeout(() => { this.showWebSearch = true; }, 10000);
+        this.showWebSearchTimeout = setTimeout(() => { this.showWebSearch = true; }, 3000);
         this.issueDetectedViewModels = [];
         const requests: Observable<any>[] = [];
 


### PR DESCRIPTION
Web search delay was introduced to ensure that web results do not appear before detectors start rendering in dynamic analysis.
But as observed recently, this delay is too much, specially when we are expecting the web results. Hence reducing the delay from 10 seconds to 3 seconds.