### PR TITLE
Remove extra query param when not needed

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
@@ -45,6 +45,6 @@ export class UriUtilities {
     }
 
     static removeChildDetectorStartAndEndTime(allQueryParams: { [key: string]: any }) {
-        return UriUtilities.removeQueryParams(allQueryParams,["startTimeChildDetector","endTimeChildDetector"]);
+        return UriUtilities.removeQueryParams(allQueryParams,["startTimeChildDetector","endTimeChildDetector", "branchInput"]);
     }
 }


### PR DESCRIPTION
This PR fixes removing branchInput query param when navigating from other places except for Active Pull Requests. When Navigating from side menu, we do not need this input as it can interfere with branch selection. Eg; when creating new detector we do not need this query param.