### PR TITLE
Enable diagnostic tools only for linux web app and linux paid dedicated function app

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -237,7 +237,7 @@ export class SitesCategoryService extends CategoryService {
           createFlowForCategory: true,
           chatEnabled: false
         }
-      },
+      }
   ];
 
   constructor(private _resourceService: WebSitesService, private _websiteFilter: WebSiteFilter, private _armService: ArmService) {
@@ -266,16 +266,19 @@ export class SitesCategoryService extends CategoryService {
       );
     }
 
-    this._sitesCategories.push(this._getDiagnosticToolsCategory(this._resourceService.resourceIdForRouting));
+ //   this._sitesCategories.push(this._getDiagnosticToolsCategory(this._resourceService.resourceIdForRouting));
+    this._getDiagnosticToolsCategory(this._resourceService.resourceIdForRouting).forEach((diagnosticCategory) => {
+        this._sitesCategories.push(diagnosticCategory);
+    });
 
     this._addCategories(
       this._websiteFilter.transform(this._sitesCategories)
     );
   }
 
-  private _getDiagnosticToolsCategory(siteId: string): SiteFilteredItem<Category> {
-    return <SiteFilteredItem<Category>>{
-      appType: AppType.WebApp | AppType.FunctionApp,
+  private _getDiagnosticToolsCategory(siteId: string): SiteFilteredItem<Category>[] {
+    return <SiteFilteredItem<Category>[]> [{
+      appType: AppType.WebApp,
       platform: OperatingSystem.any,
       stack: '',
       sku: Sku.All,
@@ -290,7 +293,24 @@ export class SitesCategoryService extends CategoryService {
         createFlowForCategory: false,
         overridePath: `resource${siteId}/diagnosticTools`
       }
-    };
+    },
+    {
+        appType: AppType.FunctionApp,
+        platform: OperatingSystem.linux,
+        stack: '',
+        sku: Sku.PaidDedicated,
+        hostingEnvironmentKind: HostingEnvironmentKind.All,
+        item: {
+          id: 'DiagnosticTools',
+          name: 'Diagnostic Tools',
+          overviewDetectorId:'DiagnosticTools',
+          description: 'Run proactive tools to automatically mitigate the app.',
+          keywords: ['Auto-Heal'],
+          color: 'rgb(170, 192, 208)',
+          createFlowForCategory: false,
+          overridePath: `resource${siteId}/diagnosticTools`
+        }
+      }];
   }
 
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -294,6 +294,7 @@ export class SitesCategoryService extends CategoryService {
         overridePath: `resource${siteId}/diagnosticTools`
       }
     },
+    // For Function App on Linux, "Diagnostic Tools" is only enabled for Paid Dedicated sku
     {
         appType: AppType.FunctionApp,
         platform: OperatingSystem.linux,
@@ -310,7 +311,43 @@ export class SitesCategoryService extends CategoryService {
           createFlowForCategory: false,
           overridePath: `resource${siteId}/diagnosticTools`
         }
-      }];
+      },
+      // For dedicated Function Apps on Windows
+      {
+        appType: AppType.FunctionApp,
+        platform: OperatingSystem.windows,
+        stack: '',
+        sku: Sku.NotDynamic,
+        hostingEnvironmentKind: HostingEnvironmentKind.All,
+        item: {
+          id: 'DiagnosticTools',
+          name: 'Diagnostic Tools',
+          overviewDetectorId:'DiagnosticTools',
+          description: 'Run proactive tools to automatically mitigate the app.',
+          keywords: ['Auto-Heal'],
+          color: 'rgb(170, 192, 208)',
+          createFlowForCategory: false,
+          overridePath: `resource${siteId}/diagnosticTools`
+        }
+      },
+       // For consumption Function Apps on Windows
+      {
+          appType: AppType.FunctionApp,
+          platform: OperatingSystem.windows,
+          stack: '',
+          sku: Sku.Dynamic,
+          hostingEnvironmentKind: HostingEnvironmentKind.All,
+          item: {
+            id: 'DiagnosticTools',
+            name: 'Diagnostic Tools',
+            overviewDetectorId:'DiagnosticTools',
+            description: 'Run proactive tools to automatically mitigate the app.',
+            keywords: ['Network-Troubleshooter'],
+            color: 'rgb(170, 192, 208)',
+            createFlowForCategory: false,
+            overridePath: `resource${siteId}/diagnosticTools`
+          }
+        }];
   }
 
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/server-farm.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/server-farm.ts
@@ -29,10 +29,13 @@ export enum Sku {
     Premium = 1 << 5,
     PremiumV2 = 1 << 6,
     Isolated = 1 << 7,
-    PremiumContainer = 1 << 8,
-    Paid = 504,         // 111111000
-    NotDynamic = 507,   // 111111011
-    All = 511           // 111111111
+    PremiumContainer = 1 << 8, // 100000000
+    ElasticPremium = 1 << 9, // 1000000000
+    Paid = 1016,         // 1111111000
+    Dedicated = 507,    // 111111011 Not Dynamic or ElasticPremium
+    NotDynamic = 1019,   // 1111111011
+    PaidDedicated =  504, // 111111000
+    All = (1 << 10) - 1           // 1111111111 0111111011 => 111111011
 }
 
 export enum WorkerSize {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/server-farm.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/server-farm.ts
@@ -32,10 +32,10 @@ export enum Sku {
     PremiumContainer = 1 << 8, // 100000000
     ElasticPremium = 1 << 9, // 1000000000
     Paid = 1016,         // 1111111000
-    Dedicated = 507,    // 111111011 Not Dynamic or ElasticPremium
+    NotDynamicAndElasticPremium = 507,    // 111111011 Not Dynamic or ElasticPremium
     NotDynamic = 1019,   // 1111111011
-    PaidDedicated =  504, // 111111000
-    All = (1 << 10) - 1           // 1111111111 0111111011 => 111111011
+    PaidDedicated =  504, // 111111000: Paid & Dedicated
+    All = (1 << 10) - 1           // 1111111111
 }
 
 export enum WorkerSize {


### PR DESCRIPTION
@puneetg1983  Putting this PR for autoheal disablement as we discussed the other day. 
In this PR, "Diagnostic Tools" category card will only show for the following type of resources in D&S homepage:
1. Linux web app
2. Linux paid dedicated function app.

Please help review/test it accordingly and see if I am missing anything here.
