### PR TITLE
Revert resource Id url by parsing query param array

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
@@ -33,14 +33,14 @@ export class GenericApiService {
 
     public getDetectors(overrideResourceUri: string = ""): Observable<DetectorMetaData[]> {
         let resourceId = overrideResourceUri ? overrideResourceUri : this.resourceId;
-        let languageQueryParam = this.isLocalizationApplicable() ? `?l=${this.effectiveLocale}` : "";
-
+        let queryParams = this.isLocalizationApplicable() ? [{"key":"l", "value": this.effectiveLocale}]: [];
         if (this.useLocal) {
             const path = `v4${resourceId}/detectors?stampName=waws-prod-bay-085&hostnames=netpractice.azurewebsites.net`;
             return this.invoke<DetectorResponse[]>(path, 'POST').pipe(map(response => response.map(detector => detector.metadata)));
         } else {
-            const path = `${resourceId}/detectors${languageQueryParam}`;
-            return this._armService.getResourceCollection<DetectorResponse[]>(path).pipe(map((response: ResponseMessageEnvelope<DetectorResponse>[]) => {
+            const path = `${resourceId}/detectors`;
+            return this._armService.getResourceCollection<DetectorResponse[]>(path, null, false, queryParams).pipe(map((response: ResponseMessageEnvelope<DetectorResponse>[]) => {
+
                 this.detectorList = response.map(listItem => listItem.properties.metadata);
                 return this.detectorList;
             }));


### PR DESCRIPTION
It looks like we will get failed request if there is Api version appended, something like:
https://management.azure.com/subscriptions/ef90e930-9d7f-4a60-8a99-748e0eea69de/resourcegroups/akstest/providers/microsoft.containerservice/managedclusters/aksperiscope?l=zh?api-version=2019-04-01

