### PR TITLE
Edit the home page to show the static AKS text in China cloud.

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/home/home.component.html
@@ -11,19 +11,7 @@
 </ng-container>
 
 
-<div *ngIf="useLegacy else newHomePage" class="home-container">
-  <div class="input-group input-group-lg search-input-group" (keyup.escape)="clearSearch()" role="search"
-    *ngIf="!isAKSOnNationalCloud">
-    <input tabindex="0" type="search" class="form-control" placeholder="{{searchPlaceHolder}}" [ngModel]="searchValue"
-      (ngModelChange)="updateSearchValue($event)" (focus)="onSearchBoxFocus(event)" (focusout)="onSearchLostFocus()"
-      aria-controls="search-results">
-    <div class="input-group-btn" id="clear-search">
-      <button class="btn btn-default" type="button" aria-label="Clear" title="Clear" tabindex="0"
-        (click)="clearSearch()" (focus)="onFocusClear()">
-        <i class="fa fa-close"></i>
-      </button>
-    </div>
-  </div>
+<div *ngIf="useStaticAksText else newHomePage" class="home-container">
   <div role="status">
     <p *ngIf="inputAriaLabel">{{inputAriaLabel}}</p>
   </div>


### PR DESCRIPTION
While we still don't have the proper form of Diagnose and Solve fully enabled in China cloud, we need to provide this static view of text for AKS in China cloud just like how it was before as we are seeing issues where customer's are seeing the new UI of Diagnose and Solve and they are not able to successfully use it. 

This is a temporary solution until the coming weeks we can deploy an instance of appservice diagnostics in that cloud.

![image](https://user-images.githubusercontent.com/917998/160210932-c5898929-729b-43a3-84f2-faf53d52a392.png)
