### PR TITLE
Remove logging, Disable A/B testing banner, Change time-picker logic

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-time-picker/detector-time-picker.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-time-picker/detector-time-picker.component.ts
@@ -19,7 +19,7 @@ export class DetectorTimePickerComponent implements OnInit {
 
   today: Date = new Date(Date.now());
   maxDate: Date = this.convertUTCToLocalDate(this.today);
-  minDate: Date = this.convertUTCToLocalDate(addMonths(this.today, -1));
+  minDate: Date = this.convertUTCToLocalDate(addDays(this.today, -30));
 
   set time(value: string) {
     this.updateTimerMessage.next(value);
@@ -168,6 +168,7 @@ export class DetectorTimePickerComponent implements OnInit {
         endDate: infoEndDate
       };
     } else {
+      this.today = new Date();
       const localEndTime = this.today;
       const localStartTime = new Date(localEndTime.getTime() - this.hourDiff * 60 * 60 * 1000);
       startDateWithTime = this.convertLocalDateToUTC(localStartTime);

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/abtesting.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/abtesting.service.ts
@@ -8,7 +8,7 @@ import { Location } from "@angular/common";
 
 @Injectable()
 export class ABTestingService {
-    enableABTesting: boolean = true;
+    enableABTesting: boolean = false;
     slot: SlotType;
     resourceUri: string = "";
     isPreview: boolean = false;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
@@ -84,8 +84,6 @@ export class LoaderDetectorViewComponent implements OnInit {
 
     ngAfterViewInit() {
         this.startLoadingTimeInMilliSeconds = Date.now();
-        let startLoadingTimeISOString = new Date().toISOString();
-        this.telemetryService.logEvent(TelemetryEventNames.LoadingDetectorViewStarted, { "TrackingEventId": this.trackingEventId, "StartLoadingTime": startLoadingTimeISOString });
     }
 }
 


### PR DESCRIPTION
This PR is for,
1) Remove logging for throttling issue [WI 2072](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2072)

2) Change min date in time-picker to last 30 days instead of last 1 month [WI 2081](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2081)

3) Disable A/B testing banner since traffic to preview slot is 100% now