### PR TITLE
Enable Sessions button for Linux .NET Core apps

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -191,7 +191,7 @@
         <button type="button" class="btn btn-sm btn-primary" [disabled]="!saveEnabled"
           (click)="saveChanges()">Save</button>
         <button type="button" class="btn btn-sm btn-primary" [disabled]="!saveEnabled" (click)="reset()">Cancel</button>
-        <button *ngIf="isWindowsApp" type="button" class="btn btn-sm btn-primary" (click)="toggleSessionPanel()">View
+        <button *ngIf="isWindowsApp || isLinuxDotNetApp" type="button" class="btn btn-sm btn-primary" (click)="toggleSessionPanel()">View
           All Sessions</button>
         <div *ngIf="savingAutohealSettings" class="inline ml-3">
           <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.ts
@@ -54,6 +54,12 @@ export class AutohealingComponent implements OnInit {
     this.isWindowsApp = this._webSiteService.platform === OperatingSystem.windows;
     this.isLinuxDotNetApp = this._webSiteService.platform === OperatingSystem.linux
       && this._webSiteService.linuxFxVersion.startsWith("DOTNETCORE");
+
+    //
+    // Disable AutoHeal temporarily because Cloud Services in ANT96 are still pointing to old KuduLite bits
+    // Will remove this check after ANT 96.1 is deployed (Rough ETA is first week of Jan)
+    //
+      this.isLinuxDotNetApp = false;
   }
 
   ngOnInit() {


### PR DESCRIPTION
Cloud Services in ANT96 are still pointing to old KuduLite bits. I will remove this check after ANT 96.1 is deployed (Rough ETA is first week of Jan)