### PR TITLE
Branch queryparam

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -106,7 +106,7 @@ export class OnboardingFlowComponent implements OnInit {
   @Input() startTime: momentNs.Moment = moment.utc().subtract(1, 'days');
   @Input() endTime: momentNs.Moment = moment.utc();
   @Input() gistMode: boolean = false;
-
+  @Input() branchInput: string = ''; 
   DevelopMode = DevelopMode;
   HealthStatus = HealthStatus;
   PanelType = PanelType;
@@ -405,6 +405,7 @@ export class OnboardingFlowComponent implements OnInit {
 
   ngOnInit() {
     this.detectorGraduation = true;
+    this.branchInput = this._activatedRoute.snapshot.queryParams['branchInput'];
     this.diagnosticApiService.getDevopsConfig(`${this.resourceService.ArmResource.provider}/${this.resourceService.ArmResource.resourceTypeName}`).subscribe(devopsConfig => {
       this.detectorGraduation = devopsConfig.graduationEnabled;
       this.deleteVisibilityStyle = !(this.detectorGraduation === true && this.mode !== DevelopMode.Create) ? {display: "none"} : {};
@@ -413,6 +414,8 @@ export class OnboardingFlowComponent implements OnInit {
 
       this.defaultBranch = "MainMVP";
 
+      if (this.detectorGraduation)
+       this.getBranchList();
 
       if (!this.initialized) {
         this.initialize();
@@ -442,10 +445,6 @@ export class OnboardingFlowComponent implements OnInit {
       });
 
       this.autoMerge = devopsConfig.autoMerge;
-
-      if (this.detectorGraduation)
-        this.getBranchList();
-
       if (this._detectorControlService.isInternalView) {
         this.internalExternalText = this.internalViewText;
       }
@@ -458,7 +457,7 @@ export class OnboardingFlowComponent implements OnInit {
   getBranchList() {
     this.optionsForSingleChoice = [];
     this.showBranches = [];
-
+    this.resourceId = this.resourceId == undefined || this.resourceId == '' ? this.resourceService.getCurrentResourceId() : this.resourceId;  
     this.diagnosticApiService.getBranches(this.resourceId).subscribe(branches => {
       var branchRegEx = new RegExp(`^dev\/.*\/detector\/${this.id}$`, "i");
       branches.forEach(option => {
@@ -488,13 +487,21 @@ export class OnboardingFlowComponent implements OnInit {
         this.noBranchesAvailable();
       }
       else {
-        var targetBranch = `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}`
+        var targetBranch = `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}`;
+        // if a branch is present via query params, default to that branch.
+        if (this.branchInput != undefined && this.branchInput != '' && this.mode == DevelopMode.Edit)  {
+          this.Branch = this.branchInput;
+          this.displayBranch = this.Branch;
+          this.tempBranch = this.Branch;
+        } else {
         this.Branch = this.targetInShowBranches(targetBranch) ? targetBranch : this.showBranches[0].key;
         this.displayBranch = this.Branch;
         this.tempBranch = this.Branch;
-        this.updateBranch();
       }
+      this.updateBranch();
+    }
     });
+  
   }
 
   internalExternalToggle() {
@@ -1488,6 +1495,9 @@ export class OnboardingFlowComponent implements OnInit {
     let detectorFile: Observable<string>;
     this.recommendedUtterances = [];
     this.utteranceInput = "";
+    if (this.detectorGraduation && this.mode == DevelopMode.Edit && this.branchInput != undefined && this.branchInput != '') {
+      this.Branch = this.branchInput;
+    } 
     if (this.detectorGraduation && this.mode != DevelopMode.Create) {
       this.diagnosticApiService.getDetectorCode(`${this.id.toLowerCase()}/metadata.json`, this.Branch, this.resourceId).subscribe(res => {
         this.allUtterances = JSON.parse(res).utterances;
@@ -1560,21 +1570,22 @@ export class OnboardingFlowComponent implements OnInit {
           }));
       }
       else {
-        const branchObservable = this.diagnosticApiService.getBranches(this.resourceId).pipe(map(branches => {
-          const defaultBranch = branches.find(b => b.isMainBranch.toLowerCase() === "true");
-          this.defaultBranch = String(defaultBranch.branchName);
-          return this.defaultBranch;
-        }));
+        // TODO: Get package.json from branch depending on input query param 
+        // const branchObservable = this.diagnosticApiService.getBranches(this.resourceId).pipe(map(branches => {
+        //   const defaultBranch = branches.find(b => b.isMainBranch.toLowerCase() === "true");
+        //   this.defaultBranch = String(defaultBranch.branchName);
+        //   return this.defaultBranch;
+        // }));
 
-        configuration = branchObservable.pipe(switchMap((branch: string) => {
-          return this.diagnosticApiService.getDetectorCode(`${this.id.toLowerCase()}/package.json`, branch, this.resourceId).pipe(map(config => {
+      //  branchObservable.pipe(switchMap((branch: string) => {
+        configuration =  this.diagnosticApiService.getDetectorCode(`${this.id.toLowerCase()}/package.json`, this.Branch, this.resourceId).pipe(map(config => {
             let c: object = JSON.parse(config)
             c['dependencies'] = c['dependencies'] || {};
 
             this.configuration = c;
             return this.configuration['dependencies'];
           }));
-        }));
+        // }));
       }
     } 
     else {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1570,14 +1570,6 @@ export class OnboardingFlowComponent implements OnInit {
           }));
       }
       else {
-        // TODO: Get package.json from branch depending on input query param 
-        // const branchObservable = this.diagnosticApiService.getBranches(this.resourceId).pipe(map(branches => {
-        //   const defaultBranch = branches.find(b => b.isMainBranch.toLowerCase() === "true");
-        //   this.defaultBranch = String(defaultBranch.branchName);
-        //   return this.defaultBranch;
-        // }));
-
-      //  branchObservable.pipe(switchMap((branch: string) => {
         configuration =  this.diagnosticApiService.getDetectorCode(`${this.id.toLowerCase()}/package.json`, this.Branch, this.resourceId).pipe(map(config => {
             let c: object = JSON.parse(config)
             c['dependencies'] = c['dependencies'] || {};
@@ -1585,7 +1577,6 @@ export class OnboardingFlowComponent implements OnInit {
             this.configuration = c;
             return this.configuration['dependencies'];
           }));
-        // }));
       }
     } 
     else {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -487,7 +487,7 @@ export class OnboardingFlowComponent implements OnInit {
         this.noBranchesAvailable();
       }
       else {
-        var targetBranch = `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}`;
+        var targetBranch = this.gistMode ? `dev/${this.userName.split("@")[0]}/gist/${this.id.toLowerCase()}` : `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}`;
         // if a branch is present via query params, default to that branch.
         if (this.branchInput != undefined && this.branchInput != '' && this.mode == DevelopMode.Edit)  {
           this.Branch = this.branchInput;
@@ -1179,7 +1179,7 @@ export class OnboardingFlowComponent implements OnInit {
   }
 
   setTargetBranch(){
-    var targetBranch = `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}`;
+    var targetBranch = this.gistMode ?  `dev/${this.userName.split("@")[0]}/gist/${this.id.toLowerCase()}` : `dev/${this.userName.split("@")[0]}/detector/${this.id.toLowerCase()}` ;
 
     if (this.Branch === this.defaultBranch && this.targetInShowBranches(targetBranch)) {
       this.Branch = targetBranch;

--- a/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
@@ -43,12 +43,14 @@ export class UserActivePullrequestsComponent implements OnInit {
       let sourceBranchTrim = sourceBranch.replace('refs/heads/', '');
       let title:string = element['title'];
       let link:string = element['remoteUrl'];
+      // Note: this logic will work for branches created with following pattern : dev/<user_alias>/<entitytype>/<entityid>, eg: dev/microsoftalias/detector/mydetector or dev/microsoftalias/gist/mygist
       let branchUserName = sourceBranchTrim.startsWith('dev/') ? sourceBranchTrim.split("/")[1] : sourceBranchTrim;
-      if (branchUserName.includes(this.userId) && title != undefined && title != '' && link != undefined && link != '') {  
+      if (branchUserName.toLocaleLowerCase() == this.userId.toLocaleLowerCase() && title != undefined && title != '' && link != undefined && link != '') {  
         let rowElement = `<markdown><a href="${link}" target="_blank">${title}</a></markdown>`;
         sourceBranch = sourceBranch.replace('refs/heads/','');
-        let detectorId = sourceBranchTrim.split("/")[3];
-        let path = `${this.resourceId}/detectors/${detectorId}/edit?branchInput=${sourceBranch}`;
+        let entityid = sourceBranchTrim.split("/")[3];
+        let entityType = sourceBranchTrim.split("/")[2];
+        let path = entityType.toLocaleLowerCase() == 'gist' ? `${this.resourceId}/gists/${entityid}?branchInput=${sourceBranch}` : `${this.resourceId}/detectors/${entityid}/edit?branchInput=${sourceBranch}`;
         let sourceClickContent =  `<p> ${sourceBranch}  <a href="${path}" target="_blank">(Click here to edit in AppLens) </a></p>`;
         rows.push([rowElement, sourceClickContent]);
       }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
@@ -49,7 +49,7 @@ export class UserActivePullrequestsComponent implements OnInit {
         sourceBranch = sourceBranch.replace('refs/heads/','');
         let detectorId = sourceBranchTrim.split("/")[3];
         let path = `${this.resourceId}/detectors/${detectorId}/edit?branchInput=${sourceBranch}`;
-        let sourceClickContent =  `<p><a href="${path}" target="_blank">${sourceBranch}</a></p>`;
+        let sourceClickContent =  `<p> ${sourceBranch}  <a href="${path}" target="_blank">(Click here to edit in AppLens) </a></p>`;
         rows.push([rowElement, sourceClickContent]);
       }
     })

--- a/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/user-active-pullrequests/user-active-pullrequests.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { AdalService } from 'adal-angular4';
 import { DataTableResponseColumn, DataTableResponseObject } from 'diagnostic-data';
 import { ResourceService } from '../../../shared/services/resource.service';
@@ -15,9 +16,11 @@ export class UserActivePullrequestsComponent implements OnInit {
   pullRequests: [];
   table: DataTableResponseObject = null;
   errorMessage: string = "";
-  constructor(private _diagnosticApiService: ApplensDiagnosticService, private resourceService: ResourceService, private _adalService: AdalService) { }
+  resourceId:string = "";
+  constructor(private _diagnosticApiService: ApplensDiagnosticService, private resourceService: ResourceService, private _adalService: AdalService, private router: Router) { }
 
   ngOnInit() {
+    this.resourceId = this._diagnosticApiService.resourceId;
     let alias = Object.keys(this._adalService.userInfo.profile).length > 0 ? this._adalService.userInfo.profile.upn : '';
     this.userId = alias.replace('@microsoft.com', '');
     this._diagnosticApiService.getDevopsPullRequest(`${this.resourceService.ArmResource.provider}/${this.resourceService.ArmResource.resourceTypeName}`).subscribe(pullRequestResponse => {
@@ -42,9 +45,12 @@ export class UserActivePullrequestsComponent implements OnInit {
       let link:string = element['remoteUrl'];
       let branchUserName = sourceBranchTrim.startsWith('dev/') ? sourceBranchTrim.split("/")[1] : sourceBranchTrim;
       if (branchUserName.includes(this.userId) && title != undefined && title != '' && link != undefined && link != '') {  
-        let rowElement = `<markdown><a href="${link}">${title}</a></markdown>`;
+        let rowElement = `<markdown><a href="${link}" target="_blank">${title}</a></markdown>`;
         sourceBranch = sourceBranch.replace('refs/heads/','');
-        rows.push([rowElement, sourceBranch]);
+        let detectorId = sourceBranchTrim.split("/")[3];
+        let path = `${this.resourceId}/detectors/${detectorId}/edit?branchInput=${sourceBranch}`;
+        let sourceClickContent =  `<p><a href="${path}" target="_blank">${sourceBranch}</a></p>`;
+        rows.push([rowElement, sourceClickContent]);
       }
     })
 


### PR DESCRIPTION
- When authors create new detectors/gist, they can go back and edit them via Active Pull Requests tab 
- Whenever branch is created for gist PR, the branch name would be dev/user-alias/gist/id instead of dev/user-alias/detector/id
- Ability to create deep link of branch query param with edit flow