### PR TITLE
Fixing bug 1815

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/step-views/dropdown-step-view/dropdown-step.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/step-views/dropdown-step-view/dropdown-step.component.ts
@@ -31,9 +31,11 @@ export class DropDownStepComponent implements OnInit {
     var expandByDefault = this.dropdownStepView.expandByDefault;
     this.dropdownRef = {
       set current(val: IDropdown) {
-        this.dropdown = val;
-        if (expandByDefault) {
-          val.focus(true);
+        if (val != null) {
+          this.dropdown = val;
+          if (expandByDefault) {
+            val.focus(true);
+          }
         }
       },
 


### PR DESCRIPTION
Fixing [bug 1815](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1815)
```
TypeError: Cannot read property 'focus' of null     
at focus (webpack:///src/app/shared/components/step-views/dropdown-step-view/dropdown-step.component.ts:36:14)     
at value (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/initializeComponentRef.js.pre-build-optimizer.js:31:35)     
at _setComponentRef (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/initializeComponentRef.js.pre-build-optimizer.js:26:4)     
at webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/appendFunction.js.pre-build-optimizer.js:19:55     
at forEach (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/appendFunction.js.pre-build-optimizer.js:19:18)     
at webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/appendFunction.js.pre-build-optimizer.js:19:55     
at forEach (webpack:///home/vsts/work/1/s/AngularApp/node_modules/@uifabric/utilities/lib/appendFunction.js.pre-build-optimizer.js:19:18)     
at webpack:///home/vsts/work/1/s/AngularApp/node_modules/react-dom/cjs/react-dom.production.min.js:193:317
```