### PR TITLE
Adding AppLens Insights on CRI Correction page

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.html
+++ b/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.html
@@ -15,7 +15,7 @@
             <h3 class="box-title">Incident <a href="{{'https://portal.microsofticm.com/imp/v3/incidents/details/' + incidentInfo.incidentId + '/home'}}" target="_blank">{{incidentInfo.incidentId}}</a> &nbsp; {{incidentInfo.title}}</h3>
           </div>
   
-          <div style="height: calc(100vh - 140px);">
+          <div style="max-height: calc(100vh - 140px);">
             <div class="form-group form-content">
               <div class="form-row" *ngFor="let field of incidentInfo.validationResults;">
                   <div class="col-md-12 field-box">
@@ -42,6 +42,27 @@
               {{footerMessage}}
             </div>
           </div>
+        </div>
+        <div *ngIf="solutions && solutions.length>0" id="solutions-content-div" class="card-box" style="margin-bottom: 100px;">
+          <p>We ran some analysis on this app. Here is a summary of issues detected. Please explore 'More info' links to dig into details of <b>potential issues with your app</b>.</p>
+          <table style="width: 100%">
+            <tbody>
+              <tr>
+                <th style="width:20%">Issue</th>
+                <th style="width:60%">Description</th>
+                <th style="width:20%">Link</th>
+              </tr>
+              <tr *ngFor="let solution of solutions">
+                <td style="width:20%">
+                  <div *ngIf="solution.Status==0" style="color:red;font-weight:bold;border-radius:10px;text-align:center;width:20px;height:20px;padding-top:3px;display:inline;margin-right:10px;background-color:white;">!</div>
+                  <div *ngIf="solution.Status==1" style="color:rgb(240,171,44);font-weight:bold;border-radius:10px;text-align:center;width:20px;height:20px;padding-top:3px;display:inline;margin-right:10px;background-color:white;"><span style="top:-4px;position:relative;">&#9888;</span></div>
+                  <div style="display:inline-block;font-weight:700;">{{solution.Title}}</div>
+                </td>
+                <td style="width:60%"><div [innerHTML]="solution.Description"></div></td>
+                <td style="width:20%"><a href="{{solution.Uri}}" target="_blank">More Info</a></td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.scss
@@ -1,6 +1,7 @@
 .main-container {
     background-color: #f3f3f3;
     height: 100vh;
+    overflow-y: auto;
 }
 
 .top-banner{

--- a/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/incidentassist/components/incidentvalidation/incidentvalidation.component.ts
@@ -23,6 +23,7 @@ export class IncidentValidationComponent implements OnInit {
   footerMessage: string = null;
   footerMessageType: string = "none";
   userId: string = null;
+  solutions: any = null;
 
   constructor(private _incidentAssistanceService: IncidentAssistanceService, private _route: ActivatedRoute, private _telemetryService: TelemetryService, private _router: Router, private _adalService: AdalService) {}
 
@@ -88,6 +89,14 @@ export class IncidentValidationComponent implements OnInit {
     });
   }
 
+  scrollToSolutions() {
+    var elementToScroll = document.querySelector(".main-container");
+        var elementToScrollTo = document.getElementById("solutions-content-div") as HTMLElement;
+        if (elementToScroll && elementToScrollTo) {
+            elementToScroll.scrollTop = elementToScrollTo.offsetTop+100;
+        }
+  }
+
   onSubmit() {
     if (!this.validationButtonDisabled){
       var body = {
@@ -100,11 +109,17 @@ export class IncidentValidationComponent implements OnInit {
         this.displayLoader = false;
         var result = JSON.parse(res.body);
         if (result.validationStatus) {
+          if (result.solutions && result.solutions.length>2) {
+            this.solutions = JSON.parse(result.solutions);
+          }
           this.incidentValidationStatus = true;
           this.footerMessage = "All validations have passed.";
           this.footerMessageType = "success";
           this.incidentInfo.validationResults.forEach(x => {x.validationStatus = true; x.oldValue = x.value;});
           this.refreshButtonStatus();
+          if (this.solutions && this.solutions.length>0) {
+            setTimeout(() => {this.scrollToSolutions();}, 300);
+          }
         }
         else {
           this.onValidationFailed(result);


### PR DESCRIPTION
We have already started posting solutions on ICM incidents.

This work is related to showing solutions to customers even before that when the CRI validation has failed and they visit **AppLens CRI correction page** to update the right information.
![ErrorPage](https://user-images.githubusercontent.com/8492235/123175987-8daac180-d437-11eb-848f-18817e7afec4.png)

Once they provide the correct information, we show them any insights that show potential issues detected with their app.
![ShowInsights](https://user-images.githubusercontent.com/8492235/123176038-a1562800-d437-11eb-9eb7-0b62835aa0b0.png)

It is possible customer finds this information relevant and never reactivates the CRI, thus creating deflection.
