### PR TITLE
Fixes bug in Functions network validation  where it runs despite Kudu being unavailable.

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
@@ -462,7 +462,7 @@ export async function checkDnsSettingV2Async(siteInfo, diagProvider, flowMgr, is
                 var dnsCheck = wordings.dnsCheckResult.get(dnsCheckResult, subChecks);
                 views = [dnsCheck, ...views];
             } else {
-                views.push(wordings.cannotCheckWithoutKudu.get());
+                views.push(wordings.cannotCheckWithoutKudu.get("DNS settings"));
             }
         }else{
             isContinue = true;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
@@ -31,6 +31,12 @@ export var functionsFlow = {
             dnsServers = [""]; //default Azure DNS
         }
 
+        if (!await isKuduAccessiblePromise)
+        {
+            flowMgr.addView(new VnetDnsWordings().cannotCheckWithoutKudu.get("Functions settings"));
+            return;
+        }
+
         /**
          * Functions specific checks
          **/

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
@@ -1,6 +1,7 @@
 import { DropdownStepView, InfoStepView, StepFlow, StepFlowManager, CheckStepView, StepViewContainer, InputStepView, ButtonStepView, PromiseCompletionSource, TelemetryService } from 'diagnostic-data';
 import { checkKuduAvailabilityAsync, checkVnetIntegrationV2Async, checkDnsSettingV2Async, checkAppSettingsAsync, extractHostPortFromConnectionString, extractHostPortFromKeyVaultReference } from './flowMisc.js';
 import { VnetIntegrationConfigChecker } from './vnetIntegrationConfigChecker.js';
+import { VnetDnsWordings } from './vnetDnsWordings.js';
 
 export var functionsFlow = {
     title: "Connectivity issues",

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/vnetDnsWordings.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/vnetDnsWordings.js
@@ -109,9 +109,9 @@ export class VnetDnsWordings {
         }
 
         this.cannotCheckWithoutKudu = {
-            get(){
+            get(what){
                 return new CheckStepView({
-                    title: "Cannot validate DNS settings without kudu access",
+                    title: `Cannot validate ${what} without kudu access`,
                     level: 3
                 });
             }


### PR DESCRIPTION
UX after the bug fix:

![image](https://user-images.githubusercontent.com/22335857/130590087-5c2c0193-70d9-465d-8190-ea9e34a105a4.png)
