### PR TITLE
Accessibilty and service health bugs

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-startup-time/autohealing-startup-time.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-startup-time/autohealing-startup-time.component.html
@@ -1,9 +1,12 @@
 <div *ngIf="!editMode">
-  Override the minimum time the process must execute before excecuting the auto-healing action. This is useful in
-  scenarios where
-  the app has high startup time and you don't want the mitigation action to kick in during app startup.
+  <label for="modifyStartupTime">
+    Override the minimum time the process must execute before executing the auto-healing action. This is useful in
+    scenarios where
+    the app has high startup time and you don't want the mitigation action to kick in during app startup.
+  </label>
   <div class="rule-button">
-    <button type="button" class="btn btn-primary btn-sm" (click)="configureMinProcessExecutionTime()">
+    <button id="modifyStartupTime" type="button" class="btn btn-primary btn-sm"
+      (click)="configureMinProcessExecutionTime()">
       Modify Startup time
     </button>
   </div>
@@ -12,7 +15,7 @@
 <div class="form-group" *ngIf="editMode">
   <div class="row">
     <div class="col-sm-6">
-      <label for="minProcessExecutionTime">Specify the time (in seconds) after process startup after which autohealing
+      <label for="minProcessExecutionTime">Specify the time (in seconds) after process startup after which auto-heal
         should kick in ?</label>
     </div>
     <div class="col-sm-4">

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -120,7 +120,8 @@
 
           <div class="header2">3. Override when Action executes (Optional)</div>
           <div class="autohealtile-content">
-            <div class="autohealtile" tabindex="0" [class.activeAction]="minProcessExecutionTime > 0" role="button"
+            <div class="autohealtile" tabindex="0" [class.activeAction]="minProcessExecutionTime > 0" role="radio"
+              [attr.aria-checked]="minProcessExecutionTime > 0"
               (click)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded"
               (keyup.space)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded"
               (keyup.enter)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded">

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/collapsible-menu-item/collapsible-menu-item.component.html
@@ -5,7 +5,7 @@
         <div tabindex="0" role="button" (keyup.enter)="handleClick()" [attr.aria-label]="menuItem.label" type="button">
             <i class="fa expand-icon" *ngIf=" menuItem.subItems && menuItem.subItems.length > 0"
                 [class.fa-caret-right]="!menuItem.expanded" [class.fa-caret-down]="menuItem.expanded"></i>
-            <img class="category-icon" [src]="menuItem.icon" />
+            <img class="category-icon" role="presentation" [src]="menuItem.icon" />
             <span class="menu-label" style="font-size: 13px!important;"
                 [innerHtml]="menuItem.label | searchmatch:searchValueLocal"></span>
         </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-v2/daas-v2.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-v2/daas-v2.component.ts
