### PR TITLE
Enable customize search place holder and pre-select options for data table

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -6,7 +6,7 @@
     <!-- Filters -->
     <div *ngIf="tableFilters.length > 0" style="display: flex;">
       <div *ngFor="let filter of tableFilters;let i = index" style="margin-left: 16px;">
-        <fab-data-table-filter [tableFilter]=filter [options]="getOptionsWithColName(filter.columnName)" (onFilterUpdate)="updateFilter(filter.columnName,$event)" [index]="i" [tableId]="tableId"></fab-data-table-filter>
+        <fab-data-table-filter [tableFilter]="filter" [options]="getOptionsWithColName(filter.name)" (onFilterUpdate)="updateFilter(filter.name,$event)" [index]="i" [tableId]="tableId"></fab-data-table-filter>
       </div>
     </div>
   </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.html
@@ -1,7 +1,7 @@
 <data-container [title]="renderingProperties.title">
   <div style="display: flex;align-items: baseline;">
     <div *ngIf="allowColumnSearch" class="text-field">
-        <fab-search-box #fabSearchBox [value]="searchValue" (onChange)="updateSearchValue($event)" (onFocus)="focusSearchBox()" [placeholder]="searchAriaLabel"></fab-search-box>
+        <fab-search-box #fabSearchBox [value]="searchValue" (onChange)="updateSearchValue($event)" (onFocus)="focusSearchBox()" [placeholder]="searchPlaceholder"></fab-search-box>
     </div>
     <!-- Filters -->
     <div *ngIf="tableFilters.length > 0" style="display: flex;">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -27,15 +27,28 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       });
     }
 
+    //Add pre-selection into filtersMap
     for (const filter of this.tableFilters) {
       this.filtersMap.set(filter.name, new Set<string>());
-      if (filter.defaultSelection && filter.defaultSelection.length > 0) {
+      if (this.checkHasDefaultSelection(filter)) {
         const set = new Set(filter.defaultSelection);
         this.filterSelectionMap.set(filter.name, set);
       }
     }
 
     this.createFabricDataTableObjects();
+
+    //Add first option into filtersMap for single selection
+    for (const filter of this.tableFilters) {
+      if (filter.selectionOption === TableFilterSelectionOption.Single && !this.checkHasDefaultSelection(filter)) {
+        const defaultSelection = Array.from(this.filtersMap.get(filter.name))[0];
+        const set = new Set([defaultSelection]);
+        this.filterSelectionMap.set(filter.name, set);
+      }
+    }
+
+
+
     this.updateTable();
 
     this.fabDetailsList.selectionMode = this.renderingProperties.descriptionColumnName ? SelectionMode.single : SelectionMode.none;
@@ -74,7 +87,7 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       this.fabDetailsList.renderDetailsFooter = this.emptyTableFooter
     }
 
-    if(this.renderingProperties.searchPlaceholder && this.renderingProperties.searchPlaceholder.length > 0) {
+    if (this.renderingProperties.searchPlaceholder && this.renderingProperties.searchPlaceholder.length > 0) {
       this.searchPlaceholder = this.renderingProperties.searchPlaceholder;
     }
   }
@@ -291,6 +304,10 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     let str = `${s}`;
     str = str.trim();
     return str.startsWith('<markdown>') && str.endsWith('</markdown>');
+  }
+
+  private checkHasDefaultSelection(filter: TableFilter) {
+    return filter.defaultSelection && filter.defaultSelection.length > 0;
   }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -73,6 +73,10 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     if (this.rowsClone.length === 0) {
       this.fabDetailsList.renderDetailsFooter = this.emptyTableFooter
     }
+
+    if(this.renderingProperties.searchPlaceholder && this.renderingProperties.searchPlaceholder.length > 0) {
+      this.searchPlaceholder = this.renderingProperties.searchPlaceholder;
+    }
   }
 
 
