### PR TITLE
Add array check for optional params in chat service

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/cxp-chat-caller.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/cxp-chat-caller.service.ts
@@ -37,7 +37,7 @@ export class CXPChatCallerService {
             this.chatLanguage = startupInfo.effectiveLocale;
           }
 
-          if (!!startupInfo.optionalParameters) {
+          if (!!startupInfo.optionalParameters && Array.isArray(startupInfo.optionalParameters)) {
             var caseSubjectParam = startupInfo.optionalParameters.find(param => param.key === "caseSubject");
             if (!!caseSubjectParam) {
               this.caseSubject = caseSubjectParam.value;
@@ -374,7 +374,7 @@ export class CXPChatCallerService {
         "checkType": checkType,
         "checkOutcome": checkOutcome
       };
-  
+
       this._telemetryService.logEvent(TelemetryEventNames.CXPChatEligibilityCheck, notificationMessage);
     }
   }


### PR DESCRIPTION
We are seeing exception:
TypeError: t.optionalParameters.find is not a function
    at find (webpack:///src/app/shared-v2/services/cxp-chat-caller.service.ts:41:66)
    at call (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subscriber.js.pre-build-optimizer.js:195:15)
    at __tryOrUnsub (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subscriber.js.pre-build-optimizer.js:133:21)
    at next (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subscriber.js.pre-build-optimizer.js:77:25)
    at _next (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subscriber.js.pre-build-optimizer.js:54:17)
    at next (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/operators/map.js.pre-build-optimizer.js:41:25)
    at _next (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subscriber.js.pre-build-optimizer.js:54:17)
    at next (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/ReplaySubject.js.pre-build-optimizer.js:67:27)
    at _subscribe (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Observable.js.pre-build-optimizer.js:42:24)
    at call (webpack:///home/vsts/work/1/s/AngularApp/node_modules/rxjs/_esm5/internal/Subject.js.pre-build-optimizer.js:89:50)
    
https://ms.portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22:%22aec19b60-bcad-11eb-ac14-076ecada2bcb%22,%22timestamp%22:%222021-05-24T16:32:51.079Z%22%7D/ComponentId/%7B%22Name%22:%22DiagnoseAndSolvePortal%22,%22ResourceGroup%22:%22DiagnoseAndSolve%22,%22SubscriptionId%22:%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%7D