### PR TITLE
Darreldonald/viewdetails button

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -68,8 +68,8 @@
                           <fab-primary-button *ngIf="allSolutionsMap.has(viewModel.model.title)" contentClass="mr-5"
                             (onClick)="openSolutionPanel(viewModel)"
                             contentStyle="border-radius: 2px;font-size: 13px;">View Solutions</fab-primary-button>
-                            <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
-                            <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                            <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                            <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link>
                         </div>
                       </div>
                     </fab-card>
@@ -205,8 +205,8 @@
                     </div>
                     <div footer>
                       <div style="margin-bottom:15px;">
-                        <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
-                        <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                        <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                        <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress" [styles]="linkStyle">[Open in new tab]</fab-link>
                       </div>
                     </div>
                   </fab-card>
@@ -236,8 +236,8 @@
                   </div>
                   <div footer>
                     <div style="margin-bottom: 12px;">
-                      <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
-                      <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                      <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                      <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link>
                     </div>
                   </div>
                 </fab-card>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -68,7 +68,8 @@
                           <fab-primary-button *ngIf="allSolutionsMap.has(viewModel.model.title)" contentClass="mr-5"
                             (onClick)="openSolutionPanel(viewModel)"
                             contentStyle="border-radius: 2px;font-size: 13px;">View Solutions</fab-primary-button>
-                          <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                            <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
+                            <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
                         </div>
                       </div>
                     </fab-card>
@@ -204,7 +205,8 @@
                     </div>
                     <div footer>
                       <div style="margin-bottom:15px;">
-                        <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                        <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
+                        <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
                       </div>
                     </div>
                   </fab-card>
@@ -234,8 +236,8 @@
                   </div>
                   <div footer>
                     <div style="margin-bottom: 12px;">
