### PR TITLE
CXP Chat -> Explicit consent to share diagnostic information before starting chat

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.html
@@ -6,11 +6,13 @@
           <img src="assets/img/jen.jpg" class="agentImage">
           <span class="agentName"> Jen </span>
         </div>
-        <div class="cxpChat-ChangeIcon" role="button" aria-label="Close chat dialogue" title="Close"
-          (click)="hideChatConfDialog(true, 'CloseIcon')">
-          <i class="fa fa-times cxpChat-CloseIcon"></i>
-          <i class="fa fa-window-close fa-lg cxpChat-CloseIcon"></i>
-        </div>
+        <button class="cxpChat-RemoveOutline cxpChat-FlatButton" role="button" title="Close"
+          aria-label="Close chat dialogue" (click)="hideChatConfDialog(true, 'CloseIcon')">
+          <div class="cxpChat-ChangeIcon">
+            <i class="fa fa-times cxpChat-CloseIcon"></i>
+            <i class="fa fa-window-close fa-lg cxpChat-CloseIcon"></i>
+          </div>
+        </button>
       </div>
       <hr>
       <div>
@@ -19,32 +21,54 @@
       <div *ngIf="showDiagnosticsConsentOption" class="cxpChat-ConsentContainer">
         <div class="cxpChat-ConsentOptionContainer">
           <div>
-            <input id="chkBoxDiagnosticConsent" type="checkbox" [(ngModel)]="diagnosticLogsConsent">
+            <span>Share diagnostic information?</span>
           </div>
           <div class="cxpChat-ConsentText">
-            <label for="chkBoxDiagnosticConsent">Share diagnostic information.</label>
+            <sup class="cxpChat-Required"> * </sup>
+            <a target="_blank" role="link" aria-label="Click to learn more about the information we collect"
+              title="Click to learn more about the information we collect."
+              href="https://azure.microsoft.com/en-us/support/legal/support-diagnostic-information-collection/">
+              <i class="fa fa-info-circle"></i>
+            </a>
           </div>
         </div>
         <div>
-          <a target="_blank" role="link" aria-label="Click to learn more about the information we collect"
-            title="Click to learn more about the information we collect."
-            href="https://azure.microsoft.com/en-us/support/legal/support-diagnostic-information-collection/">
-            <i class="fa fa-info-circle"></i>
-          </a>
+          <div role="radiogroup"
+            aria-roledescription="Consent options to allow Microsoft access to diagnostic information."
+            aria-required="true">
+            <input id="diagConsentYes" aria-label="Yes, share diagnostic information with Microsoft." type="radio"
+              name="diagConsentOptions" value="Yes" [(ngModel)]="diagnosticLogsConsent">
+            <span class="cxpChat-ConsentText">
+              <label for="diagConsentYes">Yes</label>
+            </span>
+          </div>
+          <div>
+            <input id="diagConsentNo" aria-label="No, do not share diagnostic information with Microsoft." type="radio"
+              name="diagConsentOptions" value="No" [(ngModel)]="diagnosticLogsConsent">
+            <span class="cxpChat-ConsentText">
+              <label for="diagConsentNo">No</label>
+            </span>
+          </div>
+        </div>
+        <div aria-hidden="true">
+          <!--Placeholder-->
         </div>
       </div>
     </div>
     <div *ngIf="showChatButtons" class="cxpChat-actionBtnContainer">
       <input class="custom-button inactive-button white-border" (click)="hideChatConfDialog(true, 'CancelButton')"
         type="button" role="button" aria-label="Maybe later" value="Maybe later" />
-      <input class="custom-button default-button white-border" (click)="openChatPopup()" type="button" role="button"
-        aria-label="Confirm and Start" value="Confirm & Start!" />
+      <input class="custom-button default-button white-border" [disabled]="diagnosticLogsConsent==''"
+        [title]="diagnosticLogsConsent==''?'Select an option to share diagnostic information before you start the chat.':'Confirm and start chat.'"
+        (click)="openChatPopup()" type="button" role="button" aria-label="Confirm and Start" value="Confirm & Start!" />
     </div>
   </div>
 
   <div *ngIf="showChatConfDialog" class="arrow-bottom"></div>
 