@@ -98,7 +102,7 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
   columns: IColumn[] = [];
   allowColumnSearch: boolean = false;
   searchTimeout: any;
-  searchAriaLabel = "Search by keywords";
+  searchPlaceholder = "Search by keywords";
   heightThreshold = window.innerHeight * 0.5;
   tableFilters: TableFilter[] = [];
   searchValue: string = "";

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -27,29 +27,11 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
       });
     }
 
-    //Add pre-selection into filtersMap
     for (const filter of this.tableFilters) {
       this.filtersMap.set(filter.name, new Set<string>());
-      if (this.checkHasDefaultSelection(filter)) {
-        const set = new Set(filter.defaultSelection);
-        this.filterSelectionMap.set(filter.name, set);
-      }
     }
 
     this.createFabricDataTableObjects();
-
-    //Add first option into filtersMap for single selection
-    for (const filter of this.tableFilters) {
-      if (filter.selectionOption === TableFilterSelectionOption.Single && !this.checkHasDefaultSelection(filter)) {
-        const defaultSelection = Array.from(this.filtersMap.get(filter.name))[0];
-        const set = new Set([defaultSelection]);
-        this.filterSelectionMap.set(filter.name, set);
-      }
-    }
-
-
-
-    this.updateTable();
 
     this.fabDetailsList.selectionMode = this.renderingProperties.descriptionColumnName ? SelectionMode.single : SelectionMode.none;
     this.fabDetailsList.selection = this.selection;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -157,7 +157,8 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
         rowObject[columnName] = row[i];
 
         if (this.filtersMap.has(columnName)) {
-          this.filtersMap.get(columnName).add(row[i]);
+          const value = `${row[i]}`;
+          this.filtersMap.get(columnName).add(value);
         }
       }
 
@@ -262,7 +263,8 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     //Only if filterSelectionMap has the column name and value for the cell value does not include in the set, return false
     const keys = Array.from(this.filterSelectionMap.keys());
     for (let key of keys) {
-      if (row[key] !== undefined && !this.filterSelectionMap.get(key).has(row[key])) return false;
+      const value = row[key];
+      if (value !== undefined && !this.filterSelectionMap.get(key).has(`${value}`)) return false;
     }
     return true;
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -289,10 +289,6 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     str = str.trim();
     return str.startsWith('<markdown>') && str.endsWith('</markdown>');
   }
-
-  private checkHasDefaultSelection(filter: TableFilter) {
-    return filter.defaultSelection && filter.defaultSelection.length > 0;
-  }
 }
 
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -22,16 +22,21 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     if (this.renderingProperties.columnOptions && this.renderingProperties.columnOptions.length > 0) {
       this.renderingProperties.columnOptions.forEach((option) => {
         if (this.validateFilterOption(option)) {
-          this.tableFilters.push({ columnName: option.name, selectionOption: option.selectionOption });
+          this.tableFilters.push({ name: option.name, selectionOption: option.selectionOption, defaultSelection: option.defaultSelection });
         }
       });
+    }
 
-      for (const filter of this.tableFilters) {
-        this.filtersMap.set(filter.columnName, new Set<string>());
+    for (const filter of this.tableFilters) {
+      this.filtersMap.set(filter.name, new Set<string>());
+      if (filter.defaultSelection && filter.defaultSelection.length > 0) {
+        const set = new Set(filter.defaultSelection);
+        this.filterSelectionMap.set(filter.name, set);
       }
     }
 
     this.createFabricDataTableObjects();
+    this.updateTable();
 
     this.fabDetailsList.selectionMode = this.renderingProperties.descriptionColumnName ? SelectionMode.single : SelectionMode.none;
     this.fabDetailsList.selection = this.selection;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
@@ -65,8 +65,7 @@ export class FabDataTableFilterComponent implements OnInit {
       this.initForMultipleSelection();
       this.updateMultipleSelectionText();
 
-      const selectNothingAsEverything = !this.tableFilter.defaultSelection || this.tableFilter.defaultSelection.length === 0;
-      this.emitSelectedOption(selectNothingAsEverything);
+      this.emitSelectedOption();
     }
   }
 
