### PR TITLE
Network Troubleshooter calls Kudu api via control plane

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
@@ -18,13 +18,13 @@ export class DiagProvider {
     private _armService: ArmService;
     private _siteService: SiteService;
     public portalDomain: string;
-    private _scmHostName: string;
+    public scmHostName: string;
     constructor(siteInfo: SiteInfoMetaData & Site & { fullSiteName: string }, armService: ArmService, siteService: SiteService, portalDomain: string) {
         this._siteInfo = siteInfo;
         this._armService = armService;
         this._siteService = siteService;
         var scmHostNameState = this._siteInfo.hostNameSslStates.filter(h => h.hostType == 1)[0];
-        this._scmHostName = scmHostNameState == null ? null : scmHostNameState.name;
+        this.scmHostName = scmHostNameState == null ? null : scmHostNameState.name;
         this.portalDomain = portalDomain;
         armService.clearCache();
     }
@@ -98,7 +98,7 @@ export class DiagProvider {
         var stack = new Error("replace_placeholder").stack;
         var params = [instance == null ? null : `instance=${instance}`, scm ? null : "api-version=2015-08-01"].filter(s => s!=null).join("&");
         var postfix = (params == "" ? "" : `?${params}`);
-        var prefix = scm ? this._scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
+        var prefix = scm ? this.scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
         return this._armService.get<T>(`https://${prefix}/api/${uri}${postfix}`)
             .toPromise()
             .catch(e => {
@@ -111,7 +111,7 @@ export class DiagProvider {
     public postKuduApiAsync<T, S>(uri: string, body?: S, instance?: string, timeoutInSec: number = 15, scm = false): Promise<boolean | {} | ResponseMessageEnvelope<T>> {
         var params = [instance == null ? null : `instance=${instance}`, scm ? null : "api-version=2015-08-01"].filter(s => s!=null).join("&");
         var postfix = (params == "" ? "" : `?${params}`);
-        var prefix = scm ? this._scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
+        var prefix = scm ? this.scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
         var stack = new Error("replace_placeholder").stack;
         var promise = this._armService.post<T, S>(`https://${prefix}/api/${uri}${postfix}`, body)
             .toPromise()

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
@@ -94,9 +94,12 @@ export class DiagProvider {
             });
     }
 
-    public getKuduApiAsync<T>(uri: string): Promise<T> {
+    public getKuduApiAsync<T>(uri: string, instance?: string, timeoutInSec: number = 15, scm = false): Promise<T> {
         var stack = new Error("replace_placeholder").stack;
-        return this._armService.get<T>(`https://${this._scmHostName}/api/${uri}`)
+        var params = [instance == null ? null : `instance=${instance}`, scm ? null : "api-version=2015-08-01"].filter(s => s!=null).join("&");
+        var postfix = (params == "" ? "" : `?${params}`);
+        var prefix = scm ? this._scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
+        return this._armService.get<T>(`https://${prefix}/api/${uri}${postfix}`)
             .toPromise()
             .catch(e => {
                 var err = new Error(e);
@@ -105,10 +108,12 @@ export class DiagProvider {
             });
     }
 
-    public postKuduApiAsync<T, S>(uri: string, body?: S, instance?: string, timeoutInSec: number = 15): Promise<boolean | {} | ResponseMessageEnvelope<T>> {
-        var postfix = (instance == null ? "" : `?instance=${instance}`);
+    public postKuduApiAsync<T, S>(uri: string, body?: S, instance?: string, timeoutInSec: number = 15, scm = false): Promise<boolean | {} | ResponseMessageEnvelope<T>> {
+        var params = [instance == null ? null : `instance=${instance}`, scm ? null : "api-version=2015-08-01"].filter(s => s!=null).join("&");
+        var postfix = (params == "" ? "" : `?${params}`);
+        var prefix = scm ? this._scmHostName : `management.azure.com/${this._siteInfo.resourceUri}/extensions`;
         var stack = new Error("replace_placeholder").stack;
-        var promise = this._armService.post<T, S>(`https://${this._scmHostName}/api/${uri}${postfix}`, body)
+        var promise = this._armService.post<T, S>(`https://${prefix}/api/${uri}${postfix}`, body)
             .toPromise()
             .catch(e => {
                 var err = new Error(e);

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/commonRecommendations.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/commonRecommendations.js
@@ -1,0 +1,18 @@
+export class CommonRecommendations
+{
+    constructor(){
+        this.KuduNotAccessible = {
+            Get(){
+                return new InfoStepView({
+                    infoType: 1,
+                    title: "Recommendations",
+                    markdown: "[Kudu](https://techcommunity.microsoft.com/t5/educator-developer-blog/using-kudu-and-deploying-apps-into-azure/ba-p/378585) is not accessible. Possible reason can be:\r\n\r\n" +
+                        "- Timeout, please click refresh button and retry\r\n\r\n" +
+                        "- The Kudu extension is not working properly due to invalid App Settings, e.g. invalid WEBSITE_CONTENTAZUREFILECONNECTIONSTRING. In this case, " + 
+                        "your app may not be working properly as well. Please fix the problem to enable the check that depends on Kudu.  \r\n\r\n" +
+                        "The diagnostic will be incomplete without Kudu access."
+                });
+            }
+        }
+    }
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/commonRecommendations.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/commonRecommendations.js
@@ -2,15 +2,16 @@ export class CommonRecommendations
 {
     constructor(){
         this.KuduNotAccessible = {
-            Get(){
+            Get(kuduUrl){
                 return new InfoStepView({
                     infoType: 1,
                     title: "Recommendations",
-                    markdown: "[Kudu](https://techcommunity.microsoft.com/t5/educator-developer-blog/using-kudu-and-deploying-apps-into-azure/ba-p/378585) is not accessible. Possible reason can be:\r\n\r\n" +
+                    markdown: "[Kudu](https://docs.microsoft.com/en-us/azure/app-service/resources-kudu) is not accessible. Possible reasons can be:\r\n\r\n" +
                         "- Timeout, please click refresh button and retry\r\n\r\n" +
-                        "- The Kudu extension is not working properly due to invalid App Settings, e.g. invalid WEBSITE_CONTENTAZUREFILECONNECTIONSTRING. In this case, " + 
+                        "- Kudu extension is not working properly due to invalid App Settings, e.g. invalid WEBSITE_CONTENTAZUREFILECONNECTIONSTRING. In this case, " + 
                         "your app may not be working properly as well. Please fix the problem to enable the check that depends on Kudu.  \r\n\r\n" +
-                        "The diagnostic will be incomplete without Kudu access."
+                        `- Kudu extension is not working properly for unknown reason, please check if you can access Kudu by [${kuduUrl}](${kuduUrl}). \r\n\r\n`+
+                        "The diagnostic results will be incomplete without Kudu access."
                 });
             }
         }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/connectionFailureFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/connectionFailureFlow.js
@@ -15,7 +15,7 @@ export var connectionFailureFlow = {
                     level: 1
                 }));
 
-                views.push(commonRec.KuduNotAccessible.Get());
+                views.push(commonRec.KuduNotAccessible.Get(`https://${diagProvider.scmHostName}`));
             }
             return views;
         })();

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/connectionFailureFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/connectionFailureFlow.js
@@ -1,8 +1,9 @@
 import {ResourcePermissionCheckManager, checkVnetIntegrationHealth, checkDnsSettingAsync, checkSubnetSizeAsync} from './flowMisc.js';
-
+import {CommonRecommendations} from './commonRecommendations.js'
 export var connectionFailureFlow = {
     title: "I'm unable to connect to a resource, such as SQL db or Redis db or on-prems, in my Virtual Network",
     async func(siteInfo, diagProvider, flowMgr) {
+        var commonRec = new CommonRecommendations();
         var isKuduAccessible = true;
 
         var kuduAvailabilityCheckPromise = (async () => {
@@ -14,16 +15,7 @@ export var connectionFailureFlow = {
                     level: 1
                 }));
 
-                views.push(new InfoStepView({
-                    infoType: 1,
-                    title: "Recommendations",
-                    markdown: "[Kudu](https://techcommunity.microsoft.com/t5/educator-developer-blog/using-kudu-and-deploying-apps-into-azure/ba-p/378585) is not accessible. Possible reason can be:\r\n\r\n" +
-                        "- Timeout, please click refresh button and retry\r\n\r\n" +
-                        "- Your app has IP restriction or Private Endpoint turned on. Please check your configuration and consider running this check in an environment that is allowed to access your app" +
-                        " or temporarily allow the traffic by adding your client IP into IP restriction allow list or turning of the Private Endpoint for running the network checks\r\n\r\n" +
-                        "- You don't have permission to access Kudu site, please check your permission\r\n\r\n" +
-                        "The diagnostic will be incomplete without Kudu access."
-                }));
+                views.push(commonRec.KuduNotAccessible.Get());
             }
             return views;
         })();

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
@@ -1,3 +1,5 @@
+import {CommonRecommendations} from './commonRecommendations.js'
+
 export class ResourcePermissionCheckManager{
     constructor(){
         this.hidden = true;
@@ -83,17 +85,9 @@ export async function runKuduAccessibleCheck(diagProvider) {
             title: "Kudu is not reachable, diagnostic will be incomplete",
             level: 1
         }));
+        var commonRecommendations = new CommonRecommendations;
 
-        views.push(new InfoStepView({
-            infoType: 1,
-            title: "Recommendations",
-            markdown: "[Kudu](https://techcommunity.microsoft.com/t5/educator-developer-blog/using-kudu-and-deploying-apps-into-azure/ba-p/378585) is not accessible. Possible reason can be:\r\n\r\n" +
-                "- Timeout, please click refresh button and retry\r\n\r\n" +
-                "- Your app has IP restriction or Private Endpoint turned on. Please check your configuration and consider running this check in an environment that is allowed to access your app" +
-                " or temporarily allow the traffic by adding your client IP into IP restriction allow list or turning of the Private Endpoint for running the network checks\r\n\r\n" +
-                "- You don't have permission to access Kudu site, please check your permission\r\n\r\n" +
-                "The diagnostic will be incomplete without Kudu access."
-        }));
+        views.push(commonRecommendations.KuduNotAccessible.Get());
     }
     return views;
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
@@ -87,7 +87,7 @@ export async function runKuduAccessibleCheck(diagProvider) {
         }));
         var commonRecommendations = new CommonRecommendations;
 
-        views.push(commonRecommendations.KuduNotAccessible.Get());
+        views.push(commonRec.KuduNotAccessible.Get(`https://${diagProvider.scmHostname}`));
     }
     return views;
 }


### PR DESCRIPTION
1. getKuduApiAsync and postKuduApiAsync uses management api by default
2. add a new CommonRecommendations to place common recommendations, will create each flow's recommendation js file to separate recommendations from flow logic