### PR TITLE
Disable /daas/sessions call if we get 'no route registered'

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -146,6 +146,10 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
             sessions.push(this.getSessionMasterFromV2(session));
           });
         }
+        // Temporary check to avoid 404s coming from /daas/sessions path
+        else if (typeof results[1] === 'string' && results[1].toLowerCase().indexOf("no route registered") > -1) {
+          this.subscription.unsubscribe();
+        }
 
         if (this.isArrayWithItems(sessionsV1)) {
           sessionsV1.forEach(session => {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
2144 | Portal kusto exceptions: dass/sessions route note registered: | app-service-diagnostics-portal\2101-1 | New | Service Health | 0 | 12/8/2021, 11:53:03 PM

<!--EndFragment-->
</body>
</html>