### PR TITLE
Fix for [Screen reader - App Service - Startup Time]

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing.component.html
@@ -126,8 +126,8 @@
 
           <div class="header2">3. Override when Action executes (Optional)</div>
           <div class="autohealtile-content">
-            <div class="autohealtile" tabindex="0" [class.activeAction]="minProcessExecutionTime > 0" role="radio"
-              [attr.aria-checked]="minProcessExecutionTime > 0"
+            <div class="autohealtile" tabindex="0" [class.activeAction]="minProcessExecutionTime > 0" role="button"
+              [attr.aria-pressed]="minProcessExecutionTimeExpanded"
               (click)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded"
               (keyup.space)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded"
               (keyup.enter)="minProcessExecutionTimeExpanded = !minProcessExecutionTimeExpanded">


### PR DESCRIPTION
ID | Title | State | Area Path | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
12480713 | [Screen reader - App Service - Startup Time]: Screen reader is not announcing the state that “Start time up” button is selected or not selected. | New | Antares\ANTUX | A11YMAS; A11ySev2; Accessibility; Benchmark; Benchmark-HCL-AppServiceWebApp-OCT2021; Diagnose and Solve Problems; HCL; MAS4.1.2; Regressed:27-12-21; Reopen; Win10-Firefox | 6 | 3/24/2022, 2:58:38 AM