### PR TITLE
Handle Platform versions for Linux Diagnostic tools

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/home.module.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/home.module.ts
@@ -229,6 +229,28 @@ export const HomeRoutes = RouterModule.forChild([
                             cacheComponent: true
                         }
                     },
+                    // Memory Dump (To be shown when a Linux site is running on instances that are both on ANT 97 and ANT 98)
+                    {
+                        path: 'tools/memorydumplinuxmultipleversions',
+                        component: MemoryDumpToolComponent,
+                        data: {
+                            navigationTitle: ToolNames.MemoryDump,
+                            cacheComponent: true,
+                            multipleVersions: true,
+                            allInstancesOnAnt98: false
+                        }
+                    },
+                    // Memory Dump (To be shown when All Instances of a Linux App are running on ANT 98)
+                    {
+                        path: 'tools/memorydumplinuxant98',
+                        component: MemoryDumpToolComponent,
+                        data: {
+                            navigationTitle: ToolNames.MemoryDump,
+                            cacheComponent: true,
+                            multipleVersions: false,
+                            allInstancesOnAnt98: true
+                        }
+                    },
                     // Java Thread Dump
                     {
                         path: 'tools/javathreaddump',

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/memorydump-tool/memorydump-tool.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/memorydump-tool/memorydump-tool.component.html
@@ -10,7 +10,8 @@
         </div>
         <ng-template #linuxApp>
             <daas-v2 [scmPath]="scmPath" [siteToBeDiagnosed]="siteToBeDiagnosed" [diagnoserName]="diagnoserName"
-                (SessionsEvent)="updateSessions($event)">
+                (SessionsEvent)="updateSessions($event)" [multipleAntaresVersions]="multipleAntaresVersions"
+                [allInstancesOnAnt98]="allInstancesOnAnt98" >
             </daas-v2>
         </ng-template>
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/memorydump-tool/memorydump-tool.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/memorydump-tool/memorydump-tool.component.ts
@@ -2,12 +2,16 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { DaasBaseComponent } from '../daas-base/daas-base.component';
 import { SiteService } from '../../../services/site.service';
 import { WebSitesService } from '../../../../resources/web-sites/services/web-sites.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
     templateUrl: 'memorydump-tool.component.html',
     styleUrls: ['../styles/daasstyles.scss']
 })
 export class MemoryDumpToolComponent extends DaasBaseComponent implements OnInit {
+
+    multipleAntaresVersions: boolean = false;
+    allInstancesOnAnt98: boolean = false;
 
     title: string = 'Collect a Memory dump';
     description: string = 'If your app is performing slow or not responding at all, you can collect a memory dump to identify the root cause of the issue.';
@@ -19,12 +23,21 @@ export class MemoryDumpToolComponent extends DaasBaseComponent implements OnInit
     ];
     diagnoserNameLookup: string;
 
-    constructor(private _siteServiceLocal: SiteService, private _webSiteServiceLocal: WebSitesService) {
+    constructor(private _siteServiceLocal: SiteService, private _webSiteServiceLocal: WebSitesService,
+        private _activatedRoute: ActivatedRoute) {
         super(_siteServiceLocal, _webSiteServiceLocal);
+
+        if (_activatedRoute.snapshot.data.hasOwnProperty("multipleVersions")) {
+            this.multipleAntaresVersions = _activatedRoute.snapshot.data["multipleVersions"];
+        }
+
+        if (_activatedRoute.snapshot.data.hasOwnProperty("allInstancesOnAnt98")) {
+            this.allInstancesOnAnt98 = _activatedRoute.snapshot.data["allInstancesOnAnt98"];
+        }
     }
 
     ngOnInit(): void {
-        this.diagnoserName = this.isWindowsApp && !this.isBetaSubscription? 'Memory Dump' : 'MemoryDump';
+        this.diagnoserName = this.isWindowsApp && !this.isBetaSubscription ? 'Memory Dump' : 'MemoryDump';
         this.diagnoserNameLookup = this.diagnoserName;
         this.scmPath = this._siteServiceLocal.currentSiteStatic.enabledHostNames.find(hostname => hostname.indexOf('.scm.') > 0);
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -62,9 +62,15 @@ export class DaasService {
         return <Observable<Session[]>>this._armClient.getResourceWithoutEnvelope<Session[]>(resourceUri, null, true);
     }
 
-    getActiveSession(site: SiteDaasInfo, isWindowsApp: boolean): Observable<SessionV2> {
+    //
+    // With ANT 97 for Linux, the  path to check active session was changed to '/daas/sessions/active'
+    // but accidentally the old path '/daas/activesession' got removed. Hence, the caller needs to try both 
+    // paths unfortunately. This will go away post ANT97 deployment
+    //
+
+    getActiveSession(site: SiteDaasInfo, isWindowsApp: boolean, useNewRouteForLinux: boolean): Observable<SessionV2> {
         let resourceUri: string = this._uriElementsService.getActiveDiagnosticsSessionV2Url(site);
-        if (!isWindowsApp) {
+        if (!isWindowsApp && !useNewRouteForLinux) {
             resourceUri = this._uriElementsService.getActiveDiagnosticsSessionV2LinuxUrl(site);
         }
         return <Observable<SessionV2>>this._armClient.getResourceWithoutEnvelope<SessionV2>(resourceUri, null, true);


### PR DESCRIPTION
There is a change done with ANT97 (for Linux Apps) in which a new route for checking the active session was added to KuduLite. The new route is `daas/sessions/active`. It looks like while making that change, the old route `daas/activesession` got accidently removed from KUDU code. Due to this, sites that are getting upgraded to ANT97 will fail to run Diagnostic Tools for Linux. This PR addresses will basically check for both the routes.

Secondly, with ANT98, we are changing the way DaaS sessions will be submitted which means we need to change the way some of the DAAS APIs are called. Also if an app is running on both ANT97 and ANT97, diagnostic tools wont work. To handle this, I will be updating the LinuxDiagnosticTools detector and that detector will check the instances on which the app is running and set the ActionValue on the Card to some path like this.

memoryDump.ActionValue = "memorydumplinuxmultipleversions";

I am also adding new routes for these strings and the DAAS component will read the route data to show the right kind of tool based on the Platform version. In this manner we can move the check to detect the platform version in the detector and keep the UI code clean. Once ANT 98 deployment finishes completely, I will remove this newly added routes.

I will implement the newer API's for ANT98 once all the backend PR's get merged