-  <div class='chatBubble' *ngIf="showChatBubble" (click)="toggleChatConfDialog()">
-    <i class="fa fa-comments chatIcon" aria-hidden="true"></i>
-  </div>
+  <button role="button" class='chatBubble cxpChat-FlatButton' *ngIf="showChatBubble" (click)="toggleChatConfDialog()">
+    <div class='chatBubble'>
+      <i class="fa fa-comments chatIcon" aria-hidden="true"></i>
+    </div>
+  </button>
 </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.scss
@@ -1,24 +1,33 @@
 @import "../../../../../app-service-diagnostics/src/styles/common/variables";
 @import "../../../../../app-service-diagnostics/src/styles/controls/buttons";
 
-$chatBubble-color:#008080;
-$zIndex:99;
+$chatBubble-color: #008080;
+$zIndex: 99;
 
 .chatBubble {
     position: fixed;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    width:4em;
-    height:4em;
-    bottom:10px;
-    left:10px;
+    width: 4em;
+    height: 4em;
+    bottom: 10px;
+    left: 10px;
     text-align: center;
-    box-shadow: 0 0 15px #00214B;
-    border-radius:50%;
+    box-shadow: 0 0 15px #00214b;
+    border-radius: 50%;
     cursor: pointer;
     background-color: $chatBubble-color;
-    z-index:$zIndex;
+    z-index: $zIndex;
+}
+
+.cxpChat-FlatButton {
+    background-color: $chatBubble-color;
+    border: thin;
+}
+
+.cxpChat-RemoveOutline {
+    outline: none;
 }
 
 .agentImage {
@@ -28,60 +37,60 @@ $zIndex:99;
 }
 
 .agentName {
-    padding-left:4px;
+    padding-left: 4px;
 }
 
 .chatIcon {
-    font-size:1.7em;
+    font-size: 1.7em;
     color: ghostwhite;
 }
 
- .arrow-bottom  {
+.arrow-bottom {
     width: 2.5%;
     height: 0;
-    position:fixed;
-    bottom:4.9em;
-    left:2em;
-    z-index:$zIndex + 1;
- }
+    position: fixed;
+    bottom: 4.9em;
+    left: 2em;
+    z-index: $zIndex + 1;
+}
 
