### PR TITLE
Worker Apps in AppLens

### DIFF
--- a/AngularApp/projects/applens/src/app/app.module.ts
+++ b/AngularApp/projects/applens/src/app/app.module.ts
@@ -68,6 +68,10 @@ export const Routes = RouterModule.forRoot([
             loadChildren: './modules/site/site.module#SiteModule'
           },
           {
+            path: 'workerapps/:workerapp',
+            loadChildren: './modules/workerapp/workerapp.module#WorkerAppModule'
+          },
+          {
             path: 'icm/:incidentId',
             loadChildren: './modules/incidentassist/incidentassist.module#IncidentAssistModule'
           },

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -111,13 +111,13 @@ export class DashboardComponent implements OnDestroy {
       if (resource) {
         this.resource = resource;
 
-        if (serviceInputs.resourceType.toString() === 'Microsoft.Web/hostingEnvironments' && this.resource && this.resource.Name)
+        if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/hostingenvironments' && this.resource && this.resource.Name)
         {
             this.observerLink = "https://wawsobserver.azurewebsites.windows.net/MiniEnvironments/"+ this.resource.Name;
             this._diagnosticApiService.GeomasterServiceAddress = this.resource["GeomasterServiceAddress"];
             this._diagnosticApiService.GeomasterName = this.resource["GeomasterName"];
         }
-        else if (serviceInputs.resourceType.toString() === 'Microsoft.Web/sites')
+        else if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/sites')
         {
             this._diagnosticApiService.GeomasterServiceAddress = this.resource["GeomasterServiceAddress"];
             this._diagnosticApiService.GeomasterName = this.resource["GeomasterName"];
@@ -128,7 +128,7 @@ export class DashboardComponent implements OnDestroy {
                 this.resourceService.imgSrc = this.resourceService.altIcons['Xenon'];
             }
         }
-        else if (serviceInputs.resourceType.toString() === 'Microsoft.Web/workerApps')
+        else if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/workerapps')
         {
           this._diagnosticApiService.GeomasterServiceAddress = this.resource.ServiceAddress;
           this._diagnosticApiService.GeomasterName = this.resource.GeoMasterName;

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -128,6 +128,12 @@ export class DashboardComponent implements OnDestroy {
                 this.resourceService.imgSrc = this.resourceService.altIcons['Xenon'];
             }
         }
+        else if (serviceInputs.resourceType.toString() === 'Microsoft.Web/workerApps')
+        {
+          this._diagnosticApiService.GeomasterServiceAddress = this.resource.ServiceAddress;
+          this._diagnosticApiService.GeomasterName = this.resource.GeoMasterName;
+          this.observerLink = "https://wawsobserver.azurewebsites.windows.net/partner/workerapp/" + this.resource.WorkerAppName;
+        }
 
         this.keys = Object.keys(this.resource);
       }

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -61,6 +61,14 @@ export class MainComponent implements OnInit {
       displayName: 'Azure Virutal Machine',
       enabled: true,
       caseId: false
+    },
+    {
+      resourceType: ResourceType.WorkerApp,
+      resourceTypeLabel: 'Worker App Name',
+      routeName: (name) => `workerapps/${name}`,
+      displayName: 'Worker App',
+      enabled: true,
+      caseId: false
     }
   ];
 

--- a/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.html
@@ -1,0 +1,24 @@
+<div class="container-fluid main-container">
+  <div class="big-text" *ngIf="loading">Searching for workerapp ...</div>
+  <div class="big-text" *ngIf="!loading && error">{{error}}</div>
+  <div class="big-text" *ngIf="!loading && !error && matchingSites.length == 1">Redirecting to {{siteName}}</div>
+  <div *ngIf="!loading && !error && matchingSites.length > 0">
+    <div class="multiple-sites">
+      <div>
+        <h3>Multiple worker apps with the name '{{matchingSites[0].SiteName}}' found. Pick the correct one:</h3>
+      </div>
+      <div class="matching-site" *ngFor="let site of matchingSites">
+        <div class="panel main-panel">
+          <div class="panel-body">
+            <h5 class="panel-title">{{site.WorkerAppName}}
+            </h5>
+            <p class="panel-text">{{site.SubscriptionName}}</p>
+            <p class="panel-text">{{site.ResourceGroupName}}</p>
+            <p class="panel-text">{{site.KubeEnvironmentName}}</p>
+            <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.scss
@@ -1,0 +1,25 @@
+.main-container {
+    background-color: #e4e4e4;
+}
+
+.multiple-sites {
+    width: 100%;
+    height: 100%;
+    padding: 50px;
+}
+
+.matching-site {
+    margin: 5px;
+    float: left;
+}
+
+.main-panel {
+    width: 40rem;
+}
+
+.big-text {
+    padding: 100px;
+    font-size: 30px;
+    height: 100%;
+}
+

--- a/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.spec.ts
+++ b/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WorkerAppFinderComponent } from './workerapp-finder.component';
+
+describe('WorkerAppFinderComponent', () => {
+  let component: WorkerAppFinderComponent;
+  let fixture: ComponentFixture<WorkerAppFinderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ WorkerAppFinderComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WorkerAppFinderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/workerapp/workerapp-finder/workerapp-finder.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ObserverService } from '../../../shared/services/observer.service';
+import { StartupService } from '../../../shared/services/startup.service';
+
+@Component({
+  selector: 'workerapp-finder',
+  templateUrl: './workerapp-finder.component.html',
+  styleUrls: ['./workerapp-finder.component.scss']
+})
+export class WorkerAppFinderComponent implements OnInit {
+
+  siteName: string;
+  loading: boolean = true;
+  error: string;
+
+  matchingSites: Observer.ObserverWorkerAppInfo[] = [];
+
+  contentHeight: string;
+
+  constructor(private _route: ActivatedRoute, private _router: Router, private _observerService: ObserverService, private _startupService: StartupService) {
+    this.contentHeight = window.innerHeight + 'px';
+  }
+
+  ngOnInit() {
+    this.siteName = this._route.snapshot.params['workerapp'];
+
+    this._observerService.getWorkerApp(this.siteName).subscribe(observerWorkerAppResponse => {
+      if (observerWorkerAppResponse.details.toString() == "Unable to fetch data from Observer API : GetWorkerApp"){
+        this.error = `There was an error trying to find worker app ${this.siteName}`;
+        this.loading = false;  
+      }
+      else if (observerWorkerAppResponse.details.length === 1) {
+        let matchingSite = observerWorkerAppResponse.details[0];
+        this.navigateToSite(matchingSite);
+      }
+      else if (observerWorkerAppResponse.details.length > 1) {
+        this.matchingSites = observerWorkerAppResponse.details;
+      }
+
+      this.loading = false;
+    }, (error: Response) => {
+      this.error = error.status == 404 ? `Worker App with the name ${this.siteName} was not found` : `There was an error trying to find worker app ${this.siteName}`;
+      this.loading = false;
+    });
+  }
+
+  navigateToSite(matchingSite: Observer.ObserverWorkerAppInfo) {
+    let resourceArray: string[] = [
+      'subscriptions', matchingSite.SubscriptionName,
+      'resourceGroups', matchingSite.ResourceGroupName,
+      'providers', 'Microsoft.Web',
+      'workerApps', matchingSite.WorkerAppName];
+
+    resourceArray.push('home');
+    resourceArray.push('category');
+
+    this._router.navigate(resourceArray, { queryParamsHandling: 'preserve' });
+  }
+
+}

--- a/AngularApp/projects/applens/src/app/modules/workerapp/workerapp.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/workerapp/workerapp.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModuleWithProviders } from '@angular/compiler/src/core';
+import { RouterModule } from '@angular/router';
+import { WorkerAppFinderComponent } from './workerapp-finder/workerapp-finder.component';
+import { SharedModule } from '../../shared/shared.module';
+
+export const WorkerAppModuleRoutes : ModuleWithProviders = RouterModule.forChild([
+  {
+    path: '',
+    component: WorkerAppFinderComponent
+  }
+]);
+
+@NgModule({
+  imports: [
+    CommonModule,
+    WorkerAppModuleRoutes,
+    SharedModule
+  ],
+  declarations: [WorkerAppFinderComponent]
+})
+export class WorkerAppModule { }

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -3,6 +3,11 @@ namespace Observer {
         siteName: string;
         details: ObserverSiteInfo[];
     }
