### PR TITLE
Enable Worker App on AppLens

### DIFF
--- a/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
+++ b/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
@@ -40,6 +40,17 @@
         },
         {
             "service": "ResourceService",
+            "resourceType": "Microsoft.Web/workerApps",
+            "templateFileName": "WorkerApp",
+            "imgSrc": "assets/img/Azure-KubernetesService-Logo.png",
+            "versionPrefix": "",
+            "azureCommImpactedServicesList": "workerapp",
+            "pesId": "12345",
+            "staticSelfHelpContent": "microsoft.web",
+            "searchSuffix": "Azure Worker App"
+        },
+        {
+            "service": "ResourceService",
             "resourceType": "Microsoft.ContainerService/managedClusters",
             "templateFileName": "KubernetesService",
             "imgSrc": "assets/img/Azure-KubernetesService-Logo.png",


### PR DESCRIPTION
To start with, the entry point will be like ARM Resource (later we will build an appname kind of experience when there is more clarity on how worker apps are searched)
![image](https://user-images.githubusercontent.com/8492235/128645374-32761209-8658-47b5-9cfa-b458c9ca63ec.png)

Landing page and first sample detector:
![image](https://user-images.githubusercontent.com/8492235/128645464-bb049cd6-2f9a-4b80-ad1a-ec5b70681394.png)

This change is just to facilitate them to start developing detectors. Worker Apps is still a work in progress and we will add more features and icons (currently we are using the kubernetes icon for them).