### PR TITLE
Enabling network checker for Consumption SKU Function Apps

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
@@ -137,7 +137,7 @@ export class CategoryNavComponent implements OnInit {
         this.toolCategories.push(<SiteFilteredItem<any>>{
             appType: AppType.WebApp | AppType.FunctionApp,
             platform: OperatingSystem.windows,
-            sku: Sku.NotDynamic,
+            sku: Sku.All,
             hostingEnvironmentKind: HostingEnvironmentKind.All,
             stack: '',
             item: {

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.ts
@@ -76,7 +76,7 @@ export class DiagnosticToolsComponent {
     this.toolCategories.push(<SiteFilteredItem<any>>{
       appType: AppType.WebApp | AppType.FunctionApp,
       platform: OperatingSystem.windows,
-      sku: Sku.NotDynamic,
+      sku: Sku.All,
       hostingEnvironmentKind: HostingEnvironmentKind.All,
       stack: '',
       item: {

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -436,7 +436,7 @@ export class SiteFeatureService extends FeatureService {
       {
         appType: AppType.WebApp | AppType.FunctionApp,
         platform: OperatingSystem.windows,
-        sku: Sku.NotDynamic,
+        sku: Sku.All,
         hostingEnvironmentKind: HostingEnvironmentKind.All,
         stack: '',
         item: {

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-quick-link.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-quick-link.service.ts
@@ -51,7 +51,7 @@ export class SiteQuickLinkService extends QuickLinkService {
             appType: AppType.FunctionApp,
             platform: OperatingSystem.windows,
             stack: '',
-            sku: Sku.NotDynamic,
+            sku: Sku.All,
             hostingEnvironmentKind: HostingEnvironmentKind.All,
             item: [
                 'networkchecks'

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -278,7 +278,7 @@ export class SitesCategoryService extends CategoryService {
       appType: AppType.WebApp | AppType.FunctionApp,
       platform: OperatingSystem.any,
       stack: '',
-      sku: Sku.NotDynamic,
+      sku: Sku.All,
       hostingEnvironmentKind: HostingEnvironmentKind.All,
       item: {
         id: 'DiagnosticTools',

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/configFailureFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/configFailureFlow.js
@@ -4,6 +4,18 @@ export var configFailureFlow = {
     title: "I tried to configure VNet integration via the Azure Portal or ARM template, but it failed",
     async func(siteInfo, diagProvider, flowMgr) {
         var vnets = null, subnets = null, subscriptions = null;
+
+        siteInfo
+
+        if (siteInfo.kind.includes("functionapp") && siteInfo.sku.toLowerCase() == "dynamic") {
+            flowMgr.addView(new InfoStepView({  
+                title: "VNet integration is not supported for Consumption Plan Function Apps.",
+                infoType: 1,
+                markdown: 'For more information please review <a href="https://docs.microsoft.com/en-us/azure/app-service/web-sites-integrate-with-vnet" target="_blank">Integrate your app with an Azure virtual network</a>.'
+            }));
+            return;
+        }
+
         var getAspSitesPromise = getAspSites(diagProvider, siteInfo["serverFarmId"]);
         flowMgr.addViews(getAspSitesPromise.then(d => d.views), "Fetching App Service Plan data...");
         var aspSites = (await getAspSitesPromise).aspSites;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/configFailureFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/configFailureFlow.js
@@ -5,8 +5,6 @@ export var configFailureFlow = {
     async func(siteInfo, diagProvider, flowMgr) {
         var vnets = null, subnets = null, subscriptions = null;
 
-        siteInfo
-
         if (siteInfo.kind.includes("functionapp") && siteInfo.sku.toLowerCase() == "dynamic") {
             flowMgr.addView(new InfoStepView({  
                 title: "VNet integration is not supported for Consumption Plan Function Apps.",

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.ts
@@ -114,31 +114,27 @@ export class NetworkCheckComponent implements OnInit, AfterViewInit {
                 flows = flows.concat(remoteFlows);
             }
             var mgr = this.stepFlowManager;
-            if (this.siteInfo.kind.includes("functionapp") && this.siteInfo.sku.toLowerCase() == "dynamic") {
-                mgr.addView(new CheckStepView({ id: "NotSupportedCheck", title: "VNet integration is not supported by Consumption Plan Function App", level: 2 }));
-            } else {
-                var dropDownView = new DropdownStepView({
-                    id: "InitialDropDown",
-                    description: "Tell us more about the problem you are experiencing:",
-                    dropdowns: [{
-                        options: flows.map(f => f.title),
-                        placeholder: "Please select..."
-                    }],
-                    expandByDefault: true,
-                    async callback(dropdownIdx: number, selectedIdx: number): Promise<void> {
-                        mgr.reset(state);
-                        var flow = flows[selectedIdx];
-                        globals.messagesData.currentNetworkCheckFlow = flow.id;
-                        globals.messagesData.feedbackPanelConfig.detectorName = "NetworkCheckingTool." + flow.id;
-                        telemetryService.logEvent("NetworkCheck.FlowSelected", { flowId: flow.id });
-                        mgr.setFlow(flow);
-                    },
-                    onDismiss: ()=>{
-                        telemetryService.logEvent("NetworkCheck.DropdownExpanded", {});
-                    }
-                });
-                var state = mgr.addView(dropDownView);
-            }
+            var dropDownView = new DropdownStepView({
+                id: "InitialDropDown",
+                description: "Tell us more about the problem you are experiencing:",
+                dropdowns: [{
+                    options: flows.map(f => f.title),
+                    placeholder: "Please select..."
+                }],
+                expandByDefault: true,
+                async callback(dropdownIdx: number, selectedIdx: number): Promise<void> {
+                    mgr.reset(state);
+                    var flow = flows[selectedIdx];
+                    globals.messagesData.currentNetworkCheckFlow = flow.id;
+                    globals.messagesData.feedbackPanelConfig.detectorName = "NetworkCheckingTool." + flow.id;
+                    telemetryService.logEvent("NetworkCheck.FlowSelected", { flowId: flow.id });
+                    mgr.setFlow(flow);
+                },
+                onDismiss: ()=>{
+                    telemetryService.logEvent("NetworkCheck.DropdownExpanded", {});
+                }
+            });
+            var state = mgr.addView(dropDownView);
         } catch (e) {
             console.log("loadFlowsAsync failed", e);
             throw e;


### PR DESCRIPTION
## Summary
At present, all diagnostic tools are only supported for Function App SKUs other than consumption (SKU is not "Dynamic").  This change allows the network checker diagnostic tool to be used for consumption SKU Function Apps.

Additional changes needed to complete this change:
- [x] The App Lens detector "Diagnostic Tools" renders a list of tools based on filtering logic maintained in the detector so the logic here has been modified to include the Function App consumption SKU.

## Validation
Local validation by navigating through various WebApps and Function Apps of various SKUs