### PR TITLE
Explicit cast exception for application insights API

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-appinsights-telemetry.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/portal-appinsights-telemetry.service.ts
@@ -101,7 +101,11 @@ export class PortalAppInsightsTelemetryService implements ITelemetryProvider {
 
     public logException(exception: Error, handledAt?: string, properties?: any, severityLevel?: SeverityLevel) {
         const mergedProperties = { handledAt: handledAt, ...properties };
-        const exceptionTelemetry = { exception, severityLevel, mergedProperties } as IExceptionTelemetry;
+        const exceptionTelemetry: IExceptionTelemetry = {
+            error: exception,
+            severityLevel: severityLevel,
+            properties: mergedProperties
+        };
 
         if (this.appInsights) {
             this.appInsights.trackException(exceptionTelemetry);


### PR DESCRIPTION
Sometimes there are exceptions thrown from application insights trackException API. This fix is to explicit cast the type in case there is any null value for Error type that is going to be logged.