@@ -147,7 +147,7 @@ export class DaasV2Component implements OnInit, OnDestroy {
       .subscribe(activeSession => {
         this.operationInProgress = false;
         this.operationStatus = '';
-        if (activeSession) {
+        if (activeSession && activeSession.Tool === this.diagnoserName) {
           this.sessionInProgress = true;
           this.initWizard();
           this.updateInstanceInformationOnLoad();
@@ -163,7 +163,7 @@ export class DaasV2Component implements OnInit, OnDestroy {
   pollRunningSession(sessionId: string) {
     this._daasService.getSession(this.siteToBeDiagnosed, sessionId)
       .subscribe(activeSession => {
-        if (activeSession != null) {
+        if (activeSession != null && activeSession.Tool === this.diagnoserName) {
           this.populateSessionInformation(activeSession);
 
           if (activeSession.Status != "Active") {
@@ -200,20 +200,23 @@ export class DaasV2Component implements OnInit, OnDestroy {
 
     if (activeInstance.Status == "Started") {
       this.sessionStatus = 2;
-      let messageCount = activeInstance.CollectorStatusMessages.length;
-      if (messageCount > 0) {
-        this.WizardStepStatus = activeInstance.CollectorStatusMessages[messageCount - 1];
-      } else {
-        this.WizardStepStatus = "";
+      if (Array.isArray(activeInstance.CollectorStatusMessages)) {
+        let messageCount = activeInstance.CollectorStatusMessages.length;
+        if (messageCount > 0) {
+          this.WizardStepStatus = activeInstance.CollectorStatusMessages[messageCount - 1];
+        } else {
+          this.WizardStepStatus = "";
+        }
       }
     } else if (activeInstance.Status == "Analyzing") {
       this.sessionStatus = 3;
-      this.activeInstance = activeInstance;
-      let messageCount = activeInstance.AnalyzerStatusMessages.length;
-      if (messageCount > 0) {
-        this.WizardStepStatus = activeInstance.CollectorStatusMessages[messageCount - 1];
-      } else {
-        this.WizardStepStatus = "";
+      if (Array.isArray(activeInstance.AnalyzerStatusMessages)) {
+        let messageCount = activeInstance.AnalyzerStatusMessages.length;
+        if (messageCount > 0) {
+          this.WizardStepStatus = activeInstance.CollectorStatusMessages[messageCount - 1];
+        } else {
+          this.WizardStepStatus = "";
+        }
       }
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler.component.ts
@@ -33,7 +33,7 @@ export class ProfilerComponent extends DaasComponent implements OnInit, OnDestro
 
         super(_serverFarmServiceLocal, _siteServiceLocal, _daasServiceLocal, _windowServiceLocal, _loggerLocal);
         this.diagnoserName = 'CLR Profiler';
-        this.diagnoserNameLookup = 'Profiler';
+        this.diagnoserNameLookup = 'CLR Profiler';
     }
 
     ngOnInit(): void {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/card-selection-v4/card-selection-v4.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/card-selection-v4/card-selection-v4.component.html
@@ -2,7 +2,7 @@
   <div *ngFor="let card of cardSelections" class="card-tile">
     <div (click)="selectCard(card)" tabindex="0" (keyup.enter)="selectCard(card)" role="button" class="card-tile-container">
       <div *ngIf="isPublic">
-        <img class="card-tile-image" [src]="getImagePath(card.linkValue)">
+        <img class="card-tile-image" role="presentation" [src]="getImagePath(card.linkValue)">
       </div>
       <div>
         <h3 class="card-tile-title">{{card.title}}</h3>


### PR DESCRIPTION
Fixes for these and some DAAS UI bugs.

<html>
<body>
<!--StartFragment-->

ID | Title | State | Area Path | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
12480713 | [Screen reader - App Service - Startup Time]: Screen reader is not announcing the state that “Start time up” button is selected or not selected. | Approved | Antares\ANTUX | A11YMAS; A11ySev2; Accessibility; Benchmark; Benchmark-HCL-AppServiceWebApp-OCT2021; Diagnose and Solve Problems; HCL; MAS4.1.2; Win10-Firefox | 0 | 11/15/2021, 9:33:15 PM
12481736 | [Programmatic Access - App Service - Diagnostic tools]: Ensures <img> elements have alternate text or a role of none or presentation (.card-tile-image) | Approved | Antares\ANTUX | A11yAuto; A11YMAS; A11ySev2; Accessibility; Benchmark; Benchmark-HCL-AppServiceWebApp-OCT2021; Diagnose and Solve Problems; HCL; K4W; MAS1.1.1; Win10-Firefox | 0 | 11/15/2021, 9:25:00 PM

<!--EndFragment-->
</body>
</html>


<html>
<body>
<!--StartFragment-->

ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
2079 | TypeError: Cannot read properties of undefined (reading 'length') | app-service-diagnostics-portal\2101-1 | New | Service Health | 1 | 11/10/2021, 11:27:40 PM

<!--EndFragment-->
</body>
</html>
