### PR TITLE
Nmallick1/base64 partner apis

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -99,6 +99,10 @@ export class WebSitesService extends ResourceService {
         return this.appType === AppType.WebApp ? this.platform === OperatingSystem.windows ? 'Web App (Windows)' : 'Web App (Linux)' : 'Function App';
     }
 
+    public get isArmApiResponseBase64Encoded():boolean {
+        return false;
+    }
+
     public get isApplicableForLiveChat(): boolean {
         return this.resource
             && (this.appType & (AppType.WebApp | AppType.FunctionApp)) > 0 //Enable chat for Function apps

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/resource.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/resource.service.ts
@@ -106,6 +106,15 @@ export class ResourceService {
     }
   }
 
+  public get isArmApiResponseBase64Encoded():boolean {
+    if (this._genericArmConfigService) {
+      return this._genericArmConfigService.isArmApiResponseBase64Encoded(this.resource.id);
+    }
+    else {
+      return false;
+    }
+  }
+
   public get isApplicableForLiveChat(): boolean {
     if (this._genericArmConfigService) {
       let currConfig: ArmResourceConfig = this._genericArmConfigService.getArmResourceConfig(this.resource.id);


### PR DESCRIPTION
Accept base64 encoded response from partners for GET detector and list detectors calls that they proxy into us. This will allow partners to publish their own swagger and not depend on ours eliminating their dependency on us.