### PR TITLE
Add sap id routing for D&S

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/support-topic-redirect/support-topic-redirect.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/support-topic-redirect/support-topic-redirect.component.ts
@@ -18,7 +18,7 @@ export class SupportTopicRedirectComponent implements OnInit {
     private _notificationService: NotificationService, private portalKustoLogging: PortalKustoTelemetryService, private subscriptionPropertiesService: SubscriptionPropertiesService, private _riskAlertService: RiskAlertService) { }
 
   ngOnInit() {
-    this._supportTopicService.getPathForSupportTopic(this._activatedRoute.snapshot.queryParams.supportTopicId, this._activatedRoute.snapshot.queryParams.pesId, this._activatedRoute.snapshot.queryParams.caseSubject).subscribe(res => {
+    this._supportTopicService.getPathForSupportTopic(this._activatedRoute.snapshot.queryParams.supportTopicId, this._activatedRoute.snapshot.queryParams.pesId, this._activatedRoute.snapshot.queryParams.caseSubject, this._activatedRoute.snapshot.queryParams.sapSupportTopicId, this._activatedRoute.snapshot.queryParams.sapProductId).subscribe(res => {
         this._router.navigate([`../${res.path}`], { relativeTo: this._activatedRoute, queryParams: res.queryParams });
 
     // Discussed with the team and we decide to disable the notification for now

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/components/diagnostic-tools/diagnostic-tools.component.ts
@@ -130,12 +130,14 @@ export class DiagnosticToolsComponent {
         const resourceId = startUpInfo.resourceId ? startUpInfo.resourceId : '';
         const ticketBladeWorkflowId = startUpInfo.workflowId ? startUpInfo.workflowId : '';
         const supportTopicId = startUpInfo.supportTopicId ? startUpInfo.supportTopicId : '';
+        const sapSupportTopicId = startUpInfo.sapSupportTopicId ? startUpInfo.sapSupportTopicId : '';
         const sessionId = startUpInfo.sessionId ? startUpInfo.sessionId : '';
 
         const eventProperties: { [name: string]: string } = {
           'ResourceId': resourceId,
           'TicketBladeWorkflowId': ticketBladeWorkflowId,
           'SupportTopicId': supportTopicId,
+          'SapSupportTopicId': sapSupportTopicId,
           'PortalSessionId': sessionId,
           'AzureServiceName': this._resourceService.azureServiceName,
         };

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
@@ -26,16 +26,16 @@ export class SiteSupportTopicService extends SupportTopicService {
     }
   }
 
-  getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string): Observable<string> {
+  getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string, sapSupportTopicId: string="", sapProductId: string=""): Observable<string> {
     const matchingMapping = this._hardCodedSupportTopicIdMapping.find(
-      supportTopic => supportTopic.supportTopicId === supportTopicId &&
-        (!pesId || pesId === '' || supportTopic.pesId === pesId)
+      supportTopic => supportTopic.sapSupportTopicId === sapSupportTopicId &&
+        (!sapProductId || sapProductId === '' || supportTopic.sapProductId === sapProductId)
     );
 
     if (matchingMapping && this._webSiteService.platform == OperatingSystem.windows) {
       return of(`/legacy${matchingMapping.path}`);
     } else {
-      return super.getPathForSupportTopic(supportTopicId, pesId, searchTerm);
+      return super.getPathForSupportTopic(supportTopicId, pesId, searchTerm, sapSupportTopicId, sapProductId);
     }
   }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/resource-redirect/resource-redirect.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/resource-redirect/resource-redirect.component.ts
@@ -31,6 +31,7 @@ export class ResourceRedirectComponent implements OnInit {
             const resourceId = info.resourceId ? info.resourceId : '';
             const ticketBladeWorkflowId = info.workflowId ? info.workflowId : '';
             const supportTopicId = info.supportTopicId ? info.supportTopicId : '';
+            const sapSupportTopicId = info.sapSupportTopicId ? info.sapSupportTopicId : '';
             const sessionId = info.sessionId ? info.sessionId : '';
             const effectiveLocale = !!info.effectiveLocale ? info.effectiveLocale.toLowerCase() : "";
             const theme = !!info.theme ? info.theme.toLowerCase() : "";
@@ -40,6 +41,7 @@ export class ResourceRedirectComponent implements OnInit {
                 'ResourceId': resourceId,
                 'TicketBladeWorkflowId': ticketBladeWorkflowId,
                 'SupportTopicId': supportTopicId,
+                'SapSupportTopicId': sapSupportTopicId,
                 'PortalSessionId': sessionId,
                 'EffectiveLocale': effectiveLocale,
                 'Theme': theme,

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/resource-redirect/resource-redirect.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/resource-redirect/resource-redirect.component.ts
@@ -95,13 +95,16 @@ export class ResourceRedirectComponent implements OnInit {
               );
             }
           }
-          if (info.supportTopicId) {
+
+          if (info.supportTopicId || info.sapSupportTopicId) {
             path += `/supportTopicId`;
             navigationExtras.queryParams = {
               ...navigationExtras.queryParams,
               supportTopicId: info.supportTopicId,
               caseSubject: caseSubject,
-              pesId: info.pesId
+              pesId: info.pesId,
+              sapSupportTopicId: info.sapSupportTopicId,
+              sapProductId: info.sapProductId,
             };
           }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/logging/logging.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/logging/logging.service.ts
@@ -21,6 +21,7 @@ export class LoggingService {
     private _resourceType: string = '';
     private _ticketBladeWorkflowId: string = '';
     private _supportTopicId: string = '';
+    private _sapSupportTopicId: string = '';
     private _appType: string = '';
     private _source: string = '';
     private _diagnosticsVersion: string = '';
@@ -57,6 +58,10 @@ export class LoggingService {
 
                 if (this._startUpInfo.supportTopicId) {
                     this._supportTopicId = this._startUpInfo.supportTopicId;
+                }
+
+                if (this._startUpInfo.sapSupportTopicId) {
+                    this._sapSupportTopicId = this._startUpInfo.sapSupportTopicId;
                 }
 
                 if (this._startUpInfo.source) {
@@ -103,6 +108,7 @@ export class LoggingService {
             platform: this.platform,
             appType: this._appType,
             supportTopicId: this._supportTopicId,
+            sapSupportTopicId: this._sapSupportTopicId,
             bladeSource: this._source,
             diagnosticsVersion: this._diagnosticsVersion
         };

--- a/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/startup/services/auth.service.ts
@@ -19,7 +19,8 @@ export class AuthService {
         subscriptions: null,
         resourceId: environment.authServiceResourceId,
         workflowId: '',
-        supportTopicId: ''
+        supportTopicId: '',
+        sapSupportTopicId: ''
     };
 
     public get hasLocalStartupInfo() {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-support-topic.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-support-topic.service.ts
@@ -226,15 +226,23 @@ export class ApplensSupportTopicService {
         return of(null);
     }
 
-
-    getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string): Observable<string> {
+    getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string, sapSupportTopicId: string = "", sapProductId: string = ""): Observable<string> {
         return this._diagnosticApiService.getDetectors().pipe(map(detectors => {
             let detectorPath = '';
 
             if (detectors) {
-                const matchingDetector = detectors.find(detector =>
-                    detector.supportTopicList &&
-                    detector.supportTopicList.findIndex(supportTopic => supportTopic.id === supportTopicId) >= 0);
+                var matchingDetector = null;
+                if (sapSupportTopicId != "")
+                {
+                    matchingDetector = detectors.find(detector =>
+                        detector.supportTopicList &&
+                        detector.supportTopicList.findIndex(supportTopic => supportTopic.sapSupportTopicId === sapSupportTopicId) >= 0);
+                }
+                else{
+                    matchingDetector = detectors.find(detector =>
+                        detector.supportTopicList &&
+                        detector.supportTopicList.findIndex(supportTopic => supportTopic.id === supportTopicId) >= 0);
+                }
 
                 if (matchingDetector) {
                     detectorPath = `/detectors/${matchingDetector.id}`;

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-support-topic.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-support-topic.service.ts
@@ -161,6 +161,7 @@ export class ApplensSupportTopicService {
     }
 
     public supportTopicId: string;
+    public sapSupportTopicId: string;
 
     public getSupportTopics(): Observable<any> {
         let pesId = this._resourceService.pesId;
@@ -238,7 +239,9 @@ export class ApplensSupportTopicService {
                         detector.supportTopicList &&
                         detector.supportTopicList.findIndex(supportTopic => supportTopic.sapSupportTopicId === sapSupportTopicId) >= 0);
                 }
-                else{
+
+                if (matchingDetector == null)
+                {
                     matchingDetector = detectors.find(detector =>
                         detector.supportTopicList &&
                         detector.supportTopicList.findIndex(supportTopic => supportTopic.id === supportTopicId) >= 0);

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -86,6 +86,8 @@ export interface KustoPropertyBagValue {
 export interface SupportTopic {
     id: string;
     pesId: string;
+    sapSupportTopicId: string;
+    sapPesId: string;
 }
 
 export enum DetectorType {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-support-topic.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-support-topic.service.ts
@@ -9,12 +9,13 @@ export class GenericSupportTopicService {
     // In applens we provide this withValue: applens-diagnostics.service
     // In Support Center we provide this withValue: generic-api.service
     public supportTopicId: string;
+    public sapSupportTopicId: string;
 
     public getSelfHelpContentDocument(): Observable<any> {
         return null;
     }
 
-    public getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string): Observable<any> {
+    public getPathForSupportTopic(supportTopicId: string, pesId: string, searchTerm: string, sapSupportTopicId: string, sapProductId: string): Observable<any> {
         return null;
     }
 }


### PR DESCRIPTION
To support opening detector page with new SapSupportTopicId for ASC and help 2.0, we parse SapSupportTopicId along with SupportTopicId in startupInfo.

For Support topic service, SapSupportTopicId will take precedence over SupportTopicId to find the matched detector.

We still need to update chat service to check live chat eligibility for the passed SapSuppotTopicId. 
@nmallick1 will help update live chat support for SapSuppotTopicId.