### PR TITLE
Update source location of detector and gist templates

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -13,6 +13,7 @@ import { flatMap, map } from 'rxjs/operators'
 import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Package } from '../../../shared/models/package';
 import { GithubApiService } from '../../../shared/services/github-api.service';
+import { DetectorGistApiService } from '../../../shared/services/detectorgist-template-api.service';
 import { ResourceService } from '../../../shared/services/resource.service';
 import { ApplensDiagnosticService } from '../services/applens-diagnostic.service';
 import { RecommendedUtterance } from '../../../../../../diagnostic-data/src/public_api';
@@ -317,7 +318,7 @@ export class OnboardingFlowComponent implements OnInit {
   selectedKey: string = '';
 
 
-  constructor(private cdRef: ChangeDetectorRef, private githubService: GithubApiService,
+  constructor(private cdRef: ChangeDetectorRef, private githubService: GithubApiService, private detectorGistApiService: DetectorGistApiService,
     private diagnosticApiService: ApplensDiagnosticService, private _diagnosticApi: DiagnosticApiService, private resourceService: ResourceService,
     private _detectorControlService: DetectorControlService, private _adalService: AdalService,
     public ngxSmartModalService: NgxSmartModalService, private _telemetryService: TelemetryService, private _activatedRoute: ActivatedRoute,
@@ -1704,7 +1705,7 @@ export class OnboardingFlowComponent implements OnInit {
     switch (this.mode) {
       case DevelopMode.Create: {
         let templateFileName = (this.gistMode ? "Gist_" : "Detector_") + this.resourceService.templateFileName;
-        detectorFile = this.githubService.getTemplate(templateFileName);
+        detectorFile = this.detectorGistApiService.getTemplate(templateFileName);
         this.fileName = "new.csx";
         this.startTime = this._detectorControlService.startTime;
         this.endTime = this._detectorControlService.endTime;

--- a/AngularApp/projects/applens/src/app/shared/services/detectorgist-template-api.service.spec.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/detectorgist-template-api.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { GithubApiService } from './github-api.service';
+
+describe('GithubApiService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GithubApiService]
+    });
+  });
+
+  it('should be created', inject([GithubApiService], (service: GithubApiService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/AngularApp/projects/applens/src/app/shared/services/detectorgist-template-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/detectorgist-template-api.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { DiagnosticApiService } from './diagnostic-api.service';
+import { Observable, of } from 'rxjs';
+import { Commit } from '../models/commit';
+import { Dependency } from '../models/package';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class DetectorGistApiService {
+
+  constructor(private _diagnosticApiService: DiagnosticApiService) { }
+
+  public getTemplate(name: string): Observable<string> {
+    return this._diagnosticApiService.get<string>(`api/templates/${name}`, true);
+  }
+}

--- a/AngularApp/projects/applens/src/app/shared/shared.module.ts
+++ b/AngularApp/projects/applens/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import { UserSettingService } from '../modules/dashboard/services/user-setting.s
 import { ApplensDocsComponent } from './components/applens-docs/applens-docs.component';
 import { StaticWebAppService } from './services/staticwebapp.service';
 import { StampService } from './services/stamp.service';
+import { DetectorGistApiService } from './services/detectorgist-template-api.service';
 
 @NgModule({
   imports: [
@@ -65,7 +66,8 @@ export class SharedModule {
         CacheService,
         AadAuthGuard,
         CaseCleansingApiService,
-        UserSettingService
+        UserSettingService,
+        DetectorGistApiService
       ]
     }
   }

--- a/ApplensBackend/AppLensV3.csproj
+++ b/ApplensBackend/AppLensV3.csproj
@@ -59,5 +59,11 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="Templates\*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -78,6 +78,7 @@ namespace AppLensV3
             services.AddSingleton<IHealthCheckService, HealthCheckService>();
             services.AddSingleton<ISurveysService, SurveysService>();
             services.AddSingleton<ICosmosDBUserSettingHandler, CosmosDBUserSettingHandler>();
+            services.AddSingleton<IDetectorGistTemplateService, TemplateService>();
 
             services.AddMemoryCache();
             services.AddMvc();

--- a/ApplensBackend/Controllers/DetectorGistTemplateController.cs
+++ b/ApplensBackend/Controllers/DetectorGistTemplateController.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AppLensV3.Helpers;
+using AppLensV3.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AppLensV3.Controllers
+{
+    /// <summary>
+    /// API to deliever templates for detector and gists.
+    /// </summary>
+    [Produces("application/json")]
+    [Route("api/templates")]
+    //[Authorize(Policy = "ApplensAccess")]
+    public class DetectorGistTemplateController : Controller
+    {
+        private IDetectorGistTemplateService templateService;
+
+        public DetectorGistTemplateController(IDetectorGistTemplateService templateService)
+        {
+            this.templateService = templateService;
+        }
+
+        /// <summary>
+        /// Get template.
+        /// </summary>
+        /// <param name="name">File name.</param>
+        /// <returns>Task for getting template.</returns>
+        [HttpGet("{name}")]
+        public async Task<IActionResult> GetTemplate(string name)
+        {
+            var cTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(DetectorGistTemplateServiceConstants.ApiTimeoutInMilliseconds));
+            string content = await templateService.GetTemplate($"{name}.csx", cTokenSource.Token);
+            return Ok(content);
+        }
+
+        /// <summary>
+        /// Get template.
+        /// </summary>
+        /// <param name="name">File name.</param>
+        /// <param name="fileExtension">File extension.</param>
+        /// <returns>Task for getting template.</returns>
+        [HttpGet("{name}/{fileExtension}")]
+        public async Task<IActionResult> GetTemplate(string name, string fileExtension)
+        {
+            var cTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(DetectorGistTemplateServiceConstants.ApiTimeoutInMilliseconds));
+            string content = await templateService.GetTemplate($"{name}.{fileExtension}", cTokenSource.Token);
+            return Ok(content);
+        }
+    }
+}

--- a/ApplensBackend/Helpers/Constants.cs
+++ b/ApplensBackend/Helpers/Constants.cs
@@ -71,4 +71,11 @@ namespace AppLensV3.Helpers
         public const string IsTemporaryAccessHeader = "IsTemporaryAccess";
         public const string TemporaryAccessExpiresHeader = "TemporaryAccessExpires";
     }
+
+    public static class DetectorGistTemplateServiceConstants
+    {
+        public const int MaxDiskReadTimeInMilliseconds = 3 * 60 * 1000; // 3 minutes
+        public const int ApiTimeoutInMilliseconds = 15 * 1000; // 15 seconds
+        public const int MaxCacheTimeInDays = 30;
+    }
 }

--- a/ApplensBackend/Services/DetectorGistTemplateService/IDetectorGistTemplateService.cs
+++ b/ApplensBackend/Services/DetectorGistTemplateService/IDetectorGistTemplateService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Services
+{
+    public interface IDetectorGistTemplateService
+    {
+        Task<string> GetTemplate(string name, CancellationToken cancellationToken);
+    }
+}

--- a/ApplensBackend/Services/DetectorGistTemplateService/TemplateService.cs
+++ b/ApplensBackend/Services/DetectorGistTemplateService/TemplateService.cs
@@ -1,0 +1,80 @@
+﻿// <copyright file="TemplateService.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AppLensV3.Helpers;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace AppLensV3.Services
+{
+
+    public class TemplateService : IDetectorGistTemplateService
+    {
+        private readonly IMemoryCache memoryCache;
+        private Task templateTask;
+
+        public TemplateService(IMemoryCache detectorGistCache)
+        {
+            memoryCache = detectorGistCache;
+            templateTask = Task.Run(() =>
+            {
+                return FillDetectorGistCache();
+            });
+        }
+
+        public async Task<string> GetTemplate(string name, CancellationToken cancellationToken)
+        {
+            if (!templateTask.IsCompleted)
+            {
+                await templateTask;
+            }
+
+            if (!memoryCache.TryGetValue(name, out string template))
+            {
+                throw new FileNotFoundException($"Cannot find template with name: {name}");
+            }
+
+            return template;
+        }
+
+        private async Task FillDetectorGistCache()
+        {
+            var exceptions = new List<Exception>();
+            var cTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            var cToken = cTokenSource.Token;
+
+            var files = Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "Templates"));
+            foreach (var file in files)
+            {
+                try
+                {
+                    var templateContent = await File.ReadAllTextAsync(file, cToken);
+
+                    memoryCache.Set(Path.GetFileName(file), templateContent, new MemoryCacheEntryOptions
+                    {
+                        AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(DetectorGistTemplateServiceConstants.MaxCacheTimeInDays)
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError($"Error in TemplateService File: {file} ExceptionType {ex.GetType()} Exception Message: {ex.Message}");
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+    }
+}

--- a/ApplensBackend/Templates/Detector_ApiManagementService.csx
+++ b/ApplensBackend/Templates/Detector_ApiManagementService.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<ApiManagementService> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        <YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[ApiManagementServiceFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ApiManagementService> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "YOUR_KUSTO_CLUSTER", "YOUR_KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AppInsights.csx
+++ b/ApplensBackend/Templates/Detector_AppInsights.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "microsoft.insights", resourceTypeName: "components")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AppServiceCertificate.csx
+++ b/ApplensBackend/Templates/Detector_AppServiceCertificate.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<AppServiceCertificate> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        <YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[AppServiceCertificateFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<AppServiceCertificate> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AppServiceDomain.csx
+++ b/ApplensBackend/Templates/Detector_AppServiceDomain.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<AppServiceDomain> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        <YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[AppServiceDomainFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<AppServiceDomain> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ArcAppliance.csx
+++ b/ApplensBackend/Templates/Detector_ArcAppliance.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        YOUR_TABLE_NAME
+        | where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+        YOUR_QUERY
+    ";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ResourceConnector", resourceTypeName: "appliances")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KustoClusterName", "KustoDatabaseName", null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ArcK8s.csx
+++ b/ApplensBackend/Templates/Detector_ArcK8s.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        cluster('CdbSupport').database('Support').<YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[ArmResourceFilter(provider: "Microsoft.Kubernetes", resourceTypeName: "connectedClusters")]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_Automation.csx
+++ b/ApplensBackend/Templates/Detector_Automation.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Automation", resourceTypeName: "automation")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AzurePortal.csx
+++ b/ApplensBackend/Templates/Detector_AzurePortal.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.AzurePortal", resourceTypeName: "sessions")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AzureSqlServer.csx
+++ b/ApplensBackend/Templates/Detector_AzureSqlServer.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Sql", resourceTypeName: "servers")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KustoClusterName", "KustoDatabaseName", null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_AzureStackHub.csx
+++ b/ApplensBackend/Templates/Detector_AzureStackHub.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.AzureStack", resourceTypeName: "registrations")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KustoClusterName", "KustoDataBaseName", null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_Batch.csx
+++ b/ApplensBackend/Templates/Detector_Batch.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Batch", resourceTypeName: "batchAccounts")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_BotService.csx
+++ b/ApplensBackend/Templates/Detector_BotService.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.BotService", resourceTypeName: "botServices")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ClassicStorageAccount.csx
+++ b/ApplensBackend/Templates/Detector_ClassicStorageAccount.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ClassicStorage", resourceTypeName: "classicStorageAccounts")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ContainerApp.csx
+++ b/ApplensBackend/Templates/Detector_ContainerApp.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<ContainerApp> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        cluster('Aks').database('AKSprod').<YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[ContainerAppFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ContainerApp> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ContainerInstance.csx
+++ b/ApplensBackend/Templates/Detector_ContainerInstance.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerInstance", resourceTypeName: "containerGroups")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ContainerRegistry.csx
+++ b/ApplensBackend/Templates/Detector_ContainerRegistry.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerRegistry", resourceTypeName: "registries")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_CosmosDB.csx
+++ b/ApplensBackend/Templates/Detector_CosmosDB.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        cluster('CdbSupport').database('Support').<YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[ArmResourceFilter(provider: "Microsoft.DocumentDB", resourceTypeName: "databaseAccounts")]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_EventHub.csx
+++ b/ApplensBackend/Templates/Detector_EventHub.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.EventHub", resourceTypeName: "namespaces")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_FunctionApp.csx
+++ b/ApplensBackend/Templates/Detector_FunctionApp.csx
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<App> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+[AppFilter(AppType = AppType.FunctionApp, PlatformType = PlatformType.Windows | PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_HostingEnvironment.csx
+++ b/ApplensBackend/Templates/Detector_HostingEnvironment.csx
@@ -1,0 +1,24 @@
+private static string GetQuery(OperationContext<HostingEnvironment> cxt)
+{
+    return
+    $@"<YOUR_TABLE_NAME>
+        | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)}
+        | <YOUR_QUERY>";
+}
+
+[HostingEnvironmentFilter(HostingEnvironmentType = HostingEnvironmentType.All, PlatformType = PlatformType.Windows)]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<HostingEnvironment> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.InternalName),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ISE.csx
+++ b/ApplensBackend/Templates/Detector_ISE.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Logic", resourceTypeName: "integrationServiceEnvironments")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_KubernetesService.csx
+++ b/ApplensBackend/Templates/Detector_KubernetesService.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<AzureKubernetesService> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        cluster('Aks').database('AKSprod').<YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[AzureKubernetesServiceFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<AzureKubernetesService> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_LinuxApp.csx
+++ b/ApplensBackend/Templates/Detector_LinuxApp.csx
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<App> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+[AppFilter(AppType = AppType.ApiApp|AppType.MobileApp|AppType.WebApp, PlatformType = PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_LogAnalytics.csx
+++ b/ApplensBackend/Templates/Detector_LogAnalytics.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "microsoft.operationalinsights", resourceTypeName: "workspaces")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_LogSearchAlerts.csx
+++ b/ApplensBackend/Templates/Detector_LogSearchAlerts.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Insights", resourceTypeName: "scheduledQueryRules")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_LogicApp.csx
+++ b/ApplensBackend/Templates/Detector_LogicApp.csx
@@ -1,0 +1,27 @@
+private static string GetQuery(OperationContext<LogicApp> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        <YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[LogicAppFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<LogicApp> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_MachineLearningServices.csx
+++ b/ApplensBackend/Templates/Detector_MachineLearningServices.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.MachineLearningServices", resourceTypeName: "workspaces")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_MediaService.csx
+++ b/ApplensBackend/Templates/Detector_MediaService.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Media", resourceTypeName: "mediaservices")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_MetricAlerts.csx
+++ b/ApplensBackend/Templates/Detector_MetricAlerts.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Insights", resourceTypeName: "metricAlerts")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_MicrosoftAppContainerApp.csx
+++ b/ApplensBackend/Templates/Detector_MicrosoftAppContainerApp.csx
@@ -1,0 +1,26 @@
+private static string GetQuery(OperationContext<ContainerApp> cxt)
+{
+    return
+    $@"
+        let startTime = datetime({cxt.StartTime});
+        let endTime = datetime({cxt.EndTime});
+        <YOUR_TABLE_NAME>
+        | where Timestamp >= startTime and Timestamp <= endTime
+        | <YOUR_QUERY>";
+}
+
+[MicrosoftAppContainerAppFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ContainerApp> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_NetAppAccounts.csx
+++ b/ApplensBackend/Templates/Detector_NetAppAccounts.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.NetApp", resourceTypeName: "netAppAccounts")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_OpenShiftClusters.csx
+++ b/ApplensBackend/Templates/Detector_OpenShiftClusters.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.RedHatOpenShift", resourceTypeName: "openShiftClusters")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_OpenShiftManagedClusters.csx
+++ b/ApplensBackend/Templates/Detector_OpenShiftManagedClusters.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerService", resourceTypeName: "openShiftManagedClusters")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_RedisCache.csx
+++ b/ApplensBackend/Templates/Detector_RedisCache.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Cache", resourceTypeName: "redis")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KustoClusterName", "KustoDatabaseName", null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ServiceBus.csx
+++ b/ApplensBackend/Templates/Detector_ServiceBus.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ServiceBus", resourceTypeName: "namespaces")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_ServiceFabric.csx
+++ b/ApplensBackend/Templates/Detector_ServiceFabric.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.ServiceFabric", resourceTypeName: "clusters")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_SignalRService.csx
+++ b/ApplensBackend/Templates/Detector_SignalRService.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.SignalRService", resourceTypeName: "SignalR")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+} 

--- a/ApplensBackend/Templates/Detector_SpringCloudService.csx
+++ b/ApplensBackend/Templates/Detector_SpringCloudService.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.AppPlatform", resourceTypeName: "Spring")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_StampService.csx
+++ b/ApplensBackend/Templates/Detector_StampService.csx
@@ -1,0 +1,24 @@
+private static string GetQuery(OperationContext<Stamp> cxt)
+{
+    return
+    $@"<YOUR_TABLE_NAME>
+        | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)}
+        | <YOUR_QUERY>";
+}
+
+[StampFilter(Type = StampResourceType.All)]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<Stamp> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Name),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_StaticSites.csx
+++ b/ApplensBackend/Templates/Detector_StaticSites.csx
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Web", resourceTypeName: "staticSites")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_StorageAccount.csx
+++ b/ApplensBackend/Templates/Detector_StorageAccount.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Storage", resourceTypeName: "storageAccounts")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_VirtualMachineScaleSets.csx
+++ b/ApplensBackend/Templates/Detector_VirtualMachineScaleSets.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachineScaleSets")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_VirtualMachines
+++ b/ApplensBackend/Templates/Detector_VirtualMachines
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachines")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_VirtualMachines.csx
+++ b/ApplensBackend/Templates/Detector_VirtualMachines.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachines")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_WebApp.csx
+++ b/ApplensBackend/Templates/Detector_WebApp.csx
@@ -1,0 +1,24 @@
+private static string GetQuery(OperationContext<App> cxt)
+{
+    return
+    $@"<YOUR_TABLE_NAME>
+        | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)}
+        | <YOUR_QUERY>";
+}
+
+[AppFilter(AppType = AppType.WebApp, PlatformType = PlatformType.Windows, StackType = StackType.All)]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp.Name, null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_WebApp_Management.csx
+++ b/ApplensBackend/Templates/Detector_WebApp_Management.csx
@@ -1,0 +1,172 @@
+private static string OPERATION_NAME = "<YOUR_OPERATION_NAME>";  // eg:- Update, Delete, Swap etc.
+
+[AppFilter(AppType = AppType.All, PlatformType = PlatformType.Windows | PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "<YOUR_DETECTOR_NAME>", Author = "<YOUR_ALIAS>", Description = "Checks for all management operation of a given type and finds out how many of them succeeded, failed and prints out details of the failed operations")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
+{
+    var tblOperations = await dp.Kusto.ExecuteQuery(GetManagementOperations(cxt, OPERATION_NAME), cxt.Resource.Stamp.Name, null, "GetManagementOperations");
+    
+    res.AddDataSummary(GetOperationSummary(tblOperations));
+
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = GetOperationsTimeline(tblOperations),
+        RenderingProperties = new TimeSeriesRendering() {
+            Title = "Operations Timeline",
+            Description = $"This shows all the operations of type {OPERATION_NAME}",
+            GraphType = TimeSeriesType.BarGraph
+        }
+    });
+
+    await ShowFailedOperationDetails(cxt, dp, tblOperations, res);
+    return res;
+}
+
+private static string GetManagementOperations(OperationContext<App> cxt, string operationType)
+{
+    string siteName = cxt.Resource.Name;
+    return
+        $@"AntaresAdminSubscriptionAuditEvents
+        | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)} 
+        | where SiteName startswith '{siteName}(' or SiteName =~ '{siteName}'
+        | where OperationType =~ '{operationType}'       
+        | project TIMESTAMP, SiteName, RequestId 
+        | join kind = leftouter (
+            AntaresAdminControllerEvents
+            | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)} 
+            | where SiteName =~ '{siteName}' or SiteName startswith '{siteName}(' 
+            | where Exception != ''
+            | project RequestId, Exception 
+            | summarize by RequestId, Exception
+        ) on RequestId 
+        | extend Status = iif(Exception != '', Exception, 'Success')
+        | project-away RequestId1, Exception ";
+}
+
+private static List<DataSummary> GetOperationSummary(DataTable tblOperations)
+{
+    var dataSummaries = new List<DataSummary>();
+    dataSummaries.Add(new DataSummary("Total",  tblOperations.Rows.Count.ToString(), "#368cbf"));
+    dataSummaries.Add(new DataSummary("Success",  tblOperations.Select("Status = 'Success'").Length.ToString(), "#2a860c"));
+    dataSummaries.Add(new DataSummary("Failed",  tblOperations.Select("Status <> 'Success'").Length.ToString(), "#e01f1f"));
+    return dataSummaries;
+    
+}
+
+private static DataTable GetOperationsTimeline(DataTable tblOperations)
+{
+    Dictionary<DateTime, Operation> dictionaryOperations = new Dictionary<DateTime, Operation>();
+    foreach (DataRow row in tblOperations.Rows)
+    {
+        var dateTime = RoundUp(DateTime.Parse(row["TIMESTAMP"].ToString()), TimeSpan.FromMinutes(5));
+        Operation operation = null;
+
+        if (!dictionaryOperations.ContainsKey(dateTime))
+        {
+            operation = new Operation();
+            dictionaryOperations.Add(dateTime, operation);
+        }
+        
+        operation = dictionaryOperations[dateTime];
+        if (row["Status"].ToString() != "Success")
+       {
+            operation.FailedCount++;
+        }
+        else
+        {
+            operation.SuccessCount++;
+        }
+    }
+
+    DataTable timeSeries = new DataTable();
+    timeSeries.Columns.AddRange(new DataColumn[]
+        {
+        new DataColumn("TIMESTAMP", typeof(System.DateTime)),
+        new DataColumn("Failed", typeof(int)),
+        new DataColumn("Succeeded", typeof(int))
+        });
+
+    foreach (var key in dictionaryOperations.Keys)
+    {
+        var newRow = timeSeries.NewRow();
+        newRow["TIMESTAMP"] = key;
+        newRow["Succeeded"] = dictionaryOperations[key].SuccessCount;
+        newRow["Failed"] = dictionaryOperations[key].FailedCount;
+        timeSeries.Rows.Add(newRow);
+        
+    }
+
+    return timeSeries;
+}
+
+private static async Task ShowFailedOperationDetails(OperationContext<App> cxt, DataProviders dp, DataTable tblOperations, Response res)
+{
+    var failedOperations = GetFailedOperationList(tblOperations, "Status <> 'Success'");
+    if (failedOperations.Count > 0)
+    {
+        var operationDetails  = await dp.Kusto.ExecuteQuery(GetFailedOperationDetailsQuery(cxt, failedOperations), cxt.Resource.Stamp.Name, null, "GetFailedOperationDetailsQuery");
+        foreach (var failedActivityId in failedOperations)
+       {
+            DataView failedOperationDetailsView = operationDetails.DefaultView;
+            failedOperationDetailsView.RowFilter = $" (ActivityId = '{failedActivityId}' or RequestId = '{failedActivityId}')";
+            DataTable failedOperationsTable = failedOperationDetailsView.ToTable("FailedOperations", true);
+            
+            res.Dataset.Add(new DiagnosticData()
+            {
+                Table = failedOperationsTable,
+                RenderingProperties = new TableRendering() {
+                    Title = $"Detailed Message for Operations with ActivitId = {failedActivityId}",
+                    Description = $"This shows all details for an operation with ActivityId - {failedActivityId}"
+                }
+            });  
+        }
+    }
+}
+
+private static List<string> GetFailedOperationList(DataTable tblOperations, string rowFilter)
+{
+    var failedOperations = new List<string>();
+    foreach(DataRow row in tblOperations.Select(rowFilter))
+    {
+        var activityId = row["RequestId"].ToString();
+        if (!failedOperations.Contains(activityId))
+        {
+            failedOperations.Add(activityId);
+        }
+    }
+    return failedOperations;
+}
+
+private static string GetFailedOperationDetailsQuery(OperationContext<App> cxt, List<string> ActivityIds)
+{
+    string siteName = cxt.Resource.Name;
+    var normalizedActivities = NormalizeActivityIdList(ActivityIds);    
+    return
+    $@"AntaresAdminControllerEvents
+        | where {Utilities.TimeAndTenantFilterQuery(cxt.StartTime, cxt.EndTime, cxt.Resource)}
+        | where SiteName =~ '{siteName}' or SiteName startswith '{siteName}(' 
+        | where ActivityId in ({normalizedActivities}) or RequestId in ({normalizedActivities})
+        | project TIMESTAMP, SiteName, EventId, ActivityId, RequestId, Exception, TraceMessage, Address
+        | order by TIMESTAMP asc";
+}
+
+private static string NormalizeActivityIdList(List<string> ActivityIds)
+{
+    var normalizedList = new List<string>();
+    foreach (var activity in ActivityIds)
+    {
+        normalizedList.Add($"'{activity}'");
+    }
+    return string.Join(",",normalizedList);
+}
+
+private static DateTime RoundUp(DateTime dt, TimeSpan d)
+{
+    return new DateTime((dt.Ticks + d.Ticks - 1) / d.Ticks * d.Ticks, dt.Kind);
+}
+
+class Operation
+{
+    public int FailedCount;
+    public int SuccessCount;
+}

--- a/ApplensBackend/Templates/Detector_WebPubSubService.csx
+++ b/ApplensBackend/Templates/Detector_WebPubSubService.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.SignalRService", resourceTypeName: "WebPubSub")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+} 

--- a/ApplensBackend/Templates/Detector_WorkflowApp.csx
+++ b/ApplensBackend/Templates/Detector_WorkflowApp.csx
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<App> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
+		YOUR_QUERY
+	";
+}
+
+[AppFilter(AppType = AppType.WorkflowApp, PlatformType = PlatformType.Windows | PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_devices.csx
+++ b/ApplensBackend/Templates/Detector_devices.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.HybridNetwork", resourceTypeName: "devices")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Detector_networkFunctions.csx
+++ b/ApplensBackend/Templates/Detector_networkFunctions.csx
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+private static string GetQuery(OperationContext<ArmResource> cxt)
+{
+    return
+    $@"
+		let startTime = datetime({cxt.StartTime});
+		let endTime = datetime({cxt.EndTime});
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
+		YOUR_QUERY
+	";
+}
+
+
+[ArmResourceFilter(provider: "Microsoft.HybridNetwork", resourceTypeName: "networkFunctions")]
+[Definition(Id = "YOUR_DETECTOR_ID", Name = "", Author = "YOUR_ALIAS", Description = "")]
+public async static Task<Response> Run(DataProviders dp, OperationContext<ArmResource> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
+    });
+
+    return res;
+}

--- a/ApplensBackend/Templates/Gist_ApiManagementService.csx
+++ b/ApplensBackend/Templates/Gist_ApiManagementService.csx
@@ -1,0 +1,6 @@
+
+[ApiManagementServiceFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_AppInsights.csx
+++ b/ApplensBackend/Templates/Gist_AppInsights.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "microsoft.insights", resourceTypeName: "components")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_AppServiceCertificate.csx
+++ b/ApplensBackend/Templates/Gist_AppServiceCertificate.csx
@@ -1,0 +1,6 @@
+
+[AppServiceCertificateFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_AppServiceDomain.csx
+++ b/ApplensBackend/Templates/Gist_AppServiceDomain.csx
@@ -1,0 +1,6 @@
+
+[AppServiceDomainFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_ArcAppliance.csx
+++ b/ApplensBackend/Templates/Gist_ArcAppliance.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.ResourceConnector", resourceTypeName: "appliances")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_ArcK8s.csx
+++ b/ApplensBackend/Templates/Gist_ArcK8s.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Kubernetes", resourceTypeName: "connectedClusters")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_Automation.csx
+++ b/ApplensBackend/Templates/Gist_Automation.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.Automation", resourceTypeName: "automation")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_AzurePortal.csx
+++ b/ApplensBackend/Templates/Gist_AzurePortal.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.AzurePortal", resourceTypeName: "sessions")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_AzureSqlServer.csx
+++ b/ApplensBackend/Templates/Gist_AzureSqlServer.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Sql", resourceTypeName: "servers")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_AzureStackHub.csx
+++ b/ApplensBackend/Templates/Gist_AzureStackHub.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.AzureStack", resourceTypeName: "registrations")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_Batch.csx
+++ b/ApplensBackend/Templates/Gist_Batch.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Batch", resourceTypeName: "batchAccounts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_BotService.csx
+++ b/ApplensBackend/Templates/Gist_BotService.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.BotService", resourceTypeName: "botServices")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_ClassicStorageAccount.csx
+++ b/ApplensBackend/Templates/Gist_ClassicStorageAccount.csx
@@ -1,0 +1,8 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.ClassicStorage", resourceTypeName: "classicStorageAccounts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_ContainerApp.csx
+++ b/ApplensBackend/Templates/Gist_ContainerApp.csx
@@ -1,0 +1,5 @@
+[ContainerAppFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_ContainerInstance.csx
+++ b/ApplensBackend/Templates/Gist_ContainerInstance.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerInstance", resourceTypeName: "containerGroups")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_ContainerRegistry.csx
+++ b/ApplensBackend/Templates/Gist_ContainerRegistry.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerRegistry", resourceTypeName: "registries")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_CosmosDB.csx
+++ b/ApplensBackend/Templates/Gist_CosmosDB.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.DocumentDB", resourceTypeName: "databaseAccounts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_EventHub.csx
+++ b/ApplensBackend/Templates/Gist_EventHub.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.EventHub", resourceTypeName: "namespaces")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_FunctionApp.csx
+++ b/ApplensBackend/Templates/Gist_FunctionApp.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[AppFilter(AppType = AppType.FunctionApp, PlatformType = PlatformType.Windows | PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_HostingEnvironment.csx
+++ b/ApplensBackend/Templates/Gist_HostingEnvironment.csx
@@ -1,0 +1,6 @@
+
+[HostingEnvironmentFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_ISE.csx
+++ b/ApplensBackend/Templates/Gist_ISE.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.Logic", resourceTypeName: "integrationServiceEnvironments")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_KubernetesService.csx
+++ b/ApplensBackend/Templates/Gist_KubernetesService.csx
@@ -1,0 +1,6 @@
+
+[AzureKubernetesServiceFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_LinuxApp.csx
+++ b/ApplensBackend/Templates/Gist_LinuxApp.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[AppFilter(AppType = AppType.ApiApp|AppType.MobileApp|AppType.WebApp, PlatformType = PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_LogAnalytics.csx
+++ b/ApplensBackend/Templates/Gist_LogAnalytics.csx
@@ -1,0 +1,11 @@
+  
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "microsoft.operationalinsights", resourceTypeName: "workspaces")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_LogSearchAlerts.csx
+++ b/ApplensBackend/Templates/Gist_LogSearchAlerts.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Insights", resourceTypeName: "scheduledQueryRules")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_LogicApp.csx
+++ b/ApplensBackend/Templates/Gist_LogicApp.csx
@@ -1,0 +1,6 @@
+
+[LogicAppFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_MachineLearningServices.csx
+++ b/ApplensBackend/Templates/Gist_MachineLearningServices.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.MachineLearningServices", resourceTypeName: "workspaces")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_MediaService.csx
+++ b/ApplensBackend/Templates/Gist_MediaService.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.Media", resourceTypeName: "mediaservices")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_MetricAlerts.csx
+++ b/ApplensBackend/Templates/Gist_MetricAlerts.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Insights", resourceTypeName: "metricAlerts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_MicrosoftAppContainerApp.csx
+++ b/ApplensBackend/Templates/Gist_MicrosoftAppContainerApp.csx
@@ -1,0 +1,5 @@
+[MicrosoftAppContainerAppFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_NetAppAccounts.csx
+++ b/ApplensBackend/Templates/Gist_NetAppAccounts.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.NetApp", resourceTypeName: "netAppAccounts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_OpenShiftClusters.csx
+++ b/ApplensBackend/Templates/Gist_OpenShiftClusters.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.RedHatOpenShift", resourceTypeName: "openShiftClusters")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_OpenShiftManagedClusters.csx
+++ b/ApplensBackend/Templates/Gist_OpenShiftManagedClusters.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.ContainerService", resourceTypeName: "openShiftManagedClusters")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_RedisCache.csx
+++ b/ApplensBackend/Templates/Gist_RedisCache.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Cache", resourceTypeName: "redis")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_ServiceBus.csx
+++ b/ApplensBackend/Templates/Gist_ServiceBus.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.ServiceBus", resourceTypeName: "namespaces")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_ServiceFabric.csx
+++ b/ApplensBackend/Templates/Gist_ServiceFabric.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.ServiceFabric", resourceTypeName: "clusters")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_SignalRService.csx
+++ b/ApplensBackend/Templates/Gist_SignalRService.csx
@@ -1,0 +1,11 @@
+
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.SignalRService", resourceTypeName: "SignalR")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_SpringCloudService.csx
+++ b/ApplensBackend/Templates/Gist_SpringCloudService.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.AppPlatform", resourceTypeName: "Spring")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_StampService.csx
+++ b/ApplensBackend/Templates/Gist_StampService.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[StampFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_StaticSites.csx
+++ b/ApplensBackend/Templates/Gist_StaticSites.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Web", resourceTypeName: "staticSites")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_StorageAccount.csx
+++ b/ApplensBackend/Templates/Gist_StorageAccount.csx
@@ -1,0 +1,8 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.Storage", resourceTypeName: "storageAccounts")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_VirtualMachineScaleSets.csx
+++ b/ApplensBackend/Templates/Gist_VirtualMachineScaleSets.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachineScaleSets")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_VirtualMachines
+++ b/ApplensBackend/Templates/Gist_VirtualMachines
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachines")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_VirtualMachines.csx
+++ b/ApplensBackend/Templates/Gist_VirtualMachines.csx
@@ -1,0 +1,10 @@
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.Compute", resourceTypeName: "virtualMachines")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_WebApp.csx
+++ b/ApplensBackend/Templates/Gist_WebApp.csx
@@ -1,0 +1,6 @@
+
+[AppFilter]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME> {
+
+}

--- a/ApplensBackend/Templates/Gist_WebPubSubService.csx
+++ b/ApplensBackend/Templates/Gist_WebPubSubService.csx
@@ -1,0 +1,11 @@
+
+using System;
+using System.Threading;
+
+
+[ArmResourceFilter(provider: "Microsoft.SignalRService", resourceTypeName: "WebPubSub")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_WorkflowApp.csx
+++ b/ApplensBackend/Templates/Gist_WorkflowApp.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[AppFilter(AppType = AppType.WorkflowApp, PlatformType = PlatformType.Windows | PlatformType.Linux, StackType = StackType.All)]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_devices.csx
+++ b/ApplensBackend/Templates/Gist_devices.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.HybridNetwork", resourceTypeName: "devices")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Gist_networkFunctions.csx
+++ b/ApplensBackend/Templates/Gist_networkFunctions.csx
@@ -1,0 +1,9 @@
+using System;
+using System.Threading;
+
+[ArmResourceFilter(provider: "Microsoft.HybridNetwork", resourceTypeName: "networkFunctions")]
+[Definition(Id = "<YOUR_GIST_ID>", Name = "", Author = "<YOUR_ALIAS>", Description = "")]
+public static class <YOUR_CLASS_NAME>
+{
+
+}

--- a/ApplensBackend/Templates/Kusto_Mapping.json
+++ b/ApplensBackend/Templates/Kusto_Mapping.json
@@ -1,0 +1,12 @@
+[{
+    "publicClusterName":"",
+    "publicDatabaseName":"",
+    "fairfaxClusterName":"",
+    "fairfaxDatabaseName":"",
+    "mooncakeClusterName":"",
+    "mooncakeDatabaseName":"",
+    "usNatClusterName":"",   
+    "usNatDatabaseName":"",
+    "usSecClusterName":"", 
+    "usSecDatabaseName":""
+}]

--- a/ApplensBackend/Templates/SystemInvokerTest.csx
+++ b/ApplensBackend/Templates/SystemInvokerTest.csx
@@ -1,0 +1,17 @@
+﻿private static string GetQuery(Dictionary<string, dynamic> cxt)
+{
+    return
+    $@"<YOUR_QUERY>";
+}
+
+[SystemFilter]
+[Definition(Id = "<YOUR_DETECTOR_ID>", Name = "<YOUR_DETECTOR_NAME>", Author = "<YOUR_ALIAS>", Description = "")]
+public async static Task<Response> Run(DataProviders dp, Dictionary<string, dynamic> cxt, Response res)
+{
+    res.Dataset.Add(new DiagnosticData()
+    {
+		Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt))
+    });
+
+    return res;
+}


### PR DESCRIPTION
- Copy over Detector and Gist templates from our Diagnostics project to here in our UI project as the new place for it to live
- Instead of reading templates using Github API, read from local disk as templates will be deployed along the UI project.
    - When we move this project to internal repo. No API changes need to be made. Everything will work as is.
- Update Angular project to use the template API for detectors and gist templates.