### PR TITLE
Move table description under search bar

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,4 +1,4 @@
-<data-container [title]="renderingProperties.title" [description]="renderingProperties.description">
+<data-container [title]="renderingProperties.title">
   <div style="display: flex;">
     <div *ngIf="allowColumnSearch" class="text-field">
       <fab-text-field (onChange)=updateTableBySearch($event) [rows]="1" [placeholder]="searchAriaLabel"
@@ -11,6 +11,11 @@
       </div>
     </div>
   </div>
+  
+  <div *ngIf="renderingProperties.description" style="margin-bottom: 18px;">
+    <markdown-text [markdownData]="renderingProperties.description"></markdown-text>
+  </div>
+  
   <div [attr.data-is-scrollable]="true" style="overflow: auto;">
     <fab-details-list [items]="rows">
       <columns>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.scss
@@ -10,7 +10,7 @@
 
   .text-field{
     max-width: 300px; 
-    margin-bottom: 30px;
+    margin-bottom: 24px;
     min-width: 250px;
   }
 


### PR DESCRIPTION
In this PR, I move table description from very top to under search bar, so it can align with Yao's design for Linux Log Viewer detector

![image](https://user-images.githubusercontent.com/23129934/116736587-ec5a3e80-a9a4-11eb-8fce-c13f69f844c6.png)
