### PR TITLE
Fix regression where nothing is rendered from existing detector binaries

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/dynamic-data/dynamic-data.component.ts
@@ -108,7 +108,7 @@ export class DynamicDataComponent implements OnInit {
     this.versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
     this.dataBehaviorSubject.subscribe((diagnosticData: DiagnosticData) => {
       const isVisible = (<Rendering>diagnosticData.renderingProperties).isVisible;
-      if (!isVisible)
+      if (isVisible !== undefined && !isVisible)
       {
         return;
       }


### PR DESCRIPTION
This PR fixes a regression caused by the introduction of IsVisible flag. Now it renders responses from existing detector binaries correctly.

Tested locally with a modified runtimehost & compilehost with IsVisible removed.