### PR TITLE
Hide confirmation message for solution action of blade / tab open

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
@@ -16,11 +16,11 @@
       </div>
 
       <span class="ml-3">
-        {{actionStatus}}
+        <span *ngIf="showCompletionConfirmation()">{{actionStatus}}</span>
         <span *ngIf="actionStatus === 'Running...'">
           <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
         </span>
-        <span *ngIf="actionStatus === confirmationMessage">
+        <span *ngIf="actionStatus === confirmationMessage && showCompletionConfirmation()">
           <i class="fa fa-check-circle" aria-hidden="true"></i>
         </span>
       </span>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
@@ -75,6 +75,10 @@ export class SolutionComponent extends DataRenderBaseComponent {
         return ActionType.Markdown;
     }
 
+    public showCompletionConfirmation():boolean {
+        return this.solution.Action!= ActionType.GoToBlade && this.solution.Action!= ActionType.OpenTab;
+    }
+
     prepareAction() {
         let actionOptions = {};
 


### PR DESCRIPTION
Hide confirmation message for solution action of blade / tab open as those are UI actions and a confirmation message is irrelevant.