### PR TITLE
Add Network Troubleshooter to portal referrer

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -47,6 +47,13 @@ export class WebSitesService extends ResourceService {
                 ReferrerTabName: '',
                 DetectorType: DetectorType.Detector,
                 DetectorId: 'configuringsslandcustomdomains'
+            },
+            {
+                ReferrerExtensionName: 'Websites',
+                ReferrerBladeName: 'VnetIntegrationV2DetailsBlade',
+                ReferrerTabName: '',
+                DetectorType: DetectorType.DiagnosticTool,
+                DetectorId: 'networkchecks'
             }];
 
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -59,7 +59,7 @@ export class SupportTopicService {
                         
                     } else{
                         // non-container windows webapp/function app
-                        return observableOf({ path: 'tools/networkchecks', queryParams: { "isSupportCenter": true } });
+                        return observableOf({ path: 'tools/networkchecks', queryParams: { "redirectFrom": "supportTopic" }});
                     }
                 }
             } 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
@@ -83,11 +83,13 @@ export class PortalReferrerResolverComponent implements OnInit {
         if (referrerMatch.DetectorType === DetectorType.Detector) {
           path = `${path}/detectors/${referrerMatch.DetectorId}`;
         }
-        else {
-          if (referrerMatch.DetectorType === DetectorType.Analysis) {
-            path = `${path}/analysis/${referrerMatch.DetectorId}`;
-          }
+        else if (referrerMatch.DetectorType === DetectorType.Analysis) {
+          path = `${path}/analysis/${referrerMatch.DetectorId}`;
         }
+        else if (referrerMatch.DetectorType === DetectorType.DiagnosticTool) {
+          path = `${path}/tools/${referrerMatch.DetectorId}`;
+        }
+
         this._logService.logEvent('IntegratedDiagnostics', {
           details: 'Redirect decided by detector map.',
           referrerInformation: JSON.stringify(referrer),
@@ -106,6 +108,6 @@ export class PortalReferrerResolverComponent implements OnInit {
     }
 
     this.isEvaluating = false;
-    this._router.navigate([path], { queryParamsHandling: 'merge' });
+    this._router.navigate([path], { queryParamsHandling: 'merge',  queryParams: { "redirectFrom": "referrer" } });
   }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
@@ -64,11 +64,10 @@ export class PortalReferrerResolverComponent implements OnInit {
 
       if (referrer.DetectorType.toLowerCase() === DetectorType.Analysis.toLowerCase()) {
         path = `${path}/analysis/${referrer.DetectorId}`;
-      }
-      else {
-        if (referrer.DetectorType.toLowerCase() === DetectorType.Detector.toLowerCase()) {
-          path = `${path}/detectors/${referrer.DetectorId}`;
-        }
+      } else if (referrer.DetectorType.toLowerCase() === DetectorType.Detector.toLowerCase()) {
+        path = `${path}/detectors/${referrer.DetectorId}`;
+      } else if (referrer.DetectorType.toLowerCase() === DetectorType.DiagnosticTool.toLowerCase()) {
+        path = `${path}/tools/${referrer.DetectorId}`;
       }
     }
     else {
@@ -108,6 +107,6 @@ export class PortalReferrerResolverComponent implements OnInit {
     }
 
     this.isEvaluating = false;
-    this._router.navigate([path], { queryParamsHandling: 'merge',  queryParams: { "redirectFrom": "referrer" } });
+    this._router.navigate([path], { queryParamsHandling: 'merge', queryParams: { "redirectFrom": "referrer" } });
   }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.html
@@ -1,4 +1,4 @@
-<div class="network-checking-tool" #networkCheckingTool [ngStyle]="isSupportCenter ? {width: '100vw', height:'100vh'}:{width: 'calc(100vw - 298px)', height:'calc(100vh - 35px)'}">
+<div class="network-checking-tool" #networkCheckingTool [ngStyle]="{width: width, height: height}">
     <div class="container">
         <h2 >{{ title }}</h2>
         <p>{{ description }}</p>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-checks.component.ts
@@ -43,8 +43,10 @@ export class NetworkCheckComponent implements OnInit, AfterViewInit {
     vnetIntegrationDetected = null;
     openFeedback = false;
     debugMode = false;
-    isSupportCenter: boolean;
+    isSupportTopic: boolean;
     logEvent: (eventMessage: string, properties: { [name: string]: string }, measurements?: any) => void;
+    width =  'calc(100vw - 298px)';
+    height = 'calc(100vh - 35px)';
     private _feedbackQuestions = "- Is your networking issue resolved? \r\n\r\n\r\n" +
         "- What was the issue?\r\n\r\n\r\n" +
         "- If the issue was not resolved, what can be the reason?\r\n\r\n\r\n" +
@@ -57,9 +59,13 @@ export class NetworkCheckComponent implements OnInit, AfterViewInit {
             var feedbackPanelConfig = { defaultFeedbackText: this._feedbackQuestions, detectorName: "NetworkCheckingTool", notResetOnDismissed: true, url: window.location.href }
             _globals.messagesData.feedbackPanelConfig = feedbackPanelConfig;
             var queryParams = _route.snapshot.queryParams;
-            this.isSupportCenter = (queryParams["isSupportCenter"] === "true");
+            this.isSupportTopic = (queryParams["redirectFrom"] === "supportTopic");
+            if(this.isSupportTopic || queryParams["redirectFrom"] === "referrer"){
+                this.width = '100vw';
+                this.height = '100vh';
+            }
             this.logEvent = (eventMessage: string, properties: { [name: string]: string } = {}, measurements?: any) => {
-                properties.isSupportCenter = this.isSupportCenter.toString();
+                properties.redirectFrom = queryParams["redirectFrom"];
                 _telemetryService.logEvent(eventMessage, properties, measurements);
             };
             window["networkCheckLinkClickEventLogger"] = (viewId: string, url: string, text: string) => {
@@ -114,7 +120,7 @@ export class NetworkCheckComponent implements OnInit, AfterViewInit {
                 flows = flows.concat(remoteFlows);
             }
             var mgr = this.stepFlowManager;
-            if (this.isSupportCenter && 
+            if (this.isSupportTopic && 
                 this.siteInfo.kind.includes("functionapp") && 
                 this.siteInfo.sku.toLowerCase() == "dynamic") {
                 mgr.addView(new InfoStepView({

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -82,7 +82,8 @@ export interface SupportTopic {
 export enum DetectorType {
     Detector = "Detector",
     Analysis = "Analysis",
-    CategoryOverview = "CategoryOverview"
+    CategoryOverview = "CategoryOverview",
+    DiagnosticTool = "DiagnosticTool"
 }
 export enum RenderingType {
     NoGraph = 0,


### PR DESCRIPTION
Add Network Troubleshooter to portal referrer for enabling integrated diagnostic experience for Network Troubleshooter

add a new `redirectFrom` queryParamter to indicate where the request was routed from

minor adjustments in network check component for integrated diagnostic experience 