### PR TITLE
Enabling dynamic analysis by default to fix white screen problems

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -82,7 +82,7 @@ export class SupportTopicService {
                             detectorPath = `/detectors/${matchingDetector.id}`;
                         }
                     }
-                    else if (this.supportTopicConfig.hasOwnProperty(this.pesId) && this.supportTopicConfig[this.pesId].findIndex(spId => spId === supportTopicId) >= 0) {
+                    else {
                         detectorPath = `/analysis/searchResultsAnalysis/search`;
                     }
                 }


### PR DESCRIPTION
What is the white screen problem?
When diagnostics blade is opened in case submission, and no detectors are mapped to the support topic or dynamic analysis is not enabled, customers see a white screen.
![image](https://user-images.githubusercontent.com/8492235/125177208-b4cef600-e18e-11eb-9559-4bbee9ce976e.png)


Below support topics were identified as showing white screen on case submission diagnostics blade:

ProductId | SupportTopicId | SupportTopicPath | Remarks
-- | -- | -- | --
16072 | 32749791 | Function App\Authentication and Authorization\OpenID Connect provider
16072 | 32630467 | Function App\Availability\Function App restarted | Functions Linux App
16072 | 32786284 | Function App\Availability\Outbound network connections from my app are   failing
16072 | 32786280 | Function App\Networking\Configuring hybrid connections with App Service | Functions Linux App
16072 | 32630463 | Function App\Configuring and Managing Function Apps.\Custom Domain
16072 | 32630470 | Function App\Configuring and Managing Function Apps.\SSL
16072 | 32607518 | Function App\Durable Functions\Creation
16072 | 32630474 | Function App\Performance\Functions scaling issues
17531 | 32630465 | Function App on Azure Arc\Configuring and Managing Function   Apps.\Deployment Slots
17531 | 32630472 | Function App on Azure Arc\Deploying Function Apps\Developer Tools   Deployment (Visual Studio, Visual Studio Code, Functions Core Tools)
17531 | 32630474 | Function App on Azure Arc\Performance\Functions scaling issues
17531 | 32630474 | Function App on Azure Arc\Performance\Functions scaling issues
16170 | 32588774 | Web App (Linux)\Deployment\Visual Studio
16170 | 32784809 | Web App (Linux)\Networking\Configuring Private Endpoints or Service   Endpoints on App Service
16333 | 32588774 | Web App for Containers\Deployment\Visual Studio
16333 | 32784809 | Web App for Containers\Networking\Configuring Private Endpoints or   Service Endpoints on App Service
16333 | 32444081 | Web App for Containers\OSS (e.g. WordPress, PHP, NodeJs, Java)\Java SE
16333 | 32581620 | Web App for Containers\Availability, Performance, and Application   Issues\Remote debugging
16333 | 32588770 | Web App for Containers\Configuration and Management\Accessing app using   SSH
16333 | 32581628 | Web App for Containers\Deployment\ARM template
16333 | 32629421 | Web App for Containers\Deployment\Azure DevOps
16333 | 32588774 | Web App for Containers\Deployment\Visual Studio
16333 | 32542210 | Web App for Containers\Networking\IP configuration
17530 | 32588770 | Web App on Azure Arc\Configuration and Management\Accessing app using SSH
17530 | 32542211 | Web App on Azure Arc\Configuration and Management\Scaling
17530 | 32581628 | Web App on Azure Arc\Deployment\ARM template
17530 | 32629421 | Web App on Azure Arc\Deployment\Azure DevOps
15791 | 32742502 | Logic App\Connectors\Event Grid
15791 | 32742529 | Logic App\Connectors\IBM MQ
15791 | 32742534 | Logic App\Connectors\Office 365 Outlook
15791 | 32742535 | Logic App\Connectors\Oracle DB
15791 | 32742542 | Logic App\Connectors\Salesforce
15791 | 32742547 | Logic App\Connectors\SharePoint


To fix this we are defaulting to dynamic analysis for any scenario where diagnostics blade opens in case submission and there is no detector mapped and no keystone solution is found.

So if detectors can be found matching customer query, customers will see something like this:
![image](https://user-images.githubusercontent.com/8492235/125177213-c1ebe500-e18e-11eb-89f0-6693446d6420.png)

Even if detectors were not found, the dynamic analysis will shows answers and articles from web and static self help content:
![image](https://user-images.githubusercontent.com/8492235/125177215-c6b09900-e18e-11eb-8de5-bea14f943ea7.png)

Thanks