### PR TITLE
Change 'App:' to 'Name:' to generalize solutions 

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution/solution.component.html
@@ -51,7 +51,7 @@
 
 <ng-template #dont_confirm_buttons>
   <div class="action-buttons">
-    <span class="mr-3">App: <span class="app-name">{{appName}}</span></span>
+    <span class="mr-3">Name: <span class="app-name">{{appName}}</span></span>
     <button (click)="performAction()" type="button" class="custom-button">{{solution.Title}}</button>
   </div>
 </ng-template>


### PR DESCRIPTION
Currently for ASE solutions also, we show "App:" which is incorrect

![image](https://user-images.githubusercontent.com/5299838/145572448-83570a52-4ec4-498f-b5b5-9b4ab5f3aede.png)