-                      <fab-link (onClick)="selectDetector(viewModel)">View details
-                      </fab-link>
+                      <div><fab-link (onClick)="selectDetector(viewModel)">View details</fab-link></div>
+                      <div><fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
                     </div>
                   </div>
                 </fab-card>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -873,7 +873,6 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     } else {
                         //TODO, For D&S blade, need to add a service to find category and navigate to detector
                         if (viewModel.model.startTime != null && viewModel.model.endTime != null) {
-                            this.analysisContainsDowntime().subscribe(containsDowntime => {
                                 this._detectorControl.setCustomStartEnd(viewModel.model.startTime, viewModel.model.endTime);
                                 //Todo, detector control service should able to read and infer TimePickerOptions from startTime and endTime
                                 this._detectorControl.updateTimePickerInfo({
@@ -884,7 +883,6 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                 });
                                 this.updateBreadcrumb();
                                 this._router.navigate([`../../detectors/${detectorId}`], { relativeTo: this._activatedRoute });
-                            });
                         }
                         else {
                             this.updateBreadcrumb();
@@ -897,12 +895,13 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     }
 
     queryParams = {};
-    linkStyles: ILinkProps['styles'] = {
-      root: {
-        pointerEvents: "none",
-      }
+    linkStyle: ILinkProps['styles'] = {
+        root: {
+          padding: '10px'
+        }
     }
     linkAddress: ILinkProps['href'] = "";
+    linkTarget: ILinkProps['target'] = "_blank";
 
     public selectDetectorNewTab(viewModel: any) {
         if (viewModel != null && viewModel.model.metadata.id) {
@@ -931,71 +930,34 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 this.logEvent(TelemetryEventNames.ChildDetectorClicked, clickDetectorEventProperties);
                 this.queryParams = UriUtilities.removeChildDetectorStartAndEndTime(this._activatedRoute.snapshot.queryParams);
 
-                if (this.analysisId === "searchResultsAnalysis" && this.searchTerm && this.searchTerm.length > 0) {
-                    //If in homepage then open second blade for Diagnostic Tool and second blade will continue to open third blade for
-                    if (this.withinGenie) {
-                        const isHomepage = !(!!this._activatedRoute.root.firstChild && !!this._activatedRoute.root.firstChild.firstChild && !!this._activatedRoute.root.firstChild.firstChild.firstChild && !!this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild && !!this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.firstChild && !!this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.firstChild.snapshot && !!this._activatedRoute.root.firstChild.firstChild.firstChild.firstChild.firstChild.snapshot.params["category"]);
-                        if (detectorId == 'appchanges' && !this._detectorControl.internalClient) {
-                            this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
-                            return;
-                        }
-                        if (isHomepage) {
-                            this.openBladeDiagnoseDetectorId(categoryName, detectorId, DetectorType.Detector);
-                        }
-                        else {
-                            this.logEvent(TelemetryEventNames.SearchResultClicked, { searchMode: this.searchMode, searchId: this.searchId, detectorId: detectorId, rank: 0, title: clickDetectorEventProperties.ChildDetectorName, status: clickDetectorEventProperties.Status, ts: Math.floor((new Date()).getTime() / 1000).toString() });
-                            let dest = `resource${this.resourceId}/categories/${categoryName}/detectors/${detectorId}`;
-                            this._globals.openGeniePanel = false;
-                            //this._router.navigate([dest]);
-                            let paramString = "";
-                            Object.keys(this.queryParams).forEach(x => {
-                              paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
-                            });
-                            this.linkAddress = `${dest}?${paramString}`;
-                            }
-                    }
-                    else {
-                        this.logEvent(TelemetryEventNames.SearchResultClicked, { searchMode: this.searchMode, searchId: this.searchId, detectorId: detectorId, rank: 0, title: clickDetectorEventProperties.ChildDetectorName, status: clickDetectorEventProperties.Status, ts: Math.floor((new Date()).getTime() / 1000).toString() });
-                        //this._router.navigate([`../../../analysis/${this.analysisId}/search/detectors/${detectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', preserveFragment: true, queryParams: { searchTerm: this.searchTerm } });
+                if (detectorId === 'appchanges' && !this._detectorControl.internalClient) {
+                    this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
+                } else {
+                    //TODO, For D&S blade, need to add a service to find category and navigate to detector
+                    if (viewModel.model.startTime != null && viewModel.model.endTime != null) {
+
+                        this._detectorControl.setCustomStartEnd(viewModel.model.startTime, viewModel.model.endTime);
+                        //Todo, detector control service should able to read and infer TimePickerOptions from startTime and endTime
+                        this._detectorControl.updateTimePickerInfo({
+                            selectedKey: TimePickerOptions.Custom,
+                            selectedText: TimePickerOptions.Custom,
+                            startDate: new Date(viewModel.model.startTime),
+                            endDate: new Date(viewModel.model.endTime)
+                        });
+                        this.updateBreadcrumb();
                         let paramString = "";
                         Object.keys(this.queryParams).forEach(x => {
-                          paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
+                            paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
                         });
-                        this.linkAddress = `../../../analysis/${this.analysisId}/search/detectors/${detectorId}?${paramString}`;
+                        this.linkAddress = `${this._router.url.split('/analysis/')[0]}/detectors/${detectorId}?${paramString}`;
                     }
-                }
-                else {
-                    if (detectorId === 'appchanges' && !this._detectorControl.internalClient) {
-                        this.portalActionService.openChangeAnalysisBlade(this._detectorControl.startTimeString, this._detectorControl.endTimeString);
-                    } else {
-                        //TODO, For D&S blade, need to add a service to find category and navigate to detector
-                        if (viewModel.model.startTime != null && viewModel.model.endTime != null) {
-                            
-                                this._detectorControl.setCustomStartEnd(viewModel.model.startTime, viewModel.model.endTime);
-                                //Todo, detector control service should able to read and infer TimePickerOptions from startTime and endTime
-                                this._detectorControl.updateTimePickerInfo({
-                                    selectedKey: TimePickerOptions.Custom,
-                                    selectedText: TimePickerOptions.Custom,
-                                    startDate: new Date(viewModel.model.startTime),
-                                    endDate: new Date(viewModel.model.endTime)
-                                });
-                                this.updateBreadcrumb();
-                                //this._router.navigate([`../../detectors/${detectorId}`], { relativeTo: this._activatedRoute });
-                                let paramString = "";
-                                Object.keys(this.queryParams).forEach(x => {
-                                  paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
-                                });
-                                this.linkAddress = `../../detectors/${detectorId}?${paramString}`;
-                        }
-                        else {
-                            this.updateBreadcrumb();
-                            //this._router.navigate([`../../detectors/${detectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', preserveFragment: true });
-                            let paramString = "";
-                            Object.keys(this.queryParams).forEach(x => {
-                              paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
-                            });
-                            this.linkAddress = `/detectors/${detectorId}?${paramString}`;
-                        }
+                    else {
+                        this.updateBreadcrumb();
+                        let paramString = "";
+                        Object.keys(this.queryParams).forEach(x => {
+                            paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
+                        });
+                        this.linkAddress = `${this._router.url.split('/analysis/')[0]}/detectors/${detectorId}?${paramString}`;
                     }
                 }
             }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
@@ -76,7 +76,7 @@
                 (onClick)="openSolutionPanel(viewModel)" contentStyle="border-radius: 2px;font-size: 13px;">
                 View Solutions</fab-primary-button>
                 <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
-                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress" [styles]="linkStyle">[Open in new tab]</fab-link>
             </div>
           </div>
         </fab-card>
@@ -106,7 +106,7 @@
             <div footer>
               <div style="margin-bottom: 12px;">
                 <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
-                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress" [styles]="linkStyle">[Open in new tab]</fab-link>
               </div>
             </div>
           </fab-card>
@@ -137,7 +137,7 @@
             <div footer>
               <div style="margin-bottom: 12px;">
                 <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
-                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
+                <fab-link *ngIf="!isPublic" (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress" [styles]="linkStyle">[Open in new tab]</fab-link>
               </div>
             </div>
           </fab-card>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
@@ -75,7 +75,8 @@
               <fab-primary-button *ngIf="allSolutionsMap.has(viewModel.model.title)" contentClass="mr-5"
                 (onClick)="openSolutionPanel(viewModel)" contentStyle="border-radius: 2px;font-size: 13px;">
                 View Solutions</fab-primary-button>
-              <fab-link (onClick)="selectDetector(viewModel)">View details</fab-link>
+                <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
+                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
             </div>
           </div>
         </fab-card>
@@ -104,8 +105,8 @@
             </div>
             <div footer>
               <div style="margin-bottom: 12px;">
-                <fab-link (onClick)="selectDetector(viewModel)">View details
-                </fab-link>
+                <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
+                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
               </div>
             </div>
           </fab-card>
@@ -135,8 +136,8 @@
             </div>
             <div footer>
               <div style="margin-bottom: 12px;">
-                <fab-link (onClick)="selectDetector(viewModel)">View details
-                </fab-link>
+                <fab-link *ngIf="this.overrideResourceUri == ''" (onClick)="selectDetector(viewModel)">View details</fab-link>
+                <div style="padding-left: 10px;" *ngIf="!isPublic"><fab-link (mouseenter)="selectDetectorNewTab(viewModel)" [target]="linkTarget" [href]="linkAddress">[Open in new tab]</fab-link></div>
               </div>
             </div>
           </fab-card>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
@@ -404,7 +404,8 @@ export class DetectorListComponent extends DataRenderBaseComponent {
               queryParams: this.queryParams,
               relativeTo: this._activatedRoute
             });
-          } else {
+          }
+           else {
             const resourceId = this._diagnosticService.resourceId;
             this._breadcrumbService.updateBreadCrumbSubject({
               name: this.detectorName,
@@ -439,10 +440,6 @@ export class DetectorListComponent extends DataRenderBaseComponent {
           if (this.isPublic) {
             const url = this._router.url.split("?")[0];
             const routeUrl = url.endsWith("/overview") ? `../detectors/${targetDetector}` : `../../detectors/${targetDetector}`;
-            // this._router.navigate([routeUrl], {
-            //   queryParams: this.queryParams,
-            //   relativeTo: this._activatedRoute
-            // });
             let paramString = "";
             Object.keys(this.queryParams).forEach(x => {
               paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
@@ -461,8 +458,6 @@ export class DetectorListComponent extends DataRenderBaseComponent {
               paramString = paramString === "" ? `${paramString}${x}=${this.queryParams[x]}` : `${paramString}&${x}=${this.queryParams[x]}`;
             });
             this.linkAddress = this.overrideResourceUri == "" ? `${resourceId}/detectors/${targetDetector}?${paramString}` : `${this.overrideResourceUri}/detectors/${targetDetector}?${paramString}`;
-            //this.parseResourceService.resourceService.getCurrentResourceId();
-            //this._router.navigate([`${resourceId}/detectors/${targetDetector}`], { queryParams: this.queryParams });
           }
         }
       }


### PR DESCRIPTION
there is now a second button on parent/child detectors that allows the user to open the detector in a new tab
         - only appears in internal view
update to cross resource detectors
         - for internal view only the open in new tab button will be available
         - for external view the view details button will open the detector on the resource it targets in a blade