### PR TITLE
Fix loading issue on safari

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/step-views/step-view-lib.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/step-views/step-view-lib.ts
@@ -148,7 +148,14 @@ function markdownPreprocess(markdown: string, id: string): string {
         return null;
     }
     // parse markdown links to html <a> tag
-    var result = markdown.replace(/(?<!\!)\[(.*?)]\((.*?)( +\"(.*?)\")?\)/g, `<a target="_blank" href="$2" title="$4" onclick="networkCheckLinkClickEventLogger('${id}','$2', '$1')">$1</a>`);
+    var result = markdown;
+    try {
+        const regex = new RegExp("(?<!\!)\[(.*?)]\((.*?)( +\"(.*?)\")?\)", "g");
+        result = markdown.replace(regex, `<a target="_blank" href="$2" title="$4" onclick="networkCheckLinkClickEventLogger('${id}','$2', '$1')">$1</a>`);
+    }
+    catch (e) {
+        result = markdown;
+    }
     return result;
 }
 


### PR DESCRIPTION
Safari doesn't support regex lookbehind, which is breaking Diagnose and Solve for safari users. This is the PR to temporary fix the loading experience. 
https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group

Still need help from @yifguoMSFT and @puneetg1983  to find the alternative regex pattern to replace the negative lookbehind here:
const regex = new RegExp("(?<!\!)\[(.*?)]\((.*?)( +\"(.*?)\")?\)", "g");