- .arrow-bottom::before {
-    content: '';
+.arrow-bottom::before {
+    content: "";
     display: block;
     width: 0;
-    margin-top:-10px;
-    z-index:$zIndex + 1;
-      
+    margin-top: -10px;
+    z-index: $zIndex + 1;
+
     border-left: 10px solid transparent;
-    border-right: 10px solid  transparent;
+    border-right: 10px solid transparent;
     border-top: 10px solid $chatBubble-color;
     border-bottom: 10px solid transparent;
 }
 
 .cxpChat-ConfContainer {
     background: $chatBubble-color;
-    color:white;
-    font-size:14px;
+    color: white;
+    font-size: 14px;
     padding: 5px;
-    z-index:$zIndex;
+    z-index: $zIndex;
     border-radius: 2px;
-    border:solid 1px $chatBubble-color;
+    border: solid 1px $chatBubble-color;
     position: fixed;
-    left:1.8em;
-    bottom:5.2em;    
+    left: 1.8em;
+    bottom: 5.2em;
 }
 
 .cxpChat-CloseIcon {
     cursor: pointer;
     color: white;
-    margin-right:4px;    
+    margin-right: 4px;
 }
 
 .cxpChat-ConfText {
     padding-top: 10px;
     padding-right: 15px;
     padding-bottom: 15px;
-    padding-left: 15px;  
+    padding-left: 15px;
     width: 25em;
 }
 
@@ -95,7 +104,7 @@ $zIndex:99;
 }
 
 .cxpChat-ConsentText {
-    padding-left: .2em;
+    padding-left: 0.2em;
 }
 
 label {
@@ -124,6 +133,7 @@ hr {
     margin-left: 0px;
     padding-left: 35px;
     padding-right: 35px;
+    &:focus,
     &:hover {
         background-color: $primary-color;
     }
@@ -136,9 +146,15 @@ hr {
     margin-left: 0px;
     padding-left: 35px;
     padding-right: 35px;
-    &:hover{
+    &:enabled:focus,
+    &:enabled:hover {
         color: white;
         background-color: $primary-color;
+    }
+    &:disabled {
+        font-weight: lighter;
+        cursor: not-allowed;
+        color: ghostwhite;
     }
 }
 
@@ -146,14 +162,21 @@ hr {
     border: 1px solid white;
 }
 
+.cxpChat-Required {
+    color: red;
+}
+
+.cxpChat-FlatButton:focus > .cxpChat-ChangeIcon > .fa,
 .cxpChat-ChangeIcon > .fa + .fa,
 .cxpChat-ChangeIcon:hover > .fa {
-  display: none;
+    display: none;
 }
+
+.cxpChat-FlatButton:focus > .cxpChat-ChangeIcon > .fa + .fa,
 .cxpChat-ChangeIcon:hover > .fa + .fa {
-  display: inherit;
-  color: #ba141a;
-  background-color: white;
-  margin-top: 5px;
-  margin-right: 0px;
+    display: inherit;
+    color: #ba141a;
+    background-color: white;
+    margin-top: 5px;
+    margin-right: 0px;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/cxp-chat-launcher/cxp-chat-launcher.component.ts
@@ -15,7 +15,7 @@ export class CxpChatLauncherComponent implements OnInit {
   public chatConfDialogOpenedAtleastOnce = false;
   public showChatConfDialog: boolean = false;
   public firstTimeCheck: boolean = true;
-  public diagnosticLogsConsent: boolean = true;
+  public diagnosticLogsConsent: string = '';
   public chatWelcomeMessage: string = "";
   public showChatButtons: boolean = true;
   public showDiagnosticsConsentOption: boolean = true;
@@ -25,7 +25,7 @@ export class CxpChatLauncherComponent implements OnInit {
   private readonly chatUrlTimeout: number = 1800000; //30 minutes
   private readonly chatBubbleConfirmationDisplayDelay: number = 10000; //10 seconds
   private readonly chatBubbleDisplayDelay: number = 40000; //40 seconds
-  public showChatBubble:boolean = false;
+  public showChatBubble: boolean = false;
 
   constructor(private _cxpChatService: CXPChatService) {
     this.chatWelcomeMessage = "I'd love to help you out with your issue and connect you with our quick help chat team.";
@@ -34,7 +34,7 @@ export class CxpChatLauncherComponent implements OnInit {
 
   ngOnInit() {
     window.setTimeout(() => {
-      
+
 
       //Have to check for first time due to the way our components are structured.
       //This gets called multiple times for each detector, specifically for child detectors that are collapsed and then expanded later.
@@ -59,8 +59,8 @@ export class CxpChatLauncherComponent implements OnInit {
           this._cxpChatService.logUserActionOnChat('ChatConfDialogShownBySystem', this.trackingId, this.chatUrl);
         }
       }, this.chatBubbleConfirmationDisplayDelay);
-      
-    }, this.chatBubbleDisplayDelay);    
+
+    }, this.chatBubbleDisplayDelay);
 
     this.refreshChatUrl();
   }
@@ -112,7 +112,7 @@ In case chat did not start in a pop up window, disable your pop up blocker and c
 
   public isComponentInitialized(): boolean {
 
-    let initializedTestResult: boolean = !!this.chatUrl && this.chatUrl != '' && !!this.trackingId && this.trackingId != '';    
+    let initializedTestResult: boolean = !!this.chatUrl && this.chatUrl != '' && !!this.trackingId && this.trackingId != '';
 
     return initializedTestResult;
   }
@@ -137,10 +137,15 @@ In case chat did not start in a pop up window, disable your pop up blocker and c
 
   public openChatPopup(): void {
     if (this.chatUrl != '') {
-      this.completeChatUrl = `${this.chatUrl}&diagnosticsConsent=${this.diagnosticLogsConsent}`;
-      window.open(this.completeChatUrl, '_blank', this.windowFeatures, false);
-      this._cxpChatService.logUserActionOnChat('ChatUrlOpened', this.trackingId, this.completeChatUrl);
-      this.showChatOpenedMessage();
+      if (this.diagnosticLogsConsent == 'Yes' || this.diagnosticLogsConsent == 'No') {
+        this.completeChatUrl = `${this.chatUrl}&diagnosticsConsent=${(this.diagnosticLogsConsent == 'Yes')}`;
+        window.open(this.completeChatUrl, '_blank', this.windowFeatures, false);
+        this._cxpChatService.logUserActionOnChat('ChatUrlOpened', this.trackingId, this.completeChatUrl);
+        this.showChatOpenedMessage();
+      }
+      else {
+        this.diagnosticLogsConsent = '';
+      }
     }
   }
 }


### PR DESCRIPTION
Require explicit consent from customers to share/not share diagnostic information before they can start a chat.
Make the chat bubble and all elements on it keyboard accessible.