+
+    export interface ObserverWorkerAppResponse {
+        workerAppName: string;
+        details: ObserverWorkerAppInfo[];
+    }
   
     export interface ObserverSiteInfo {
         SiteName: string;
@@ -19,6 +24,17 @@ namespace Observer {
         VnetName: string;
         LinuxFxVersion: string;
         WindowsFxVersion: string;
+    }
+
+    export interface ObserverWorkerAppInfo {
+        WorkerAppName: string;
+        Tags: string;
+        ResourceGroupName: string;
+        SubscriptionName: string;
+        KubeEnvironmentName: string;
+        GeoMasterName: string;
+        ServiceAddress: string;
+        Kind: string;
     }
 
     export interface ObserverSiteDetailsResponse {

--- a/AngularApp/projects/applens/src/app/shared/models/resources.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/resources.ts
@@ -4,7 +4,8 @@ import { InjectionToken } from '@angular/core';
 export enum ResourceType {
     Site,
     Function,
-    AppServiceEnvironment
+    AppServiceEnvironment,
+    WorkerApp
 }
 
 export interface ResourceTypeState {

--- a/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
+++ b/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
@@ -1,5 +1,6 @@
 import { StartupService } from "../services/startup.service";
 import { SiteService } from "../services/site.service";
+import { WorkerAppService } from "../services/workerapp.service";
 import { AseService } from "../services/ase.service";
 import { ResourceService } from "../services/resource.service";
 import { ObserverService } from "../services/observer.service";
@@ -17,6 +18,9 @@ export let ResourceServiceFactory = (startupService: StartupService, observerSer
             break;
         case 'Microsoft.Web/sites':
             service = new SiteService(serviceInputs, observerService);
+            break;
+        case 'Microsoft.Web/workerApps':
+            service = new WorkerAppService(serviceInputs, observerService);
             break;
         default:
             service = new ResourceService(serviceInputs);

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -23,6 +23,17 @@ export class ObserverService {
       }));
   }
 
+  public getWorkerApp(workerAppName: string): Observable<Observer.ObserverWorkerAppResponse> {
+    return this._diagnosticApiService.get<Observer.ObserverWorkerAppResponse>(`api/workerapps/${workerAppName}`).pipe(
+      map((workerAppRes: Observer.ObserverWorkerAppResponse) => {
+        if (workerAppRes && workerAppRes.details && isArray(workerAppRes.details)) {
+          workerAppRes.details.map(info => info);
+        }
+
+        return workerAppRes;
+      }));
+  }
+
   public getAse(ase: string): Observable<Observer.ObserverAseResponse> {
     return this._diagnosticApiService.get<Observer.ObserverAseResponse>(`api/hostingEnvironments/${ase}`);
   }

--- a/AngularApp/projects/applens/src/app/shared/services/workerapp.service.spec.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/workerapp.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { WorkerAppService } from './workerapp.service';
+
+describe('WorkerAppService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [WorkerAppService]
+    });
+  });
+
+  it('should be created', inject([WorkerAppService], (service: WorkerAppService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/AngularApp/projects/applens/src/app/shared/services/workerapp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/workerapp.service.ts
@@ -1,0 +1,38 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map, mergeMap } from 'rxjs/operators';
+import { Inject, Injectable } from '@angular/core';
+import { RESOURCE_SERVICE_INPUTS, ResourceServiceInputs } from '../models/resources';
+import { ObserverService } from './observer.service';
+import { ResourceService } from './resource.service';
+import { HttpResponse } from '@angular/common/http';
+
+@Injectable()
+export class WorkerAppService extends ResourceService {
+
+  private _currentResource: BehaviorSubject<Observer.ObserverWorkerAppInfo> = new BehaviorSubject(null);
+
+  private _workerAppObject: Observer.ObserverWorkerAppInfo;
+
+  constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
+    super(inputs);
+  }
+
+  public startInitializationObservable() {
+    this._initialized = this._observerApiService.getWorkerApp(this._armResource.resourceName)
+      .pipe(map((observerResponse: Observer.ObserverWorkerAppResponse) => {
+        this._observerResource = this._workerAppObject = this.getWorkerAppFromObserverResponse(observerResponse);
+        this._currentResource.next(this._workerAppObject);
+        return true;
+      }))
+  }
+
+    public getCurrentResource(): Observable<any> {
+        return this._currentResource;
+    }
+
+    private getWorkerAppFromObserverResponse(observerResponse: Observer.ObserverWorkerAppResponse): Observer.ObserverWorkerAppInfo {
+        return observerResponse.details.find(workerapp =>
+            workerapp.SubscriptionName.toLowerCase() === this._armResource.subscriptionId.toLowerCase() &&
+            workerapp.ResourceGroupName.toLowerCase() === this._armResource.resourceGroup.toLowerCase())
+    }
+}

--- a/AngularApp/projects/applens/src/app/shared/shared.module.ts
+++ b/AngularApp/projects/applens/src/app/shared/shared.module.ts
@@ -5,6 +5,7 @@ import { DiagnosticApiService } from './services/diagnostic-api.service';
 import { ModuleWithProviders } from '@angular/compiler/src/core';
 import { HttpClientModule } from '@angular/common/http';
 import { SiteService } from './services/site.service';
+import { WorkerAppService } from "./services/workerapp.service";
 import { FormsModule } from '@angular/forms';
 import { StartupService } from './services/startup.service';
 import { ObserverService } from './services/observer.service';
@@ -35,6 +36,7 @@ export class SharedModule {
         DiagnosticApiService,
         ResourceService,
         SiteService,
+        WorkerAppService,
         AseService,
         StartupService,
         ObserverService,

--- a/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
+++ b/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
@@ -39,7 +39,7 @@
             "searchSuffix": "Azure Logic App"
         },
         {
-            "service": "ResourceService",
+            "service": "WorkerAppService",
             "resourceType": "Microsoft.Web/workerApps",
             "templateFileName": "WorkerApp",
             "imgSrc": "assets/img/Azure-KubernetesService-Logo.png",

--- a/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
+++ b/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
@@ -42,7 +42,7 @@
             "service": "WorkerAppService",
             "resourceType": "Microsoft.Web/workerApps",
             "templateFileName": "WorkerApp",
-            "imgSrc": "assets/img/Azure-KubernetesService-Logo.png",
+            "imgSrc": "assets/img/Azure-Ase-Logo.png",
             "versionPrefix": "",
             "azureCommImpactedServicesList": "workerapp",
             "pesId": "12345",

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -10,7 +10,8 @@ namespace AppLensV3
     {
         IObserverClientService _observerService;
 
-        public ResourceController(IObserverClientService observerService) {
+        public ResourceController(IObserverClientService observerService)
+        {
             _observerService = observerService;
         }
 
@@ -19,6 +20,13 @@ namespace AppLensV3
         public async Task<IActionResult> GetSite(string siteName)
         {
             return await GetSiteInternal(null, siteName);
+        }
+
+        [HttpGet("api/workerapps/{workerAppName}")]
+        [HttpOptions("api/workerapps/{workerAppName}")]
+        public async Task<IActionResult> GetWorkerApp(string workerAppName)
+        {
+            return await GetWorkerAppInternal(workerAppName);
         }
 
         [HttpGet]
@@ -81,6 +89,25 @@ namespace AppLensV3
             };
 
             if (siteDetailsResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                return NotFound(response);
+            }
+
+            return Ok(response);
+        }
+
+        private async Task<IActionResult> GetWorkerAppInternal(string workerAppName)
+        {
+            var workerAppsTask = _observerService.GetWorkerApp(workerAppName);
+            var workerAppsResponse = await workerAppsTask;
+
+            var response = new
+            {
+                WorkerAppName = workerAppName,
+                Details = workerAppsResponse.Content
+            };
+
+            if (workerAppsResponse.StatusCode == HttpStatusCode.NotFound)
             {
                 return NotFound(response);
             }

--- a/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
@@ -54,6 +54,11 @@ namespace AppLensV3
             return GetSiteInternal(null, siteName);
         }
 
+        public async Task<ObserverResponse> GetWorkerApp(string workerAppName)
+        {
+            return await GetWorkerAppInternal(workerAppName);
+        }
+
         public Task<ObserverResponse> GetSite(string stamp, string siteName, bool details = false)
         {
             return GetSiteInternal(stamp, siteName);
@@ -68,6 +73,19 @@ namespace AppLensV3
             return new ObserverResponse
             {
                 StatusCode = siteDetailsResponse.StatusCode,
+                Content = content
+            };
+        }
+
+        private async Task<ObserverResponse> GetWorkerAppInternal(string workerAppName)
+        {
+            var path = $"partner/workerapp/{workerAppName}";
+            var workerAppDetailsResponse = await ExecuteDiagCall(path);
+            var contentJson = await workerAppDetailsResponse.Content.ReadAsStringAsync();
+            var content = JsonConvert.DeserializeObject(contentJson);
+            return new ObserverResponse
+            {
+                StatusCode = workerAppDetailsResponse.StatusCode,
                 Content = content
             };
         }

--- a/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
@@ -6,6 +6,8 @@ namespace AppLensV3
     {
         Task<ObserverResponse> GetSite(string siteName);
 
+        Task<ObserverResponse> GetWorkerApp(string workerAppName);
+
         Task<ObserverResponse> GetSite(string stamp, string siteName, bool details = false);
 
         Task<ObserverResponse> GetResourceGroup(string site);

--- a/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
@@ -21,7 +21,7 @@ namespace AppLensV3
     /// <summary>
     /// Client for Support Observer API communication
     /// </summary>
-    public sealed class SupportObserverClientService: IObserverClientService
+    public sealed class SupportObserverClientService : IObserverClientService
     {
         private static AuthenticationContext _authContext;
         private static ClientCredential _aadCredentials;
@@ -37,14 +37,16 @@ namespace AppLensV3
 
         private IConfiguration _configuration;
 
-        public SupportObserverClientService(IConfiguration configuration) {
+        public SupportObserverClientService(IConfiguration configuration)
+        {
             _configuration = configuration;
         }
 
         /// <summary>
         /// Support API Endpoint
         /// </summary>
-        private string SupportObserverApiEndpoint {
+        private string SupportObserverApiEndpoint
+        {
             get
             {
                 if (string.IsNullOrWhiteSpace(_endpoint))
@@ -119,6 +121,15 @@ namespace AppLensV3
         }
 
         /// <summary>
+        /// Get worker app details for workerAppName
+        /// </summary>
+        /// <param name="workerAppName">Worker App Name</param>
+        public async Task<ObserverResponse> GetWorkerApp(string workerAppName)
+        {
+            return await GetWorkerAppInternal(SupportObserverApiEndpoint + "partner/workerapp/" + workerAppName);
+        }
+
+        /// <summary>
         /// Get site details for siteName
         /// </summary>
         /// <param name="stamp">Stamp</param>
@@ -136,11 +147,26 @@ namespace AppLensV3
                 RequestUri = new Uri(endpoint),
                 Method = HttpMethod.Get
             };
-            
+
             request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
             var response = await _httpClient.SendAsync(request);
 
             ObserverResponse res = await CreateObserverResponse(response, "GetAdminSite");
+            return res;
+        }
+
+        private async Task<ObserverResponse> GetWorkerAppInternal(string endpoint)
+        {
+            var request = new HttpRequestMessage()
+            {
+                RequestUri = new Uri(endpoint),
+                Method = HttpMethod.Get
+            };
+
+            request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
+            var response = await _httpClient.SendAsync(request);
+
+            ObserverResponse res = await CreateObserverResponse(response, "GetWorkerApp");
             return res;
         }
 
@@ -156,7 +182,7 @@ namespace AppLensV3
                 RequestUri = new Uri(SupportObserverApiEndpoint + "sites/" + site + "/resourcegroupname"),
                 Method = HttpMethod.Get
             };
-          
+
             var serializedParameters = JsonConvert.SerializeObject(new Dictionary<string, string>() { { "site", site } });
             request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
             var response = await _httpClient.SendAsync(request);
@@ -249,7 +275,7 @@ namespace AppLensV3
                 var responseString = await response.Content.ReadAsStringAsync();
                 observerResponse.Content = JsonConvert.DeserializeObject(responseString);
             }
-            else if(response.StatusCode == HttpStatusCode.NotFound)
+            else if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 observerResponse.Content = "Resource Not Found. API : " + apiName;
             }


### PR DESCRIPTION
This PR achieves three things:
**1. Observer integration in AppLens for Worker Apps.
2. Passing Geomaster information to diagnostics backend for Geomaster data provider for worker apps.
3. Worker apps search experience on the AppLens main landing page**

**Landing Page Experience**

User selects Worker App from dropdown
![image](https://user-images.githubusercontent.com/8492235/132420708-7892848a-4ba6-45ab-aca3-7c9cb3056696.png)

User Enters Worker App name and clicks Go
![image](https://user-images.githubusercontent.com/8492235/132420731-b142a6a6-bc4d-4e85-a679-36757e4315cd.png)

Detector view with data confirmation of Geomaster data and observer data:
![image](https://user-images.githubusercontent.com/8492235/132426384-c3a6e1c2-8816-46ea-9ab8-2df1b5d4a541.png)
