### PR TITLE
Enable for picking dynamic insight title for analysis view

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/data-table-v4/data-table-v4.component.ts
@@ -276,12 +276,13 @@ export class DataTableV4Component extends DataRenderBaseComponent implements Aft
     return width;
   }
 
+  //Return true only if table is not empty and has column for this filter with same name
   private validateFilterOption(option: TableColumnOption): boolean {
     if (option.selectionOption === undefined || option.selectionOption === TableFilterSelectionOption.None) {
       return false;
     }
     const columns = this.diagnosticData.table.columns;
-    return columns.findIndex(col => col.columnName === option.name) > -1;
+    return columns.findIndex(col => col.columnName === option.name) > -1 && this.diagnosticData.table.rows.length > 0;
   }
 
   isMarkdown(s: any) {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -626,7 +626,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     }
 
     getDetectorInsight(viewModel: any): any {
-        let allInsights: Insight[] = InsightUtils.parseAllInsightsFromResponse(viewModel.response);
+        let allInsights: Insight[] = InsightUtils.parseAllInsightsFromResponse(viewModel.response,true);
         let insight: any;
         if (allInsights.length > 0) {
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.ts
@@ -113,7 +113,7 @@ export class SolutionComponent extends DataRenderBaseComponent {
         let detectorLink = UriUtilities.BuildDetectorLink(this.solution.ResourceUri, this.solution.DetectorId);
         let detectorLinkMarkdown = `Go to [App Service Diagnostics](${detectorLink})`;
 
-        if (markdownBuilder.toLowerCase().includes("{detectorlink}")) {
+        if (markdownBuilder && markdownBuilder.toLowerCase().includes("{detectorlink}")) {
             markdownBuilder = markdownBuilder.replace(/{detectorlink}/gi, detectorLink);
         } else if (!markdownBuilder.includes(detectorLinkMarkdown)) {
             markdownBuilder = markdownBuilder + "\n\n" + detectorLinkMarkdown;

--- a/AngularApp/projects/diagnostic-data/src/lib/models/insight.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/insight.ts
@@ -1,5 +1,6 @@
-import { Rendering, DiagnosticData, HealthStatus, RenderingType, DetectorResponse } from './detector';
+import { Rendering, DiagnosticData, HealthStatus, RenderingType, DetectorResponse, DynamicInsightRendering } from './detector';
 import { Solution } from '../components/solution/solution';
+
 
 export class InsightBase {
     status: HealthStatus;
@@ -38,17 +39,35 @@ export class Insight extends InsightBase {
 }
 
 export class InsightUtils {
-    static parseAllInsightsFromResponse(response: DetectorResponse): Insight[] {
-        let insightDiagnosticData = response.dataset.filter(data => (<Rendering>data.renderingProperties).type === RenderingType.Insights);
+    static parseAllInsightsFromResponse(response: DetectorResponse, withDynamicInsights = false): Insight[] {
+        let insightDiagnosticData = response.dataset.filter(data => {
+            const type = (<Rendering>data.renderingProperties).type;
 
-        let allInsights: Insight[] = [];
-
-        insightDiagnosticData.forEach((diagnosticData: DiagnosticData) => {
-            let insights = this.parseInsightRendering(diagnosticData);
-            insights.forEach(insight => allInsights.push(insight));
+            if (withDynamicInsights) {
+                return type === RenderingType.Insights || RenderingType.DynamicInsight;
+            } else {
+                return type === RenderingType.Insights;
+            }
         });
 
-        return allInsights;
+        let allInsights: Insight[] = [];
+        let allDynamicInsights: Insight[] = [];
+        insightDiagnosticData.forEach((diagnosticData: DiagnosticData) => {
+            const type = (<Rendering>diagnosticData.renderingProperties).type;
+            switch (type) {
+                case RenderingType.Insights:
+                    let insights = this.parseInsightRendering(diagnosticData);
+                    insights.forEach(insight => allInsights.push(insight));
+                    break;
+                case RenderingType.DynamicInsight:
+                    let dynamicInsight = DynamicInsightUtils.parseDynamicInsightFromResponse(diagnosticData);
+                    allDynamicInsights.push(dynamicInsight);
+                    break;
+                default:
+                    break;
+            }
+        });
+        return allDynamicInsights.concat(allInsights);
     }
 
     static parseInsightRendering(diagnosticData: DiagnosticData): Insight[] {
@@ -91,4 +110,14 @@ export class InsightUtils {
 export class DynamicInsight extends InsightBase {
     description: string;
     innerDiagnosticData: DiagnosticData;
+}
+
+class DynamicInsightUtils {
+    static parseDynamicInsightFromResponse(diagnosticData: DiagnosticData): Insight {
+        const renderingProperties = <DynamicInsightRendering>diagnosticData.renderingProperties;
+        const status = renderingProperties.status;
+        const title = renderingProperties.title;
+        const expanded = renderingProperties.expanded;
+        return new Insight(`${status}`, title, expanded);
+    }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/insight.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/insight.ts
@@ -51,7 +51,6 @@ export class InsightUtils {
         });
 
         let allInsights: Insight[] = [];
-        let allDynamicInsights: Insight[] = [];
         insightDiagnosticData.forEach((diagnosticData: DiagnosticData) => {
             const type = (<Rendering>diagnosticData.renderingProperties).type;
             switch (type) {
@@ -61,13 +60,13 @@ export class InsightUtils {
                     break;
                 case RenderingType.DynamicInsight:
                     let dynamicInsight = DynamicInsightUtils.parseDynamicInsightFromResponse(diagnosticData);
-                    allDynamicInsights.push(dynamicInsight);
+                    allInsights.push(dynamicInsight);
                     break;
                 default:
                     break;
             }
         });
-        return allDynamicInsights.concat(allInsights);
+        return allInsights;
     }
 
     static parseInsightRendering(diagnosticData: DiagnosticData): Insight[] {
@@ -115,9 +114,9 @@ export class DynamicInsight extends InsightBase {
 class DynamicInsightUtils {
     static parseDynamicInsightFromResponse(diagnosticData: DiagnosticData): Insight {
         const renderingProperties = <DynamicInsightRendering>diagnosticData.renderingProperties;
-        const status = renderingProperties.status;
+        const status = HealthStatus[renderingProperties.status];
         const title = renderingProperties.title;
         const expanded = renderingProperties.expanded;
-        return new Insight(`${status}`, title, expanded);
+        return new Insight(status, title, expanded);
     }
 }


### PR DESCRIPTION
Three changes in this PR,

1. Fix "Cannot read property 'toLowerCase' of null" in Insight.component

2. Fix  if table is empty in first place, we will show no filters.

3. Based on [WI 10316548](https://msazure.visualstudio.com/Antares/_workitems/edit/10316548), currently when displaying insight title in analysis view, we will only it pick from basic Insight. In this PR, I adding logic to pick title from both basic insights as well as dynamic insights, so insight title will be aligned with the status respectively.

In analysis,
![image](https://user-images.githubusercontent.com/23129934/125373422-fb148880-e339-11eb-9a70-2d39b3ee5f4e.png)

In detector view,
![image](https://user-images.githubusercontent.com/23129934/125373487-1a131a80-e33a-11eb-9d75-757780014df7.png)