@@ -132,7 +131,7 @@ export class FabDataTableFilterComponent implements OnInit {
 
   updateTableWithOptions() {
     this.updateText();
-    this.emitSelectedOption(true);
+    this.emitSelectedOption();
     this.closeCallout();
   }
 
@@ -178,9 +177,9 @@ export class FabDataTableFilterComponent implements OnInit {
     }
   }
 
-  emitSelectedOption(selectNothingAsEverything = true) {
+  emitSelectedOption() {
     //For multiple selection,if selected nothing when clicking from callout or no default selection then it will show as selected nothing ,but for updating table it will be same as selected everything
-    if (this.filterOption === TableFilterSelectionOption.Multiple && this.selected.size === 0 && selectNothingAsEverything) {
+    if (this.filterOption === TableFilterSelectionOption.Multiple && this.selected.size === 0) {
       this.onFilterUpdate.emit(new Set(this.options));
     } else {
       this.onFilterUpdate.emit(this.selected);

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
@@ -131,7 +131,7 @@ export class FabDataTableFilterComponent implements OnInit {
   }
 
   private formatOptionName(name: string): string {
-    let formattedString = `${name}`;
+    let formattedString = name;
     //remove empty space and <i> tag
     formattedString = formattedString.replace(/&nbsp;/g, "");
     formattedString = formattedString.replace(/<i.*><\/i>/g, "");

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
@@ -26,8 +26,6 @@ export class FabDataTableFilterComponent implements OnInit {
   selected: Set<string> = new Set<string>();
   optionsWithFormattedName: { name: string, formattedName: string, defaultSelection: boolean }[] = [];
 
-  @ViewChild("checkBoxAll", { static: false }) checkbox: FabCheckboxComponent;
-
   //For single choice
   optionsForSingleChoice: IChoiceGroupOption[] = [];
   selectedKey: string = "";
@@ -133,7 +131,7 @@ export class FabDataTableFilterComponent implements OnInit {
   }
 
   private formatOptionName(name: string): string {
-    let formattedString = name;
+    let formattedString = `${name}`;
     //remove empty space and <i> tag
     formattedString = formattedString.replace(/&nbsp;/g, "");
     formattedString = formattedString.replace(/<i.*><\/i>/g, "");

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FabCheckboxComponent } from '@angular-react/fabric';
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { DirectionalHint, IButtonStyles, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react';
 import { TableFilterSelectionOption, TableFilter } from '../../models/detector';
 
@@ -23,7 +24,9 @@ export class FabDataTableFilterComponent implements OnInit {
   name: string = "";
   filterOption: TableFilterSelectionOption = TableFilterSelectionOption.Single;
   selected: Set<string> = new Set<string>();
-  optionsWithFormattedName: { name: string, formattedName: string }[] = [];
+  optionsWithFormattedName: { name: string, formattedName: string, defaultSelection: boolean }[] = [];
+
+  @ViewChild("checkBoxAll", { static: false }) checkbox: FabCheckboxComponent;
 
   //For single choice
   optionsForSingleChoice: IChoiceGroupOption[] = [];
@@ -53,14 +56,15 @@ export class FabDataTableFilterComponent implements OnInit {
     this.filterSelector = `#${this.filterId}`;
 
     this.options.forEach(option => {
-      this.optionsWithFormattedName.push({ name: option, formattedName: this.formatOptionName(option) });
+      this.optionsWithFormattedName.push({ name: option, formattedName: this.formatOptionName(option), defaultSelection: this.checkIsDefaultSelected(option) });
     });
 
     if (this.filterOption === TableFilterSelectionOption.Single) {
       this.initForSingleSelect();
-      this.displayName = `${this.tableFilter.columnName} : ${this.selectedKey}`;
+      this.displayName = `${this.tableFilter.name} : ${this.selectedKey}`;
     } else if (this.filterOption === TableFilterSelectionOption.Multiple) {
-      this.displayName = `${this.tableFilter.columnName} : ${all}`;
+      this.initForMultipleSelection();
+      this.updateMultipleSelectionText();
     }
   }
 
@@ -94,8 +98,14 @@ export class FabDataTableFilterComponent implements OnInit {
 
   //For single selection
   initForSingleSelect() {
-    this.selectedKey = this.optionsWithFormattedName[0].formattedName;
-    this.selected.add(this.optionsWithFormattedName[0].name);
+    //If has defaultSelection and can be found then make it as default select, otherwise use first one
+    let option = this.optionsWithFormattedName[0];
+    if (this.optionsWithFormattedName.find(o => o.defaultSelection === true)) {
+      option = this.optionsWithFormattedName.find(o => o.defaultSelection === true);
+    }
+
+    this.selectedKey = option.formattedName;
+    this.selected.add(option.name);
 
     this.optionsWithFormattedName.forEach(option => {
       this.optionsForSingleChoice.push({
@@ -110,8 +120,14 @@ export class FabDataTableFilterComponent implements OnInit {
     });
   }
 
+  initForMultipleSelection() {
+    this.optionsWithFormattedName.forEach(o => {
+      if (o.defaultSelection) this.selected.add(o.name);
+    })
+  }
+
   updateTableWithOptions() {
-    this.updateDisplayName();
+    this.updateText();
     this.emitSelectedOption();
     this.closeCallout();
   }
@@ -124,6 +140,11 @@ export class FabDataTableFilterComponent implements OnInit {
     return formattedString;
   }
 
+  private checkIsDefaultSelected(name: string): boolean {
+    const set = new Set(this.tableFilter.defaultSelection);
+    return set.has(name);
+  }
+
   toggleCallout() {
     this.isCallOutVisible = !this.isCallOutVisible;
   }
@@ -132,20 +153,24 @@ export class FabDataTableFilterComponent implements OnInit {
     this.isCallOutVisible = false;
   }
 
-  updateDisplayName() {
+  updateText() {
     if (this.filterOption === TableFilterSelectionOption.Single) {
-      this.displayName = `${this.tableFilter.columnName} : ${this.selectedKey}`;
+      this.displayName = `${this.tableFilter.name} : ${this.selectedKey}`;
     } else if (this.filterOption === TableFilterSelectionOption.Multiple) {
-      if (this.selected.size === 0 || this.selected.size === this.options.length) {
-        //Selected nothing will be same as selected all as for display
-        this.displayName = `${this.tableFilter.columnName} : ${all}`;
-      } else if (this.selected.size == 1) {
-        const selectedName = Array.from(this.selected)[0];
-        const formattedSelectionName = this.optionsWithFormattedName.find(o => selectedName === o.name).formattedName;
-        this.displayName = `${this.tableFilter.columnName} : ${formattedSelectionName}`;
-      } else if (this.selected.size < this.options.length) {
-        this.displayName = `${this.tableFilter.columnName} : ${this.selected.size} of ${this.options.length} selected`;
-      }
+      this.updateMultipleSelectionText();
+    }
+  }
+
+  private updateMultipleSelectionText() {
+    if (this.selected.size === 0 || this.selected.size === this.options.length) {
+      //Selected nothing will be same as selected all as for display
+      this.displayName = `${this.tableFilter.name} : ${all}`;
+    } else if (this.selected.size == 1) {
+      const selectedName = Array.from(this.selected)[0];
+      const formattedSelectionName = this.optionsWithFormattedName.find(o => selectedName === o.name).formattedName;
+      this.displayName = `${this.tableFilter.name} : ${formattedSelectionName}`;
+    } else if (this.selected.size < this.options.length) {
+      this.displayName = `${this.tableFilter.name} : ${this.selected.size} of ${this.options.length} selected`;
     }
   }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table-filter/fab-data-table-filter.component.ts
@@ -60,9 +60,13 @@ export class FabDataTableFilterComponent implements OnInit {
     if (this.filterOption === TableFilterSelectionOption.Single) {
       this.initForSingleSelect();
       this.displayName = `${this.tableFilter.name} : ${this.selectedKey}`;
+      this.emitSelectedOption();
     } else if (this.filterOption === TableFilterSelectionOption.Multiple) {
       this.initForMultipleSelection();
       this.updateMultipleSelectionText();
+
+      const selectNothingAsEverything = !this.tableFilter.defaultSelection || this.tableFilter.defaultSelection.length === 0;
+      this.emitSelectedOption(selectNothingAsEverything);
     }
   }
 
@@ -120,13 +124,15 @@ export class FabDataTableFilterComponent implements OnInit {
 
   initForMultipleSelection() {
     this.optionsWithFormattedName.forEach(o => {
-      if (o.defaultSelection) this.selected.add(o.name);
+      if (o.defaultSelection) {
+        this.selected.add(o.name);
+      }
     })
   }
 
   updateTableWithOptions() {
     this.updateText();
-    this.emitSelectedOption();
+    this.emitSelectedOption(true);
     this.closeCallout();
   }
 
@@ -172,9 +178,9 @@ export class FabDataTableFilterComponent implements OnInit {
     }
   }
 
-  emitSelectedOption() {
-    //For multiple selection,if selected nothing then it will show as selected nothing ,but for updating table it will be same as selected everything
-    if (this.filterOption === TableFilterSelectionOption.Multiple && this.selected.size === 0) {
+  emitSelectedOption(selectNothingAsEverything = true) {
+    //For multiple selection,if selected nothing when clicking from callout or no default selection then it will show as selected nothing ,but for updating table it will be same as selected everything
+    if (this.filterOption === TableFilterSelectionOption.Multiple && this.selected.size === 0 && selectNothingAsEverything) {
       this.onFilterUpdate.emit(new Set(this.options));
     } else {
       this.onFilterUpdate.emit(this.selected);

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -161,15 +161,14 @@ export enum TableFilterSelectionOption {
 }
 
 export interface TableFilter {
-    selectionOption: TableFilterSelectionOption,
-    columnName: string
+    selectionOption: TableFilterSelectionOption;
+    name: string;
+    defaultSelection: string[];
 }
 
-export interface TableColumnOption {
-    name: string;
+export interface TableColumnOption extends TableFilter {
     minWidth: number;
     maxWidth: number;
-    selectionOption: TableFilterSelectionOption,
     visible: boolean;
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -152,6 +152,7 @@ export interface DataTableRendering extends Rendering {
     height: any;
     allowColumnSearch: boolean;
     columnOptions: TableColumnOption[];
+    searchPlaceholder: string;
 }
 
 export enum TableFilterSelectionOption {


### PR DESCRIPTION
This PR is followed by Michi's one to enable customize search place holder and pre-select table filter from detector code

![image](https://user-images.githubusercontent.com/23129934/123316065-45e07480-d4e1-11eb-83ca-e83930b4816e.png)

To specify default selection option for a column, you can pass list of sting for option name you want to  select
```
var machineNameColumnOption = new TableColumnOption()
    {
        Name = "Instance",
        SelectionOption = FileterSelectionOption.Single,
        DefaultSelection = criticalInsightMachineName != null ? new List<string> { criticalInsightMachineName } : null,
        MaxWidth = 120,
        Visible = false,
    };
```

To customize search place holder text, you can specify it with `SearchPlaceholder `  and need to set `AllowColumnSearch` to `true` as well
```
var tableRenderingProps = new TableRendering()
    {
        Description = downloadLinkMessage,
        SearchPlaceholder = "Search By Logs",
        AllowColumnSearch = true,
    }
```
