### PR TITLE
Enabling searching static web app by app name or default host name

### DIFF
--- a/AngularApp/projects/applens/src/app/app.module.ts
+++ b/AngularApp/projects/applens/src/app/app.module.ts
@@ -70,6 +70,9 @@ export const Routes = RouterModule.forRoot([
           {
             path: 'containerapps/:containerapp',
             loadChildren: './modules/containerapp/containerapp.module#ContainerAppModule'
+          }, {
+            path: 'staticwebapps/:staticwebapp',
+            loadChildren: './modules/staticwebapp/staticwebapp.module#StaticWebAppModule'
           },
           {
             path: 'icm/:incidentId',

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { ApplensGlobal } from '../../../applens-global';
 import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.service';

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -21,7 +21,7 @@ export class DashboardContainerComponent implements OnInit {
   observerLink: string = "";
   showMetrics: boolean = true;
 
-  constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _observerService: ObserverService, private _applensGlobal: ApplensGlobal,private _activatedRoute:ActivatedRoute) { }
+  constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _observerService: ObserverService, private _applensGlobal: ApplensGlobal) { }
 
   ngOnInit() {
     this.showMetrics = !(this._resourceService.overviewPageMetricsId == undefined || this._resourceService.overviewPageMetricsId == "");
@@ -45,15 +45,12 @@ export class DashboardContainerComponent implements OnInit {
             this._resourceService.imgSrc = this._resourceService.altIcons['Xenon'];
           }
         } else if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/containerapps' ||
-                   serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.app/containerapps') {
+          serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.app/containerapps') {
           this._diagnosticApiService.GeomasterServiceAddress = this.resource.ServiceAddress;
           this._diagnosticApiService.GeomasterName = this.resource.GeoMasterName;
           this.observerLink = "https://wawsobserver.azurewebsites.windows.net/partner/containerapp/" + this.resource.ContainerAppName;
         } else if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/staticsites') {
-          const defaultHostName = this._activatedRoute.snapshot.queryParams["defaultHostName"];
-          if(defaultHostName) {
-            this.observerLink = "https://wawsobserver.azurewebsites.windows.net/staticwebapps/" + defaultHostName;
-          }
+          this.observerLink = "https://wawsobserver.azurewebsites.windows.net/staticwebapps/" + this.resource["DefaultHostname"];
         }
 
         this.keys = Object.keys(this.resource);

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { ApplensGlobal } from '../../../applens-global';
 import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.service';
