### PR TITLE
Solution orchestrator updates

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -26,7 +26,7 @@ export class SupportTopicService {
     };
 
     private solutionOrchestratorConfig = {
-        "14748": []
+        "14748": ["32629421"]
     };
 
     constructor(protected _http: HttpClient, protected _authService: AuthService, protected _diagnosticService: DiagnosticService, protected _resourceService: ResourceService, protected _telemetryService: TelemetryService) {
@@ -87,7 +87,9 @@ export class SupportTopicService {
                         }
                     }
                     else {
-                        if (this.solutionOrchestratorConfig && this.solutionOrchestratorConfig[this.pesId] && this.solutionOrchestratorConfig[this.pesId].length>0 && this.solutionOrchestratorConfig[this.pesId].findIndex(s => s==this.supportTopicId)>=0) {
+                        if ((this._resourceService.subscriptionId == "c258f9c0-3d64-4761-8697-cab631f28422" || this._resourceService.subscriptionId == "ef90e930-9d7f-4a60-8a99-748e0eea69de")
+                            && this.solutionOrchestratorConfig && this.solutionOrchestratorConfig[this.pesId]
+                            && this.solutionOrchestratorConfig[this.pesId].length>0 && this.solutionOrchestratorConfig[this.pesId].findIndex(s => s==this.supportTopicId)>=0) {
                             detectorPath = `solutionorchestrator`;
                             return observableOf({ path: detectorPath, queryParams: queryParamsDic });
                         }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.html
@@ -1,9 +1,12 @@
-<div *ngIf="title" class="row collapsable-list">
+<div *ngIf="title" class="row" [ngClass]="{'collapsable-list-less-margin': lessMargin, 'collapsable-list': !lessMargin}">
   <button class="btn-outer" [attr.aria-expanded]="collapsed ?'false':'true'" (click)="clickHandler()"
     class="list-header">
     <span class="btn-inner" tabindex="-1">
       <div style="float:left" class="custom-caret" [class.custom-caret-down]="collapsed">
         <fab-icon iconName="ChevronUp" ariaLabel="ChevronUp"></fab-icon>
+      </div>
+      <div style="float:left" *ngIf="iconProps">
+        <fab-icon [iconName]="iconProps.iconName" ariaLabel="Section icon" [styles]="iconProps.styles"></fab-icon>
       </div>
       <div style="float:left">
         <span class="pl-3">{{title}}</span>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.scss
@@ -3,6 +3,13 @@
     padding: 0px 10px;
     border-bottom: 1px solid #ccc;
 }
+
+.collapsable-list-less-margin {
+    margin-top: 5px;
+    padding: 0px 10px;
+    border-bottom: 1px solid #ccc;
+}
+
 .list-header {
     font-size: 14px;
     font-weight: 500;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.ts
@@ -11,6 +11,8 @@ export class CollapsibleListFabricComponent {
 
   @Input() title: string;
   @Input() collapsed: boolean;
+  @Input() lessMargin: boolean = false;
+  @Input() iconProps: any = null;
 
   @ContentChildren(CollapsibleListItemComponent) listItemComponents: QueryList<CollapsibleListItemComponent>;
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.html
@@ -37,9 +37,9 @@
       </div>
     </div>
     <div class="row" name="top-solution" style="border-bottom: 1px solid #ccc;padding-bottom:15px;">
-      <h3 style="font-size: 16px;font-weight: 700;margin: 2px 10px;">We think we found you a solution!</h3>
-      <p style="margin: 2px 10px;">Customers with similar problems were able to solve it by following these solutions below</p>
-      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="topLevelSolutions && topLevelSolutions.length>0">
+      <h3 style="font-size: 16px;font-weight: 700;margin: 2px 10px;">Try these potential solutions!</h3>
+      <p style="margin: 2px 10px;">Customers with similar problems were able to solve it with these resources below</p>
+      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="topLevelSolutions && topLevelSolutions.length>0 && !showSolutionsTimedout">
         <solution-view-container [solutionTitle]="topLevelSolutions[mainSolutionIndex].Title" [isRecommended]="true" [detector]="'detector'"
         [isAnalysisView]="false" [isKeystoneDetector]="false" [askReasonNotHelpful]="true">
         <markdown [data]="topLevelSolutions[mainSolutionIndex].DescriptionMarkdown"></markdown>
@@ -50,25 +50,41 @@
         <div style="margin: 15px 0; min-width: 300px;" *ngIf="topLevelSolutions && topLevelSolutions.length>1">
           <span>Try these other options:</span>
           <div class="row">
-            <div *ngFor="let sol of topLevelSolutions; let i =index" class="col col-md-4-special solutions-small-card-outer">
+            <table style="table-layout: fixed;width: 100%;"><tbody>
+              <tr style="height: 50px;">
+                <td *ngFor="let sol of topLevelSolutions; let i =index" style="max-width: 33%;white-space: nowrap;" [hidden]="(i < 3)? false: true">
+                    <div class="solutions-small-card" [ngStyle]="{'background-color': mainSolutionIndex==i? '#e8e8e8': 'white'}" (click)="selectSolution(sol, i)">
+                      <span>{{sol.Title}}</span>
+                    </div>
+                </td>
+              </tr>
+            </tbody></table>
+            <!--<div *ngFor="let sol of topLevelSolutions; let i =index" class="col col-md-4 solutions-small-card-outer" [hidden]="(i < 3)? false: true">
               <div class="solutions-small-card" [ngStyle]="{'background-color': mainSolutionIndex==i? '#e8e8e8': 'white'}" (click)="selectSolution(sol, i)">
                 <span>{{sol.Title}}</span>
               </div>
-            </div>
+            </div>-->
           </div>
         </div>
       </div>
-      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="fetchingDetectors || getPendingDetectorCount() > 0">
+      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="(fetchingDetectors || getPendingDetectorCount() > 0) && !showSolutionsTimedout">
         <loader-detector-view></loader-detector-view>
       </div>
-      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="!fetchingDetectors && getPendingDetectorCount() === 0 && (!topLevelSolutions || topLevelSolutions.length==0)">
-        <div class="support-doc-section">
+      <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="!fetchingDetectors && (((getPendingDetectorCount() === 0) && (!topLevelSolutions || topLevelSolutions.length==0)) || showSolutionsTimedout)">
+        <!--<div class="support-doc-section">
           <markdown *ngIf="supportDocumentContent.length>0" [data]="supportDocumentContent"></markdown>
+        </div>-->
+        <div *ngFor="let doc of webDocuments;let i =index" class="article" style="margin: 10px 0px;" (click)="selectResult(doc)" tabindex="0" (keyup.enter)="selectResult(doc)" [hidden]="(i < 2 ) ? false : true">
+          <a style="font-weight:600;">{{doc.title}}
+          <i class="fa fa-external-link"></i>
+          </a>
+          <div class="article-link">{{doc.linkShort}}</div>
+          <div class="web-doc-text">{{doc.description}}</div>
         </div>
       </div>
     </div>
     <div class="row" name="documentation-results">
-      <collapsible-list-fabric [collapsed]="true" [title]="'View Documentation and Guides from the Web (' + 2 + ')'">
+      <collapsible-list-fabric [iconProps]="documentationSectionIcon" [collapsed]="true" [title]="'View Documentation and Guides from the Web (' + 2 + ')'" [lessMargin]="true">
         <collapsible-list-item body *ngIf="supportDocumentContent && supportDocumentContent.length>0" style="margin-left:25px;"><p style="font-weight: 500;">Azure Guides</p></collapsible-list-item>
         <collapsible-list-item body *ngIf="supportDocumentContent && supportDocumentContent.length>0" style="display:inline-block; width: 90%; margin: 5px 2.5%;">
           <div class="support-doc-section">
@@ -81,7 +97,7 @@
             <span style="margin-left:5px;font-weight:500;">Documents from the web</span>
           </div>
         </collapsible-list-item>
-        <collapsible-list-item body *ngFor="let doc of webDocuments;let i =index" style="display:inline-block; width: 90%; margin: 5px 2.5%;" [hidden]="(i < numArticlesExpanded ) ? false : !viewRemainingArticles">
+        <collapsible-list-item body *ngFor="let doc of webDocuments;let i =index" style="display:inline-block; width: 90%; margin: 5px 2.5%;">
           <div class="article" (click)="selectResult(doc)" tabindex="0" (keyup.enter)="selectResult(doc)" >
               <a style="font-weight:600;">{{doc.title}}
               <i class="fa fa-external-link"></i>
@@ -90,21 +106,17 @@
               <div class="web-doc-text">{{doc.description}}</div>
           </div>
         </collapsible-list-item>
-        <a  *ngIf="webDocuments.length>numArticlesExpanded"
-          (click)="showRemainingArticles()"> 
-          {{viewOrHideAnchorTagText(viewRemainingArticles , webDocuments.length , numArticlesExpanded )}}   
-        </a>
       </collapsible-list-fabric>
     </div>
     <div class="row" name="detector-results">
-      <div *ngIf="getPendingDetectorCount() > 0" style="margin-top: 24px;padding: 0px 10px;border-bottom: 1px solid #ccc;">
+      <div *ngIf="getPendingDetectorCount() > 0" style="margin-top: 5px;padding: 0px 10px;border-bottom: 1px solid #ccc;">
         <div style="display: inline;" class="row">
           <i class="fa fa-circle-o-notch fa-spin spin-icon" style="display:inline;float:left; vertical-align:text-bottom;" aria-hidden="true"></i>
           <div class="sections-loading-title col-md-5" style="display: inline;">Observations and solutions</div>
           <div class="sections-loading-title col-md-3" style="display: inline;">Running checks {{detectors.length-getPendingDetectorCount()}}/{{detectors.length}}</div>
         </div>
       </div>
-      <collapsible-list-fabric *ngIf="issueDetectedViewModels.length>0 && getPendingDetectorCount() === 0" [collapsed]="true" [title]="'Observations and solutions (' + issueDetectedViewModels.length + ')'">
+      <collapsible-list-fabric [iconProps]="observationSectionIcon" *ngIf="issueDetectedViewModels.length>0 && getPendingDetectorCount() === 0" [lessMargin]="true" [collapsed]="!(getPendingDetectorCount() === 0 && (!topLevelSolutions || topLevelSolutions.length==0) || showSolutionsTimedout)" [title]="'Observations and solutions (' + issueDetectedViewModels.length + ')'">
         <collapsible-list-item body *ngFor="let viewModel of issueDetectedViewModels;let i =index" style="display: block; width: 90%; margin: 5px 2.5%;">
           <div class="insight-box">
             <div style="display: block;">
@@ -123,14 +135,14 @@
           </div>
         </collapsible-list-item>
       </collapsible-list-fabric>
-      <div *ngIf="getPendingDetectorCount() > 0" style="margin-top: 24px;padding: 0px 10px;border-bottom: 1px solid #ccc;">
+      <div *ngIf="getPendingDetectorCount() > 0" style="margin-top: 5px;padding: 0px 10px;border-bottom: 1px solid #ccc;">
         <div style="display: inline;" class="row">
           <i class="fa fa-circle-o-notch fa-spin spin-icon" style="display:inline;float:left; vertical-align:text-bottom;" aria-hidden="true"></i>
           <div class="sections-loading-title col-md-5" style="display: inline;">Successful checks</div>
           <div class="sections-loading-title col-md-3" style="display: inline;">Running checks {{detectors.length-getPendingDetectorCount()}}/{{detectors.length}}</div>
         </div>
       </div>
-      <collapsible-list-fabric *ngIf="successfulViewModels.length>0 && getPendingDetectorCount() === 0" [collapsed]="true" [title]="'Successful Checks (' + successfulViewModels.length + ')'">
+      <collapsible-list-fabric [iconProps]="successfulSectionIcon" *ngIf="successfulViewModels.length>0 && getPendingDetectorCount() === 0" [collapsed]="true" [lessMargin]="true" [title]="'Successful Checks (' + successfulViewModels.length + ')'">
         <collapsible-list-item body *ngFor="let viewModel of successfulViewModels;let i =index" style="display: block; width: 90%; margin: 5px 2.5%;">
           <div class="insight-box">
             <div style="display: block;">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.scss
@@ -3,8 +3,8 @@
     cursor: pointer;
     padding: 10px;
     background-color: white;
-    margin: 10px 0px;
     overflow-wrap: break-word;
+    box-shadow: 0px 1.6px 3.6px rgba(0, 0, 0, 0.132), 0px 0.3px 0.9px rgba(0, 0, 0, 0.108);
 }
 
 .article > h5 {
@@ -36,6 +36,7 @@ br{
     background-color: white;
     margin: -4px 10px 0px 0px;
     overflow-wrap: break-word;
+    box-shadow: 0px 1.6px 3.6px rgba(0, 0, 0, 0.132), 0px 0.3px 0.9px rgba(0, 0, 0, 0.108);
 }
 
 .insight-detector-name {
@@ -67,14 +68,11 @@ br{
     background-color: white;
     margin: 10px 0px;
     overflow-wrap: break-word;
+    box-shadow: 0px 1.6px 3.6px rgba(0, 0, 0, 0.132), 0px 0.3px 0.9px rgba(0, 0, 0, 0.108);
  }
 
 .article-link {
     color:  #605e5c
-}
-
-.col-md-4-special{
-    width: 30.31%;
 }
 
 .solutions-small-card-outer{
@@ -83,18 +81,19 @@ br{
     margin: 10px 0px;
     white-space: nowrap;
     display: table;
+    box-shadow: 0px 1.6px 3.6px rgba(0, 0, 0, 0.132), 0px 0.3px 0.9px rgba(0, 0, 0, 0.108);
 }
 
 .solutions-small-card{
-    border: 1px solid #bbbbbb;
+    //border: 1px solid #bbbbbb;
     text-align: center;
     font-size: 18px;
     cursor: pointer;
     height: 100%;
+    vertical-align: middle;
+    margin: 0 10px;
     overflow: hidden;
     text-overflow: ellipsis;
-    display: table-cell;
-    vertical-align: middle;
 }
 
 .sections-loading-title{

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
@@ -98,31 +98,19 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
     mainSolutionIndex = 0;
 
     allSolutions: Solution[] = [];
+
+    timeoutToShowSolutions: number = 10000;
+    showSolutionsTimedout: boolean = false;
     
     startTime: Moment;
     endTime: Moment;
     isPublic: boolean;
 
-    numArticlesExpanded: number = 3;
-    viewRemainingArticles : boolean = false;
-
-    viewOrHideAnchorTagText(viewRemainingArticles: boolean , totalDocuments : number, numDocumentsExpanded : number)
-    {
-        let remainingDocuments: string = "";
-        if (totalDocuments && numDocumentsExpanded){
-        remainingDocuments = `${totalDocuments - numDocumentsExpanded}`;
-        remainingDocuments = viewRemainingArticles ?  `last ${remainingDocuments} ` : remainingDocuments
-        }
-        return !viewRemainingArticles ? `View ${remainingDocuments} more documents` : 
-            `Hide ${remainingDocuments} documents`;
-    }
-
-
-    showRemainingArticles()
-    {
-        this.viewRemainingArticles =!this.viewRemainingArticles
-        if(this.viewRemainingArticles)
-        {
+    /*numArticlesExpanded: number = 3;
+    articleSectionExpanded: boolean = false;
+    toggleArticleSection = () => {
+        this.articleSectionExpanded = !this.articleSectionExpanded;
+        if (this.articleSectionExpanded) {
             this.logEvent(TelemetryEventNames.MoreWebResultsClicked,
                 { 
                     searchId: this.searchId, 
@@ -130,6 +118,36 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
                     ts: Math.floor((new Date()).getTime() / 1000).toString() 
                 }
             );
+        }
+    };*/
+
+    documentationSectionIcon: any = {
+        iconName: "FileASPX",
+        styles: {
+            root: {
+                marginLeft: "11px",
+                fontSize: "16px"
+            }
+        }      
+    };
+    observationSectionIcon: any = {
+        iconName: "StatusErrorFull",
+        styles: {
+            root: {
+                color: "#A4262C",
+                marginLeft: "11px",
+                fontSize: "16px"
+            }
+        }
+    };
+    successfulSectionIcon: any = {
+        iconName: "SkypeCircleCheck",
+        styles: {
+            root: {
+                color: "#57A300",
+                marginLeft: "11px",
+                fontSize: "16px"
+            }
         }
     }
     
@@ -157,7 +175,8 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
 
     solutionButtonStyle = {
         root: {
-            marginTop: '10px',
+            //marginTop: '10px',
+            verticalAlign: "middle",
             height: '25px',
             fontSize: '13px',
             paddingBottom: '2px'
@@ -220,6 +239,7 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
     }
 
     clearInsights() {
+        this.showSolutionsTimedout = false;
         this.detectorViewModels = [];
         this.issueDetectedViewModels = [];
         this.successfulViewModels = [];
@@ -619,6 +639,11 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
         });
 
         // Log all the children detectors
+        setTimeout(() => {
+            if (this.getPendingDetectorCount()>0) {
+                this.showSolutionsTimedout = true;
+            }
+        }, this.timeoutToShowSolutions);
         observableForkJoin(requests).subscribe(childDetectorData => {
             setTimeout(() => {
                 let dataOutput = {};

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-view-container/solution-view-container.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-view-container/solution-view-container.component.scss
@@ -3,6 +3,7 @@
     border: 1px solid #C8C6C4;
     box-sizing: border-box;
     margin-top: 18px;
+    box-shadow: 0px 1.6px 3.6px rgba(0, 0, 0, 0.132), 0px 0.3px 0.9px rgba(0, 0, 0, 0.108);
 }
 
 .solution-container-title {


### PR DESCRIPTION
Changes:
1. Icons on various sections. Reduced spacing between sections.
2. Display web articles on top if no detector solutions found.
3. Expand Observations section by default when displaying articles on top.
4. Fixed the alignment issue in "Try these other options" section.
5. Timeout logic, if detectors do not return results after 10 seconds (configurable) then show article solutions on top.
6. Changing the wording of the top section from **"We think we found you a solution!"** to **"Try these potential solutions!"**

Enabling this experience **for only a couple of test subscription** (Antares-Demos and Khaled's private sub where most of our test apps exist) in one support topic Azure DevOps (for Sam's demo)

When detector solutions are found:
![image](https://user-images.githubusercontent.com/8492235/127788587-c78f70d4-2762-468d-b200-bba204990046.png)

When detector solutions are either not found or are delayed:
![image](https://user-images.githubusercontent.com/8492235/127788518-6b1a0b76-6983-4647-bf33-d9c6cdd63979.png)