### PR TITLE
Create deep link to detector page with category side nav

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/portal-referrer-resolver/portal-referrer-resolver.component.ts
@@ -52,6 +52,12 @@ export class PortalReferrerResolverComponent implements OnInit {
     let startTimeStr = "";
     let endTimeStr = "";
     let queryParamsJson:{} = { "redirectFrom": "referrer" };
+
+    if (!!referrer.CategoryId) {
+        let categoryId = referrer.CategoryId;
+        path += `/categories/${categoryId}`;
+    }
+
     if (referrer.StartTime && referrer.EndTime)
     {
         startTimeStr = referrer.StartTime;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal-referrer-map.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/portal-referrer-map.ts
@@ -12,6 +12,7 @@ export interface PortalReferrerInfo {
     ExtensionName: string,
     BladeName: string,
     TabName: string,
+    CategoryId?: string,
     DetectorType?: DetectorType,
     DetectorId?: string,
     StartTime?: string,


### PR DESCRIPTION
As per load balancing team, they want to deep link a detector view with the category side nav info. This PR is to address the requirement.