@@ -20,7 +21,7 @@ export class DashboardContainerComponent implements OnInit {
   observerLink: string = "";
   showMetrics: boolean = true;
 
-  constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _observerService: ObserverService, private _applensGlobal: ApplensGlobal) { }
+  constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _observerService: ObserverService, private _applensGlobal: ApplensGlobal,private _activatedRoute:ActivatedRoute) { }
 
   ngOnInit() {
     this.showMetrics = !(this._resourceService.overviewPageMetricsId == undefined || this._resourceService.overviewPageMetricsId == "");
@@ -48,6 +49,11 @@ export class DashboardContainerComponent implements OnInit {
           this._diagnosticApiService.GeomasterServiceAddress = this.resource.ServiceAddress;
           this._diagnosticApiService.GeomasterName = this.resource.GeoMasterName;
           this.observerLink = "https://wawsobserver.azurewebsites.windows.net/partner/containerapp/" + this.resource.ContainerAppName;
+        } else if (serviceInputs.resourceType.toString().toLowerCase() === 'microsoft.web/staticsites') {
+          const defaultHostName = this._activatedRoute.snapshot.queryParams["defaultHostName"];
+          if(defaultHostName) {
+            this.observerLink = "https://wawsobserver.azurewebsites.windows.net/staticwebapps/" + defaultHostName;
+          }
         }
 
         this.keys = Object.keys(this.resource);

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -61,7 +61,7 @@ export class MainComponent implements OnInit {
       caseId: false
     },{
       resourceType: null,
-      resourceTypeLabel: 'Static App Host Name',
+      resourceTypeLabel: 'Static App Name Or Default Host Name',
       routeName: (name) => `staticwebapps/${name}`,
       displayName: 'Static Web App',
       enabled: true,

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -61,7 +61,7 @@ export class MainComponent implements OnInit {
       caseId: false
     },{
       resourceType: null,
-      resourceTypeLabel: 'Static Web App Name',
+      resourceTypeLabel: 'Static App Host Name',
       routeName: (name) => `staticwebapps/${name}`,
       displayName: 'Static Web App',
       enabled: true,

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -59,6 +59,13 @@ export class MainComponent implements OnInit {
       displayName: 'Container App',
       enabled: true,
       caseId: false
+    },{
+      resourceType: null,
+      resourceTypeLabel: 'Static Web App Name',
+      routeName: (name) => `staticwebapps/${name}`,
+      displayName: 'Static Web App',
+      enabled: true,
+      caseId: false
     },
     {
       resourceType: null,

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
@@ -1,0 +1,25 @@
+<applens-header></applens-header>
+<div class="container-fluid main-container content-under-header">
+  <div class="big-text" *ngIf="loading">Searching for Static Web App...</div>
+  <div class="big-text" *ngIf="!loading && error">{{error}}</div>
+  <div class="big-text" *ngIf="!loading && !error && matchingSites.length == 1">Redirecting to {{defaultHostName}}</div>
+  <div *ngIf="!loading && !error && matchingSites.length > 0">
+    <div class="multiple-sites">
+      <div>
+        <h3>Multiple static web apps with the name '{{defaultHostName}}' found. Pick the correct one:</h3>
+      </div>
+      <div class="matching-site" *ngFor="let site of matchingSites">
+        <div class="panel main-panel">
+          <div class="panel-body">
+            <h5 class="panel-title">{{site.Name}}
+            </h5>
+            <p class="panel-text">{{site.SubscriptionName}}</p>
+            <p class="panel-text">{{site.ResourceGroupName}}</p>
+            <p class="panel-text">{{site.DefaultHostName}}</p>
+            <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
@@ -2,11 +2,11 @@
 <div class="container-fluid main-container content-under-header">
   <div class="big-text" *ngIf="loading">Searching for Static Web App...</div>
   <div class="big-text" *ngIf="!loading && error">{{error}}</div>
-  <div class="big-text" *ngIf="!loading && !error && matchingSites.length == 1">Redirecting to {{defaultHostName}}</div>
+  <div class="big-text" *ngIf="!loading && !error && matchingSites.length == 1">Redirecting to {{defaultHostNameOrAppName}}</div>
   <div *ngIf="!loading && !error && matchingSites.length > 0">
     <div class="multiple-sites">
       <div>
-        <h3>Multiple static web apps with the name '{{defaultHostName}}' found. Pick the correct one:</h3>
+        <h3>Multiple static web apps with the name '{{defaultHostNameOrAppName}}' found. Pick the correct one:</h3>
       </div>
       <div class="matching-site" *ngFor="let site of matchingSites">
         <div class="panel main-panel">
@@ -15,7 +15,7 @@
             </h5>
             <p class="panel-text">{{site.SubscriptionName}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
-            <p class="panel-text">{{site.DefaultHostName}}</p>
+            <p class="panel-text">{{site.DefaultHostname}}</p>
             <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.scss
@@ -1,0 +1,25 @@
+.main-container {
+    background-color: #e4e4e4;
+}
+
+.multiple-sites {
+    width: 100%;
+    height: 100%;
+    padding: 50px;
+}
+
+.matching-site {
+    margin: 5px;
+    float: left;
+}
+
+.main-panel {
+    width: 40rem;
+}
+
+.big-text {
+    padding: 100px;
+    font-size: 30px;
+    height: 100%;
+}
+

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
@@ -1,61 +1,64 @@
 import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, NavigationExtras, Router } from "@angular/router";
 import { ObserverService } from "../../../shared/services/observer.service";
 import { StartupService } from "../../../shared/services/startup.service";
 
 @Component({
-    selector: 'staticwebapp-finder',
-    templateUrl: './staticwebapp-finder.component.html',
-    styleUrls: ['./staticwebapp-finder.component.scss']
+  selector: 'staticwebapp-finder',
+  templateUrl: './staticwebapp-finder.component.html',
+  styleUrls: ['./staticwebapp-finder.component.scss']
 })
 export class StaticWebAppFinderComponent implements OnInit {
 
-    siteName: string;
-    loading: boolean = true;
-    error: string;
-  
-    matchingSites: Observer.ObserverContainerAppInfo[] = [];
-  
-    contentHeight: string;
-  
-    constructor(private _route: ActivatedRoute, private _router: Router, private _observerService: ObserverService, private _startupService: StartupService) {
-      this.contentHeight = window.innerHeight + 'px';
-    }
-  
-    ngOnInit() {
-      this.siteName = this._route.snapshot.params['staticwebapp'];
-  
-      this._observerService.getContainerApp(this.siteName).subscribe(observerContainerAppResponse => {
-        if (observerContainerAppResponse.details.toString() == "Unable to fetch data from Observer API : GetContainerApp"){
-          this.error = `There was an error trying to find container app ${this.siteName}`;
-          this.loading = false;  
-        }
-        else if (observerContainerAppResponse.details.length === 1) {
-          let matchingSite = observerContainerAppResponse.details[0];
-          this.navigateToSite(matchingSite);
-        }
-        else if (observerContainerAppResponse.details.length > 1) {
-          this.matchingSites = observerContainerAppResponse.details;
-        }
-  
-        this.loading = false;
-      }, (error: Response) => {
-        this.error = error.status == 404 ? `Static Web App with the name ${this.siteName} was not found` : `There was an error trying to find static web app ${this.siteName}`;
-        this.loading = false;
-      });
-    }
-  
-    navigateToSite(matchingSite: Observer.ObserverContainerAppInfo) {
-      let resourceArray: string[] = [
-        'subscriptions', matchingSite.SubscriptionName,
-        'resourceGroups', matchingSite.ResourceGroupName,
-        'providers', 'Microsoft.Web',
-        'staticSites', matchingSite.ContainerAppName];
-  
-      // resourceArray.push('home');
-      // resourceArray.push('category');
-  
-      this._router.navigate(resourceArray, { queryParamsHandling: 'preserve' });
-    }
-  
+  defaultHostName: string;
+  loading: boolean = true;
+  error: string;
+
+  matchingSites: Observer.ObserverStaticWebAppInfo[] = [];
+
+  contentHeight: string;
+
+  constructor(private _route: ActivatedRoute, private _router: Router, private _observerService: ObserverService) {
+    this.contentHeight = window.innerHeight + 'px';
   }
+
+  ngOnInit() {
+    //Todo, search app by host name and app name
+    this.defaultHostName = this._route.snapshot.params['staticwebapp'];
+
+    this._observerService.getStaticWebApp(this.defaultHostName).subscribe(observerStaticWebAppResponse => {
+      if (observerStaticWebAppResponse.details.toString() == "Unable to fetch data from Observer API : GetStaticWebApp") {
+        this.error = `There was an error trying to find static web app with the host name ${this.defaultHostName}`;
+        this.loading = false;
+      }
+      else if (observerStaticWebAppResponse.details.length === 1) {
+        let matchingSite = observerStaticWebAppResponse.details[0];
+        this.navigateToSite(matchingSite);
+      }
+      else if (observerStaticWebAppResponse.details.length > 1) {
+        this.matchingSites = observerStaticWebAppResponse.details;
+      }
+
+      this.loading = false;
+    }, (error: Response) => {
+      this.error = error.status == 404 ? `Static Web App with the default host name ${this.defaultHostName} was not found` : `There was an error trying to find static web app with the host name ${this.defaultHostName}`;
+      this.loading = false;
+    });
+  }
+
+  navigateToSite(matchingSite: Observer.ObserverStaticWebAppInfo) {
+    let resourceArray: string[] = [
+      'subscriptions', matchingSite.SubscriptionName,
+      'resourceGroups', matchingSite.ResourceGroupName,
+      'providers', 'Microsoft.Web',
+      'staticSites', matchingSite.Name];
+
+    const navigationExtra: NavigationExtras = {
+      queryParams: { "defaultHostName": this.defaultHostName },
+      queryParamsHandling: "merge"
+    };
+
+    this._router.navigate(resourceArray, navigationExtra);
+  }
+
+}

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
@@ -10,7 +10,7 @@ import { StartupService } from "../../../shared/services/startup.service";
 })
 export class StaticWebAppFinderComponent implements OnInit {
 
-  defaultHostName: string;
+  defaultHostNameOrAppName: string;
   loading: boolean = true;
   error: string;
 
@@ -23,12 +23,11 @@ export class StaticWebAppFinderComponent implements OnInit {
   }
 
   ngOnInit() {
-    //Todo, search app by host name and app name
-    this.defaultHostName = this._route.snapshot.params['staticwebapp'];
+    this.defaultHostNameOrAppName = this._route.snapshot.params['staticwebapp'];
 
-    this._observerService.getStaticWebApp(this.defaultHostName).subscribe(observerStaticWebAppResponse => {
+    this._observerService.getStaticWebApp(this.defaultHostNameOrAppName).subscribe(observerStaticWebAppResponse => {
       if (observerStaticWebAppResponse.details.toString() == "Unable to fetch data from Observer API : GetStaticWebApp") {
-        this.error = `There was an error trying to find static web app with the host name ${this.defaultHostName}`;
+        this.error = `There was an error trying to find static web app with default host name or app name ${this.defaultHostNameOrAppName}`;
         this.loading = false;
       }
       else if (observerStaticWebAppResponse.details.length === 1) {
@@ -41,7 +40,7 @@ export class StaticWebAppFinderComponent implements OnInit {
 
       this.loading = false;
     }, (error: Response) => {
-      this.error = error.status == 404 ? `Static Web App with the default host name ${this.defaultHostName} was not found` : `There was an error trying to find static web app with the host name ${this.defaultHostName}`;
+      this.error = error.status == 404 ? `Static Web App with the default host name or app name ${this.defaultHostNameOrAppName} was not found` : `There was an error trying to find static web app with the default host name or app name ${this.defaultHostNameOrAppName}`;
       this.loading = false;
     });
   }
@@ -53,12 +52,7 @@ export class StaticWebAppFinderComponent implements OnInit {
       'providers', 'Microsoft.Web',
       'staticSites', matchingSite.Name];
 
-    const navigationExtra: NavigationExtras = {
-      queryParams: { "defaultHostName": this.defaultHostName },
-      queryParamsHandling: "merge"
-    };
-
-    this._router.navigate(resourceArray, navigationExtra);
+    this._router.navigate(resourceArray, { queryParamsHandling: "preserve" });
   }
 
 }

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { ObserverService } from "../../../shared/services/observer.service";
+import { StartupService } from "../../../shared/services/startup.service";
+
+@Component({
+    selector: 'staticwebapp-finder',
+    templateUrl: './staticwebapp-finder.component.html',
+    styleUrls: ['./staticwebapp-finder.component.scss']
+})
+export class StaticWebAppFinderComponent implements OnInit {
+
+    siteName: string;
+    loading: boolean = true;
+    error: string;
+  
+    matchingSites: Observer.ObserverContainerAppInfo[] = [];
+  
+    contentHeight: string;
+  
+    constructor(private _route: ActivatedRoute, private _router: Router, private _observerService: ObserverService, private _startupService: StartupService) {
+      this.contentHeight = window.innerHeight + 'px';
+    }
+  
+    ngOnInit() {
+      this.siteName = this._route.snapshot.params['staticwebapp'];
+  
+      this._observerService.getContainerApp(this.siteName).subscribe(observerContainerAppResponse => {
+        if (observerContainerAppResponse.details.toString() == "Unable to fetch data from Observer API : GetContainerApp"){
+          this.error = `There was an error trying to find container app ${this.siteName}`;
+          this.loading = false;  
+        }
+        else if (observerContainerAppResponse.details.length === 1) {
+          let matchingSite = observerContainerAppResponse.details[0];
+          this.navigateToSite(matchingSite);
+        }
+        else if (observerContainerAppResponse.details.length > 1) {
+          this.matchingSites = observerContainerAppResponse.details;
+        }
+  
+        this.loading = false;
+      }, (error: Response) => {
+        this.error = error.status == 404 ? `Static Web App with the name ${this.siteName} was not found` : `There was an error trying to find static web app ${this.siteName}`;
+        this.loading = false;
+      });
+    }
+  
+    navigateToSite(matchingSite: Observer.ObserverContainerAppInfo) {
+      let resourceArray: string[] = [
+        'subscriptions', matchingSite.SubscriptionName,
+        'resourceGroups', matchingSite.ResourceGroupName,
+        'providers', 'Microsoft.Web',
+        'staticSites', matchingSite.ContainerAppName];
+  
+      // resourceArray.push('home');
+      // resourceArray.push('category');
+  
+      this._router.navigate(resourceArray, { queryParamsHandling: 'preserve' });
+    }
+  
+  }

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModuleWithProviders } from '@angular/compiler/src/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
+import { StaticWebAppFinderComponent } from './staticwebapp-finder/staticwebapp-finder.component';
+
+export const StaticWebAppAppModuleRoutes: ModuleWithProviders = RouterModule.forChild([
+  {
+    path: '',
+    component: StaticWebAppFinderComponent
+  }
+]);
+
+@NgModule({
+  imports: [
+    CommonModule,
+    StaticWebAppAppModuleRoutes,
+    SharedModule
+  ],
+  declarations: [StaticWebAppFinderComponent]
+})
+export class StaticWebAppModule { }

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -8,6 +8,11 @@ namespace Observer {
         containerAppName: string;
         details: ObserverContainerAppInfo[];
     }
+
+    export interface ObserverStaticWebAppResponse {
+        details: ObserverStaticWebAppInfo[];
+        
+    }
   
     export interface ObserverSiteInfo {
         SiteName: string;
@@ -38,6 +43,21 @@ namespace Observer {
         ServiceAddress: string;
         Kind: string;
         IsInAppNamespace: boolean;
+    }
+
+    export interface ObserverStaticWebAppInfo {
+        ApiKey: string;
+        Branch: string;
+        BuildInfo: any[];
+        CustomDomains: string;
+        DefaultHostname: string;
+        GeoMasterInstance: string;
+        Name: string;
+        RepositoryUrl: string;
+        ResourceGroupName: string;
+        Sku: string;
+        StorageRing: string;
+        SubscriptionName: string;
     }
 
     export interface ObserverSiteDetailsResponse {

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -10,6 +10,7 @@ namespace Observer {
     }
 
     export interface ObserverStaticWebAppResponse {
+        defaultHostNameOrAppName: string;
         details: ObserverStaticWebAppInfo[];
         
     }

--- a/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
+++ b/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
@@ -5,7 +5,6 @@ import { AseService } from "../services/ase.service";
 import { ResourceService } from "../services/resource.service";
 import { ObserverService } from "../services/observer.service";
 import { StaticWebAppService } from "../services/staticwebapp.service";
-import { ActivatedRoute } from "@angular/router";
 
 export let ResourceServiceFactory = (startupService: StartupService, observerService: ObserverService) => {
     let serviceInputs = startupService.getInputs();

--- a/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
+++ b/AngularApp/projects/applens/src/app/shared/providers/resource.service.provider.ts
@@ -4,6 +4,8 @@ import { ContainerAppService } from "../services/containerapp.service";
 import { AseService } from "../services/ase.service";
 import { ResourceService } from "../services/resource.service";
 import { ObserverService } from "../services/observer.service";
+import { StaticWebAppService } from "../services/staticwebapp.service";
+import { ActivatedRoute } from "@angular/router";
 
 export let ResourceServiceFactory = (startupService: StartupService, observerService: ObserverService) => {
     let serviceInputs = startupService.getInputs();
@@ -22,6 +24,9 @@ export let ResourceServiceFactory = (startupService: StartupService, observerSer
         case 'Microsoft.Web/containerApps':
         case 'Microsoft.App/containerApps':
             service = new ContainerAppService(serviceInputs, observerService);
+            break;
+        case 'Microsoft.Web/staticSites':
+            service = new StaticWebAppService(serviceInputs, observerService);
             break;
         default:
             service = new ResourceService(serviceInputs);

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -34,6 +34,16 @@ export class ObserverService {
       }));
   }
 
+  public getStaticWebApp(staticWebAppHostName: string): Observable<Observer.ObserverStaticWebAppResponse> {
+    return this._diagnosticApiService.get<Observer.ObserverStaticWebAppResponse>(`api/staticwebapps/${staticWebAppHostName}`).pipe(
+      map((staticWebAppRes: Observer.ObserverStaticWebAppResponse) => {
+        if (staticWebAppRes && staticWebAppRes.details && isArray(staticWebAppRes.details)) {
+          staticWebAppRes.details.map(info => info);
+        }
+        return staticWebAppRes;
+      }));
+  }
+
   public getAse(ase: string): Observable<Observer.ObserverAseResponse> {
     return this._diagnosticApiService.get<Observer.ObserverAseResponse>(`api/hostingEnvironments/${ase}`);
   }

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -34,8 +34,8 @@ export class ObserverService {
       }));
   }
 
-  public getStaticWebApp(staticWebAppHostName: string): Observable<Observer.ObserverStaticWebAppResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverStaticWebAppResponse>(`api/staticwebapps/${staticWebAppHostName}`).pipe(
+  public getStaticWebApp(defaultHostNameOrAppName: string): Observable<Observer.ObserverStaticWebAppResponse> {
+    return this._diagnosticApiService.get<Observer.ObserverStaticWebAppResponse>(`api/staticwebapps/${defaultHostNameOrAppName}`).pipe(
       map((staticWebAppRes: Observer.ObserverStaticWebAppResponse) => {
         if (staticWebAppRes && staticWebAppRes.details && isArray(staticWebAppRes.details)) {
           staticWebAppRes.details.map(info => info);

--- a/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
@@ -17,8 +17,7 @@ export class StaticWebAppService extends ResourceService {
     }
 
     public startInitializationObservable() {
-        //To do, change API tp get by app name
-        this._initialized = this._observerApiService.getStaticWebApp("")
+        this._initialized = this._observerApiService.getStaticWebApp(this._armResource.resourceName)
             .pipe(map((observerResponse: Observer.ObserverStaticWebAppResponse) => {
                 this._observerResource = this._staticWebAppObject = this.getStaticWebAppFromObserverResponse(observerResponse);
                 this._currentResource.next(this._staticWebAppObject);
@@ -34,19 +33,6 @@ export class StaticWebAppService extends ResourceService {
             return resource;
         }));
     }
-
-    // private getHostName(): string {
-    //     //Get hostName from route param(/staticWebApp/:staticWebApp) or from query string
-    //     let hostName = "";
-    //     let queryParams = new URLSearchParams(window.location.search);
-    //     if (this._activatedRoute.firstChild && this._activatedRoute.firstChild.firstChild && this._activatedRoute.firstChild.firstChild.firstChild) {
-    //         const route = this._activatedRoute.firstChild.firstChild.firstChild;
-    //         hostName = route.snapshot.params["staticwebapp"];
-    //     } else if (queryParams.has("defaultHostName")) {
-    //         hostName = queryParams.get("defaultHostName");
-    //     }
-    //     return hostName;
-    // }
 
     private getStaticWebAppFromObserverResponse(observerResponse: Observer.ObserverStaticWebAppResponse): Observer.ObserverStaticWebAppInfo {
         const response = observerResponse.details.find(staticWebApp =>

--- a/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable } from "@angular/core";
+import { of as observableOf, BehaviorSubject, Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { ResourceInfo, ResourceServiceInputs, RESOURCE_SERVICE_INPUTS } from "../models/resources";
+import { ObserverService } from "./observer.service";
+import { ResourceService } from "./resource.service";
+
+@Injectable()
+export class StaticWebAppService extends ResourceService {
+    private _currentResource: BehaviorSubject<any> = new BehaviorSubject(null);
+
+    private _staticWebAppObject: Observer.ObserverStaticWebAppInfo;
+
+
+    constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
+        super(inputs);
+    }
+
+    public startInitializationObservable() {
+        //To do, change API tp get by app name
+        this._initialized = this._observerApiService.getStaticWebApp("")
+            .pipe(map((observerResponse: Observer.ObserverStaticWebAppResponse) => {
+                this._observerResource = this._staticWebAppObject = this.getStaticWebAppFromObserverResponse(observerResponse);
+                this._currentResource.next(this._staticWebAppObject);
+                return new ResourceInfo(this.getResourceName(), this.imgSrc, this.displayName, this.getCurrentResourceId());
+            }))
+    }
+
+    public getCurrentResource(): Observable<any> {
+        return this._currentResource.pipe(map(currentResource => {
+            const resource = { ...currentResource };
+            //BuildInfo is an array of inputs, hide it for now
+            delete resource["BuildInfo"];
+            return resource;
+        }));
+    }
+
+    // private getHostName(): string {
+    //     //Get hostName from route param(/staticWebApp/:staticWebApp) or from query string
+    //     let hostName = "";
+    //     let queryParams = new URLSearchParams(window.location.search);
+    //     if (this._activatedRoute.firstChild && this._activatedRoute.firstChild.firstChild && this._activatedRoute.firstChild.firstChild.firstChild) {
+    //         const route = this._activatedRoute.firstChild.firstChild.firstChild;
+    //         hostName = route.snapshot.params["staticwebapp"];
+    //     } else if (queryParams.has("defaultHostName")) {
+    //         hostName = queryParams.get("defaultHostName");
+    //     }
+    //     return hostName;
+    // }
+
+    private getStaticWebAppFromObserverResponse(observerResponse: Observer.ObserverStaticWebAppResponse): Observer.ObserverStaticWebAppInfo {
+        const response = observerResponse.details.find(staticWebApp =>
+            staticWebApp.SubscriptionName.toLowerCase() === this._armResource.subscriptionId.toLowerCase() &&
+            staticWebApp.ResourceGroupName.toLowerCase() === this._armResource.resourceGroup.toLowerCase());
+        return response;
+    }
+}

--- a/AngularApp/projects/applens/src/app/shared/shared.module.ts
+++ b/AngularApp/projects/applens/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { FabButtonModule, FabCalloutModule, FabDialogModule, FabPanelModule, Fab
 import { L1SideNavComponent } from './components/l1-side-nav/l1-side-nav.component';
 import { UserSettingService } from '../modules/dashboard/services/user-setting.service';
 import { ApplensDocsComponent } from './components/applens-docs/applens-docs.component';
+import { StaticWebAppService } from './services/staticwebapp.service';
 
 @NgModule({
   imports: [
@@ -52,6 +53,7 @@ export class SharedModule {
         ResourceService,
         SiteService,
         ContainerAppService,
+        StaticWebAppService,
         AseService,
         ApplensGlobals,
         StartupService,

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -29,6 +29,13 @@ namespace AppLensV3
             return await GetContainerAppInternal(containerAppName);
         }
 
+        [HttpGet("api/staticwebapps/{staticWebAppName}")]
+        [HttpOptions("api/staticwebapps/{staticWebAppName}")]
+        public async Task<IActionResult> GetStaticWebApp(string staticWebAppName)
+        {
+            return await GetStaticWebAppInternal(staticWebAppName);
+        }
+
         [HttpGet]
         [Route("api/stamps/{stamp}/sites/{siteName}")]
         public async Task<IActionResult> GetSite(string stamp, string siteName)
@@ -108,6 +115,25 @@ namespace AppLensV3
             };
 
             if (containerAppsResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                return NotFound(response);
+            }
+
+            return Ok(response);
+        }
+
+        private async Task<IActionResult> GetStaticWebAppInternal(string staticWebAppHostName)
+        {
+            var staticWebAppsTask = _observerService.GetStaticWebApp(staticWebAppHostName);
+            var staticWebAppsResponse = await staticWebAppsTask;
+
+            var response = new
+            {
+                StaticWebAppHostName = staticWebAppHostName,
+                Details = staticWebAppsResponse.Content
+            };
+
+            if (staticWebAppsResponse.StatusCode == HttpStatusCode.NotFound)
             {
                 return NotFound(response);
             }

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -29,11 +29,11 @@ namespace AppLensV3
             return await GetContainerAppInternal(containerAppName);
         }
 
-        [HttpGet("api/staticwebapps/{staticWebAppName}")]
-        [HttpOptions("api/staticwebapps/{staticWebAppName}")]
-        public async Task<IActionResult> GetStaticWebApp(string staticWebAppName)
+        [HttpGet("api/staticwebapps/{defaultHostNameOrAppName}")]
+        [HttpOptions("api/staticwebapps/{defaultHostNameOrAppName}")]
+        public async Task<IActionResult> GetStaticWebApp(string defaultHostNameOrAppName)
         {
-            return await GetStaticWebAppInternal(staticWebAppName);
+            return await GetStaticWebAppInternal(defaultHostNameOrAppName);
         }
 
         [HttpGet]
@@ -122,14 +122,14 @@ namespace AppLensV3
             return Ok(response);
         }
 
-        private async Task<IActionResult> GetStaticWebAppInternal(string staticWebAppHostName)
+        private async Task<IActionResult> GetStaticWebAppInternal(string defaultHostNameOrAppName)
         {
-            var staticWebAppsTask = _observerService.GetStaticWebApp(staticWebAppHostName);
+            var staticWebAppsTask = _observerService.GetStaticWebApp(defaultHostNameOrAppName);
             var staticWebAppsResponse = await staticWebAppsTask;
 
             var response = new
             {
-                StaticWebAppHostName = staticWebAppHostName,
+                DefaultHostNameOrAppName = defaultHostNameOrAppName,
                 Details = staticWebAppsResponse.Content
             };
 

--- a/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
@@ -64,9 +64,9 @@ namespace AppLensV3
             return GetSiteInternal(stamp, siteName);
         }
 
-        public async Task<ObserverResponse> GetStaticWebApp(string staticWebAppHostName)
+        public async Task<ObserverResponse> GetStaticWebApp(string defaultHostNameOrAppName)
         {
-            return await GetStaticWebAppInternal(staticWebAppHostName);
+            return await GetStaticWebAppInternal(defaultHostNameOrAppName);
         }
 
         private Task<ObserverResponse> GetSiteInternal(string stamp, string siteName)
@@ -81,9 +81,9 @@ namespace AppLensV3
             return GetAppInternal(path);
         }
 
-        private Task<ObserverResponse> GetStaticWebAppInternal(string staticWebAppHostName)
+        private Task<ObserverResponse> GetStaticWebAppInternal(string defaultHostNameOrAppName)
         {
-            var path = $"partner/jamstack/{staticWebAppHostName}";
+            var path = $"partner/jamstack/{defaultHostNameOrAppName}";
             return GetAppInternal(path);
         }
 

--- a/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
@@ -64,9 +64,31 @@ namespace AppLensV3
             return GetSiteInternal(stamp, siteName);
         }
 
-        private async Task<ObserverResponse> GetSiteInternal(string stamp, string siteName)
+        public async Task<ObserverResponse> GetStaticWebApp(string staticWebAppHostName)
+        {
+            return await GetStaticWebAppInternal(staticWebAppHostName);
+        }
+
+        private Task<ObserverResponse> GetSiteInternal(string stamp, string siteName)
         {
             var path = stamp != null ? $"stamps/{stamp}/sites/{siteName}" : $"sites/{siteName}";
+            return GetAppInternal(path);
+        }
+
+        private Task<ObserverResponse> GetContainerAppInternal(string containerAppName)
+        {
+            var path = $"partner/containerapp/{containerAppName}";
+            return GetAppInternal(path);
+        }
+
+        private Task<ObserverResponse> GetStaticWebAppInternal(string staticWebAppHostName)
+        {
+            var path = $"partner/jamstack/{staticWebAppHostName}";
+            return GetAppInternal(path);
+        }
+
+        private async Task<ObserverResponse> GetAppInternal(string path)
+        {
             var siteDetailsResponse = await ExecuteDiagCall(path);
             var contentJson = await siteDetailsResponse.Content.ReadAsStringAsync();
             var content = JsonConvert.DeserializeObject(contentJson);
@@ -77,18 +99,6 @@ namespace AppLensV3
             };
         }
 
-        private async Task<ObserverResponse> GetContainerAppInternal(string containerAppName)
-        {
-            var path = $"partner/containerapp/{containerAppName}";
-            var containerAppDetailsResponse = await ExecuteDiagCall(path);
-            var contentJson = await containerAppDetailsResponse.Content.ReadAsStringAsync();
-            var content = JsonConvert.DeserializeObject(contentJson);
-            return new ObserverResponse
-            {
-                StatusCode = containerAppDetailsResponse.StatusCode,
-                Content = content
-            };
-        }
 
         private async Task<HttpResponseMessage> ExecuteDiagCall(string path)
         {

--- a/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
@@ -8,6 +8,8 @@ namespace AppLensV3
 
         Task<ObserverResponse> GetContainerApp(string containerAppName);
 
+        Task<ObserverResponse> GetStaticWebApp(string staticWebAppHostName);
+
         Task<ObserverResponse> GetSite(string stamp, string siteName, bool details = false);
 
         Task<ObserverResponse> GetResourceGroup(string site);

--- a/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
@@ -8,7 +8,7 @@ namespace AppLensV3
 
         Task<ObserverResponse> GetContainerApp(string containerAppName);
 
-        Task<ObserverResponse> GetStaticWebApp(string staticWebAppHostName);
+        Task<ObserverResponse> GetStaticWebApp(string defaultHostNameOrAppName);
 
         Task<ObserverResponse> GetSite(string stamp, string siteName, bool details = false);
 

--- a/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
@@ -130,6 +130,15 @@ namespace AppLensV3
         }
 
         /// <summary>
+        /// Get static web app details by staticWebAppHostName
+        /// </summary>
+        /// <param name="staticWebAppHostName">Host Name of Static Web App</param>
+        public async Task<ObserverResponse> GetStaticWebApp(string staticWebHostAppName)
+        {
+            return await GetStaticWebAppInternal(SupportObserverApiEndpoint + "partner/jamstack/" + staticWebHostAppName);
+        }
+
+        /// <summary>
         /// Get site details for siteName
         /// </summary>
         /// <param name="stamp">Stamp</param>
@@ -140,7 +149,22 @@ namespace AppLensV3
             return await GetSiteInternal(SupportObserverApiEndpoint + "stamps/" + stamp + "/sites/" + siteName + (details ? "/details" : "/adminsites"));
         }
 
-        private async Task<ObserverResponse> GetSiteInternal(string endpoint)
+        private Task<ObserverResponse> GetSiteInternal(string endpoint)
+        {
+            return GetAppInternal(endpoint, "GetAdminSite");
+        }
+
+        private Task<ObserverResponse> GetContainerAppInternal(string endpoint)
+        {
+            return GetAppInternal(endpoint, "GetContainerApp");
+        }
+
+        private Task<ObserverResponse> GetStaticWebAppInternal(string endpoint)
+        {
+            return GetAppInternal(endpoint, "GetStaticWebApp");
+        }
+
+        private async Task<ObserverResponse> GetAppInternal(string endpoint, string apiName)
         {
             var request = new HttpRequestMessage()
             {
@@ -151,24 +175,11 @@ namespace AppLensV3
             request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
             var response = await _httpClient.SendAsync(request);
 
-            ObserverResponse res = await CreateObserverResponse(response, "GetAdminSite");
+            ObserverResponse res = await CreateObserverResponse(response, apiName);
             return res;
         }
 
-        private async Task<ObserverResponse> GetContainerAppInternal(string endpoint)
-        {
-            var request = new HttpRequestMessage()
-            {
-                RequestUri = new Uri(endpoint),
-                Method = HttpMethod.Get
-            };
 
-            request.Headers.Add("Authorization", await GetSupportObserverAccessToken());
-            var response = await _httpClient.SendAsync(request);
-
-            ObserverResponse res = await CreateObserverResponse(response, "GetContainerApp");
-            return res;
-        }
 
         /// <summary>
         /// Get resource group for site

--- a/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
@@ -130,12 +130,12 @@ namespace AppLensV3
         }
 
         /// <summary>
-        /// Get static web app details by staticWebAppHostName
+        /// Get static web app details by static web App default host name or app name
         /// </summary>
-        /// <param name="staticWebAppHostName">Host Name of Static Web App</param>
-        public async Task<ObserverResponse> GetStaticWebApp(string staticWebHostAppName)
+        /// <param name="defaultHostNameOrAppName">Host Name of Static Web App</param>
+        public async Task<ObserverResponse> GetStaticWebApp(string defaultHostNameOrAppName)
         {
-            return await GetStaticWebAppInternal(SupportObserverApiEndpoint + "partner/jamstack/" + staticWebHostAppName);
+            return await GetStaticWebAppInternal(SupportObserverApiEndpoint + "partner/jamstack/" + defaultHostNameOrAppName);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is for enabling searching Static Web App by app name or default host name via Observer

Now in landing page dropdown, we have a new option "Static Web App"
![image](https://user-images.githubusercontent.com/23129934/163450706-57fd83b0-e39e-486c-9f76-1b92760d3498.png)

If multiple app with same name, it has the same experience as Web App and Container App,
![image](https://user-images.githubusercontent.com/23129934/163450907-936b322e-cc2f-4140-b740-98003cf10f18.png)

In home page, it shows info fetched from Observer
![image](https://user-images.githubusercontent.com/23129934/163451062-83806b77-4490-4644-ab1a-0814b07f5d78.png)


