### PR TITLE
Durian UI Changes

### DIFF
--- a/AngularApp/projects/applens/src/app/app.module.ts
+++ b/AngularApp/projects/applens/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { AngularReactBrowserModule } from '@angular-react/core';
 import { ApplensAppinsightsTelemetryService } from './shared/services/applens-appinsights-telemetry.service';
 import { ApplensThemeService } from './shared/services/applens-theme.service';
 import { FabButtonModule, FabDialogModule, FabPanelModule, FabChoiceGroupModule } from '@angular-react/fabric';
+import { AppLensInterceptorService } from './shared/services/applens-http-interceptor.service';
 
 @Injectable()
 export class ValidResourceResolver implements Resolve<void>{
@@ -167,6 +168,11 @@ export const Routes = RouterModule.forRoot([
     FabChoiceGroupModule
   ],
   providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AppLensInterceptorService,
+      multi: true
+     },
     ValidResourceResolver,
     { provide: AppInsightsTelemetryService, useExisting: ApplensAppinsightsTelemetryService },
     AdalService,

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.html
@@ -1,6 +1,29 @@
-<fabric-feedback></fabric-feedback>
-<applens-header></applens-header>
-<side-nav></side-nav>
+<fabric-feedback *ngIf="!stillLoading && showDashboardContent"></fabric-feedback>
+<div *ngIf="!stillLoading && displayAlertDialog">
+  <fab-dialog [hidden]="!displayAlertDialog" [styles]="alertDialogStyles" [modalProps]="alertDialogProps" [forceFocusInsideTrap]="true">
+    <fab-dialog-content [title]="alertInfo.header" tabindex="1">
+      <p>{{alertInfo.details}}</p>
+    </fab-dialog-content>
+    <fab-dialog-footer>
+      <div class="mt-5">
+        <fab-primary-button (onClick)="handleUserResponse(alertInfo.confirmationOptions[0])" contentClass="mr-3" tabindex="1">
+          {{!showLoaderInDialog? alertInfo.confirmationOptions[0].label: 'Loading...'}}
+        </fab-primary-button>
+        <fab-default-button (onClick)="handleUserResponse(alertInfo.confirmationOptions[1])" tabindex="1">
+          {{alertInfo.confirmationOptions[1].label}}
+        </fab-default-button>
+      </div>
+      <div class="mt-5" *ngIf="displayErrorInDialog" tabindex="1" style="font-size:12px;color:red;">
+        {{errorInDialog}}
+      </div>
+    </fab-dialog-footer>
+  </fab-dialog>
+</div>
+<applens-header *ngIf="!stillLoading && showDashboardContent"></applens-header>
+<div class="main-row" style="margin: 0px auto; width: 100%;margin-top: 50px;" *ngIf="stillLoading">
+  <fab-spinner [size]="loaderSize" [label]="'Loading...'"></fab-spinner>
+</div>
+<side-nav *ngIf="!stillLoading && showDashboardContent"></side-nav>
 <!-- <l1-side-nav></l1-side-nav> -->
 <!-- <header class="main-header">
   <nav class="navbar navbar-fixed-top" role="navigation">
@@ -36,7 +59,7 @@
     </div>
   </nav>
 </header> -->
-<div class="dashboard-container content-under-header" [ngStyle]="getContainerStyle()">
+<div *ngIf="!stillLoading && showDashboardContent" class="dashboard-container content-under-header" [ngStyle]="getContainerStyle()">
   <div class="dashboard-content">
     <applens-preview-banner></applens-preview-banner>
     <comm-alert></comm-alert>
@@ -52,7 +75,7 @@
   </div>
 </div>
 
-<fab-panel [isOpen]="_applensGlobal.openResourceInfoPanel" [type]="type" [customWidth]="width" [isHiddenOnDismiss]="true"
+<fab-panel *ngIf="!stillLoading && showDashboardContent" [isOpen]="_applensGlobal.openResourceInfoPanel" [type]="type" [customWidth]="width" [isHiddenOnDismiss]="true"
 [styles]="panelStyles" [isLightDismiss]="true" [hasCloseButton]="true" [closeButtonAriaLabel]="'close'"
 (onDismiss)="dismissedHandler()">
 <div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-diagnostic.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-diagnostic.service.ts
@@ -16,6 +16,15 @@ export class ApplensDiagnosticService {
     if (!this.resourceId.startsWith("/")) this.resourceId = "/" + this.resourceId;
   }
 
+  public checkUserAccess() {
+    return this._diagnosticApi.checkUserAccess();
+  }
+
+  public unrelatedResourceConfirmation(overrideResourceUri?: string) {
+    let resourceId = overrideResourceUri ? overrideResourceUri : this._resourceService.getCurrentResourceId(true);
+    return this._diagnosticApi.unrelatedResourceConfirmation(resourceId);
+  }
+
   getDetector(detector: string, startTime: string, endTime: string, refresh: boolean = false, internalView: boolean = true, formQueryParams?: string, overrideResourceUri?: string): Observable<DetectorResponse> {
     let resourceId = overrideResourceUri ? overrideResourceUri : this._resourceService.getCurrentResourceId(true);
     if (!resourceId.startsWith('/')) resourceId = '/' + resourceId;

--- a/AngularApp/projects/applens/src/app/modules/main/main.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main.module.ts
@@ -6,7 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { OwlDateTimeModule, OwlNativeDateTimeModule, OWL_DATE_TIME_FORMATS } from 'ng-pick-datetime';
 import { OwlMomentDateTimeModule } from 'ng-pick-datetime-moment';
 import { CUSTOM_MOMENT_FORMATS } from '../../shared/models/datetime';
-import { FabDialogModule, FabButtonModule, FabTextFieldModule, FabCalloutModule, FabChoiceGroupModule, FabIconModule, FabDropdownModule, FabPanelModule} from '@angular-react/fabric';
+import { FabDialogModule, FabButtonModule, FabTextFieldModule, FabCalloutModule, FabChoiceGroupModule, FabIconModule, FabDropdownModule, FabPanelModule, FabSpinnerModule} from '@angular-react/fabric';
 import { DiagnosticDataModule } from 'diagnostic-data';
 import { SharedModule } from '../../shared/shared.module';
 
@@ -34,6 +34,7 @@ export const MainModuleRoutes : ModuleWithProviders = RouterModule.forChild([
     FabIconModule,
     FabDropdownModule,
     FabPanelModule,
+    FabSpinnerModule,
     DiagnosticDataModule,
     SharedModule
   ],

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
@@ -1,7 +1,13 @@
 <applens-header></applens-header>
 <div class="main-container content-under-header">
   <applens-preview-banner></applens-preview-banner>
-  <div class="main-row" style="margin: 0px auto;width: 1240px;">
+  <div class="main-row" style="margin: 0px auto; width: 100%;margin-bottom: 15px;" *ngIf="displayLoader">
+    <fab-spinner [size]="loaderSize" [label]="'Loading...'"></fab-spinner>
+  </div>
+  <div class="main-row" style="margin: 0 auto; width: 50%; text-align: center; margin-bottom: 15px; font-size: 18px; color: red;" *ngIf="displayUserAccessError">
+    {{userAccessErrorMessage}}
+  </div>
+  <div class="main-row" style="margin: 0px auto;width: 1240px;" *ngIf="!displayLoader">
     <div *ngIf="userGivenName" class="welcome-word">Welcome to AppLens, {{userGivenName}}!</div>
     <div class="main-content main-card" style="width: 100%;margin-bottom: 15px;">
       <div class="main-content-header">
@@ -9,6 +15,19 @@
         <h3>Select a resource to begin troubleshooting:</h3>
       </div>
       <div style="width: 50%;">
+        <div class="section" *ngIf="caseNumberNeededForUser && (selectedResourceType && selectedResourceType.durianEnabled)">
+          <label for="landing-page-casenumber">
+            Case Number <span class="required">*</span>
+          </label>
+          <div id="landing-page-casenumber">
+            <fab-text-field [ariaLabel]="'Customer case number'" [(value)]="caseNumber"
+              [placeholder]="'Type customer case number'">
+            </fab-text-field>
+            <div *ngIf="caseNumberValidationError && caseNumberValidationError!== ''" class="mt-3 error-message-container">
+              <status-icon [status]="status"></status-icon><span class="ml-3 error-message">{{caseNumberValidationError}}</span>
+            </div>
+          </div>
+        </div>
         <div class="section">
           <label for="landing-page-service-type">
             Service type <span class="required">*</span>
@@ -26,7 +45,7 @@
             {{selectedResourceType.resourceTypeLabel}} <span class="required">*</span>
           </label>
           <div id="landing-page-resource">
-            <fab-text-field [ariaLabel]="selectedResourceType.resourceTypeLabel" (onChange)="updateResourceName($event)"
+            <fab-text-field [ariaLabel]="selectedResourceType.resourceTypeLabel" (onChange)="updateResourceName($event)" [(value)]="resourceName"
               [placeholder]="'Type ' + selectedResourceType.resourceTypeLabel" (keyup.enter)="onSubmit()">
             </fab-text-field>
             <div *ngIf="errorMessage!== ''" class="mt-3 error-message-container">
@@ -46,6 +65,9 @@
         <div class="section">
           <fab-primary-button contentStyle="border-radius: 2px; border:1px solid #EDEBE9;" [disabled]="disableSubmitButton" (click)="onSubmit()">
             Continue</fab-primary-button>
+            <div *ngIf="accessErrorMessage && accessErrorMessage!== ''" class="mt-3 error-message-container">
+              <status-icon [status]="status"></status-icon><span class="ml-3 error-message">{{accessErrorMessage}}</span>
+            </div>
         </div>
       </div>
     </div>

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -1,11 +1,11 @@
 import * as momentNs from 'moment';
 import { Component, OnInit } from '@angular/core';
-import { NavigationExtras, Router } from '@angular/router';
+import { NavigationExtras, Router, ActivatedRoute } from '@angular/router';
 import {
   ResourceServiceInputs, ResourceTypeState, ResourceServiceInputsJsonResponse
 } from '../../../shared/models/resources';
 import { HttpClient } from '@angular/common/http';
-import { IDropdownOption, IDropdownProps, PanelType } from 'office-ui-fabric-react';
+import { IDropdownOption, IDropdownProps, PanelType, SpinnerSize } from 'office-ui-fabric-react';
 import { BehaviorSubject } from 'rxjs';
 import { DataTableResponseObject, DetectorControlService, GenericThemeService, HealthStatus } from 'diagnostic-data';
 import { AdalService } from 'adal-angular4';
@@ -13,6 +13,8 @@ import { UserSettingService } from '../../dashboard/services/user-setting.servic
 import { RecentResource } from '../../../shared/models/user-setting';
 import { ResourceDescriptor } from 'diagnostic-data'
 import { applensDocs } from '../../../shared/utilities/applens-docs-constant';
+import {DiagnosticApiService} from '../../../shared/services/diagnostic-api.service';
+import { UserAccessStatus } from '../../../shared/models/alerts';
 const moment = momentNs;
 
 @Component({
@@ -35,59 +37,74 @@ export class MainComponent implements OnInit {
     }
   }
 
+  displayLoader: boolean = false;
+  loaderSize = SpinnerSize.large;
+  caseNumberNeededForUser: boolean = false;
+  caseNumber: string = '';
+  caseNumberValidationError: string = null;
+  accessErrorMessage: string = '';
+  userAccessErrorMessage: string = '';
+  displayUserAccessError: boolean = false;
+
   defaultResourceTypes: ResourceTypeState[] = [
     {
-      resourceType: null,
+      resourceType: "Microsoft.Web/sites",
       resourceTypeLabel: 'App name',
       routeName: (name) => `sites/${name}`,
       displayName: 'App Service',
       enabled: true,
       caseId: false,
-      id: 'App Service'
+      id: 'App Service',
+      durianEnabled: true
     },
     {
-      resourceType: null,
+      resourceType: "Microsoft.Web/hostingEnvironments",
       resourceTypeLabel: 'ASE name',
       routeName: (name) => `hostingEnvironments/${name}`,
       displayName: 'App Service Environment',
       enabled: true,
       caseId: false,
-      id: 'App Service Environment'
+      id: 'App Service Environment',
+      durianEnabled: false
     },
     {
-      resourceType: null,
+      resourceType: "Microsoft.Web/containerApps",
       resourceTypeLabel: 'Container App Name',
       routeName: (name) => `containerapps/${name}`,
       displayName: 'Container App',
       enabled: true,
       caseId: false,
-      id: 'Container App'
+      id: 'Container App',
+      durianEnabled: false
     }, {
-      resourceType: null,
+      resourceType: "Microsoft.Web/staticSites",
       resourceTypeLabel: 'Static App Name Or Default Host Name',
       routeName: (name) => `staticwebapps/${name}`,
       displayName: 'Static Web App',
       enabled: true,
       caseId: false,
-      id: 'Static Web App'
+      id: 'Static Web App',
+      durianEnabled: false
     },
     {
-      resourceType: null,
+      resourceType: "Microsoft.Compute/virtualMachines",
       resourceTypeLabel: 'Virtual machine Id',
       routeName: (name) => this.getFakeArmResource('Microsoft.Compute', 'virtualMachines', name),
       displayName: 'Virtual Machine',
       enabled: true,
       caseId: false,
-      id: 'Virtual Machine'
+      id: 'Virtual Machine',
+      durianEnabled: false
     },
     {
-      resourceType: null,
+      resourceType: "ARMResourceId",
       resourceTypeLabel: 'ARM Resource ID',
       routeName: (name) => `${name}`,
       displayName: 'ARM Resource ID',
       enabled: true,
       caseId: false,
-      id: 'ARM Resource ID'
+      id: 'ARM Resource ID',
+      durianEnabled: false
     },
     {
       resourceType: null,
@@ -96,7 +113,8 @@ export class MainComponent implements OnInit {
       displayName: 'Internal Stamp',
       enabled: true,
       caseId: false,
-      id: 'Internal Stamp'
+      id: 'Internal Stamp',
+      durianEnabled: false
     }
   ];
   resourceTypes: ResourceTypeState[] = [];
@@ -123,7 +141,7 @@ export class MainComponent implements OnInit {
   table: RecentResourceDisplay[];
   applensDocs = applensDocs;
 
-  constructor(private _router: Router, private _http: HttpClient, private _detectorControlService: DetectorControlService, private _adalService: AdalService, private _userSettingService: UserSettingService, private _themeService: GenericThemeService) {
+  constructor(private _router: Router, private _http: HttpClient, private _detectorControlService: DetectorControlService, private _adalService: AdalService, private _userSettingService: UserSettingService, private _themeService: GenericThemeService, private _diagnosticApiService: DiagnosticApiService, private _activatedRoute: ActivatedRoute) {
     this.endTime = moment.utc();
     this.startTime = this.endTime.clone().add(-1, 'days');
     this.inIFrame = window.parent !== window;
@@ -131,11 +149,82 @@ export class MainComponent implements OnInit {
     if (this.inIFrame) {
       this.resourceTypes = this.resourceTypes.filter(resourceType => !resourceType.caseId);
     }
+
+    if (this._activatedRoute.snapshot.queryParams['caseNumber'] && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "undefined") {
+      this.caseNumber = this._activatedRoute.snapshot.queryParams['caseNumber'];
+    }
+    if (this._activatedRoute.snapshot.queryParams['resourceName']) {
+      this.resourceName = this._activatedRoute.snapshot.queryParams['resourceName'];
+    }
+    if (this._activatedRoute.snapshot.queryParams['errorMessage']) {
+      this.accessErrorMessage = this._activatedRoute.snapshot.queryParams['errorMessage'];
+    }
+    if (this._activatedRoute.snapshot.queryParams['resourceType']) {
+      let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType === this._activatedRoute.snapshot.queryParams['resourceType']);
+      if (!foundResourceType) {
+        this.selectedResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType === "ARMResourceId");
+        this.resourceName = this._activatedRoute.snapshot.queryParams['resourceId'];
+      }
+      else {
+        this.selectedResourceType = foundResourceType;
+      }
+    }
+  }
+
+  validateCaseNumber(){
+    if (!this.caseNumber || this.caseNumber.length < 12) {
+      this.caseNumberValidationError = "Case number too short";
+      return false;
+    }
+    if (this.caseNumber.length > 18) {
+      this.caseNumberValidationError = "Case number too long";
+      return false;
+    }
+    if (this.caseNumber && this.caseNumber.length > 0 && isNaN(Number(this.caseNumber))){
+      this.caseNumberValidationError = "Case number should be a valid number";
+      return false;
+    }
+    else {
+      this.caseNumberValidationError = "";
+      return true;
+    }
+  }
+
+  fetchUserDetails() {
+    this.displayLoader = true;
+    this.userAccessErrorMessage = '';
+    this.displayUserAccessError = false;
+    this._diagnosticApiService.checkUserAccess().subscribe(res => {
+      if (res && res.Status == UserAccessStatus.CaseNumberNeeded) {
+        this.caseNumberNeededForUser = true;
+        this.displayLoader = false;
+      }
+      else {
+        this.displayLoader = false;
+      }
+    },(err) => {
+      if (err.status === 404) {
+        //This means durian is not yet available on the backend
+        this.caseNumberNeededForUser = false;
+        this.displayLoader = false;
+        return;
+      }
+      let errormsg = err.error;
+      errormsg = errormsg.replace(/\\"/g, '"');
+      errormsg = errormsg.replace(/\"/g, '"');
+        let errobj = JSON.parse(errormsg);
+        this.displayUserAccessError = true;
+        this.userAccessErrorMessage = errobj.DetailText;
+        this.displayLoader = false;
+    });
   }
 
   ngOnInit() {
+    this.fetchUserDetails();
     this.resourceTypes = [...this.defaultResourceTypes];
-    this.selectedResourceType = this.defaultResourceTypes[0];
+    if (!this.selectedResourceType) {
+      this.selectedResourceType = this.defaultResourceTypes[0];
+    }
 
     this.defaultResourceTypes.forEach(resource => {
       this.fabDropdownOptions.push({
@@ -254,6 +343,13 @@ export class MainComponent implements OnInit {
   }
 
   onSubmit() {
+    if (this.caseNumberNeededForUser && (this.selectedResourceType && this.selectedResourceType.durianEnabled)) {
+      this.caseNumber = this.caseNumber.trim();
+      if (!this.validateCaseNumber()){
+        return;
+      }
+      this._diagnosticApiService.setCustomerCaseNumber(this.caseNumber);
+    }
     this.resourceName = this.resourceName.trim();
 
     //If it is ARM resource id
@@ -279,7 +375,10 @@ export class MainComponent implements OnInit {
     }
 
     let navigationExtras: NavigationExtras = {
-      queryParams: timeParams
+      queryParams: {
+        ...timeParams,
+        ...this.caseNumber? {caseNumber: this.caseNumber}: {}
+      },
     }
 
     if (this.errorMessage === '') {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -160,9 +160,9 @@ export class MainComponent implements OnInit {
       this.accessErrorMessage = this._activatedRoute.snapshot.queryParams['errorMessage'];
     }
     if (this._activatedRoute.snapshot.queryParams['resourceType']) {
-      let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType === this._activatedRoute.snapshot.queryParams['resourceType']);
+      let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === this._activatedRoute.snapshot.queryParams['resourceType'].toLowerCase());
       if (!foundResourceType) {
-        this.selectedResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType === "ARMResourceId");
+        this.selectedResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === "armresourceid");
         this.resourceName = this._activatedRoute.snapshot.queryParams['resourceId'];
       }
       else {

--- a/AngularApp/projects/applens/src/app/shared/models/alerts.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/alerts.ts
@@ -1,0 +1,27 @@
+import { HealthStatus } from "diagnostic-data";
+
+export interface AlertInfo {
+    header: string;
+    details: string;
+    seekConfirmation: boolean;
+    confirmationOptions: ConfirmationOption[]; 
+    alertStatus: HealthStatus;
+}
+
+export interface ConfirmationOption {
+    label: string;
+    value: string;
+}
+
+export enum UserAccessStatus
+{
+  Unauthorized,
+  Forbidden,  
+  NotFound, 
+  BadRequest,  
+  ResourceNotRelatedToCase,  
+  RequestFailure,
+  SGMembershipNeeded,
+  CaseNumberNeeded,
+  HasAccess
+}

--- a/AngularApp/projects/applens/src/app/shared/models/resources.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/resources.ts
@@ -16,6 +16,7 @@ export interface ResourceTypeState {
     enabled: boolean;
     caseId: boolean;
     id: string;
+    durianEnabled: boolean;
 }
 
 export interface ActivatedResource {
@@ -67,6 +68,7 @@ export interface ResourceServiceInputs {
     emergingIssuesICMLookupEnabled?: boolean;
     displayName?: string;
     overviewPageMetricsId?: string;
+    durianEnabled: boolean;
 }
 
 export const RESOURCE_SERVICE_INPUTS = new InjectionToken<ResourceServiceInputs>('ResourceServiceInputs');
@@ -82,5 +84,6 @@ export const DEFAULT_RESOURCE_SERVICE_INPUTS: ResourceServiceInputs = {
     pesId: '',
     sapProductId:'',
     staticSelfHelpContent: '',
-    searchSuffix: 'AZURE'
+    searchSuffix: 'AZURE',
+    durianEnabled: false
 };

--- a/AngularApp/projects/applens/src/app/shared/services/alert.service.spec.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/alert.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { AlertService } from './alert.service';
+
+describe('AlertService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AlertService]
+    });
+  });
+
+  it('should be created', inject([AlertService], (service: AlertService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/AngularApp/projects/applens/src/app/shared/services/alert.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/alert.service.ts
@@ -1,0 +1,28 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable, EventEmitter } from '@angular/core';
+import { AlertInfo } from '../models/alerts';
+
+@Injectable()
+export class AlertService {
+
+  private _alertEvent: EventEmitter<AlertInfo> = new EventEmitter();
+  private _unauthorizedEvent: EventEmitter<HttpErrorResponse> = new EventEmitter();
+
+  constructor() { }
+
+  public getAlert(): EventEmitter<AlertInfo> {
+    return this._alertEvent;
+  }
+
+  public getUnAuthorizedAlerts(): EventEmitter<HttpErrorResponse> {
+    return this._unauthorizedEvent;
+  }
+
+  public sendAlert(alert: AlertInfo) {
+    this._alertEvent.emit(alert);
+  }
+
+  public notifyUnAuthorized(error: HttpErrorResponse){
+    this._unauthorizedEvent.emit(error);
+  }
+}

--- a/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.spec.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { AppLensInterceptorService } from './applens-http-interceptor.service';
+
+describe('AppLensInterceptorService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AppLensInterceptorService]
+    });
+  });
+
+  it('should be created', inject([AppLensInterceptorService], (service: AppLensInterceptorService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpResponse, HttpErrorResponse, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { AlertService } from './alert.service';
+import { AlertInfo, ConfirmationOption, UserAccessStatus } from '../models/alerts';
+import { HealthStatus } from "diagnostic-data";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppLensInterceptorService implements HttpInterceptor {
+  constructor(private _alertService: AlertService) { }
+
+  raiseAlert(event){
+    let errormsg = event.error;
+    errormsg = errormsg.replace(/\\"/g, '"');
+    errormsg = errormsg.replace(/\"/g, '"');
+    let errobj = JSON.parse(errormsg);
+    let message = errobj.DetailText;
+    message = message.trim();
+    if (message) {
+      if (message[message.length-1] == '.') {
+        message = message.substring(0, message.length - 1);
+      }
+    }
+    let alertInfo: AlertInfo = {
+        header: "Do you accept the risks?",
+        details: `${message}. If you choose to proceed, we will be logging it for audit purposes.`,
+        seekConfirmation: true,
+        confirmationOptions: [{label: 'Yes, proceed', value: 'yes'}, {label: 'No, take me back', value: 'no'}],
+        alertStatus: HealthStatus.Warning
+    };
+    this._alertService.sendAlert(alertInfo);
+  }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    return next.handle(req).pipe(map((event: HttpEvent<any>) => {
+        if (event instanceof HttpResponse && event.url.includes("api/invoke")) {
+        }
+        return event;
+      }), catchError((error: HttpErrorResponse) => {
+          let errorObj = JSON.parse(error.error);
+        if (error.status === 403 && error.url.includes("api/invoke") && errorObj.Status == UserAccessStatus.ResourceNotRelatedToCase) {
+          this.raiseAlert(error);
+        }
+        else if ((error.status === 401 || error.status === 403) && error.url.includes("api/invoke")) {
+          this._alertService.notifyUnAuthorized(error);
+        }
+        return Observable.throw(error);
+      }));
+  }
+}

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -23,12 +23,29 @@ export class DiagnosticApiService {
   public GeomasterName: string = null;
   public Location: string = null;
   public effectiveLocale: string = "";
+  public CustomerCaseNumber: string = null;
 
   constructor(private _httpClient: HttpClient, private _cacheService: CacheService,
     private _adalService: AdalService, private _telemetryService: TelemetryService, private _router: Router) { }
 
   public get diagnosticApi(): string {
     return environment.production ? '' : this.localDiagnosticApi;
+  }
+
+  public setCustomerCaseNumber(value) { this.CustomerCaseNumber = value;}
+
+  public checkUserAccess() {
+    let path = "durian/checkUserAccess";
+    return this.invoke<any>(path, HttpMethod.GET, null, true, false, true, false);
+  }
+
+  public unrelatedResourceConfirmation(resourceId: string) {
+    let body = {
+      caseNumber: this.CustomerCaseNumber,
+      resourceId: resourceId
+    };
+    let path = "durian/confirmUnrelatedResource";
+    return this.invoke<any>(path, HttpMethod.POST, body, false, false, true, false);
   }
 
   public getDetector(version: string, resourceId: string, detector: string, startTime?: string, endTime?: string,
@@ -267,6 +284,8 @@ export class DiagnosticApiService {
     if (!additionalHeaders.has('x-ms-request-id') || additionalHeaders.get('x-ms-request-id') == null || additionalHeaders.get('x-ms-request-id') == '') {
       additionalHeaders.set('x-ms-request-id', requestId);
     }
+
+    if (this.CustomerCaseNumber) additionalHeaders.set('x-ms-customer-casenumber', this.CustomerCaseNumber);
 
     let eventProps = {
       'resourceId': path,

--- a/AngularApp/projects/applens/src/app/shared/shared.module.ts
+++ b/AngularApp/projects/applens/src/app/shared/shared.module.ts
@@ -28,6 +28,7 @@ import { ApplensDocsComponent } from './components/applens-docs/applens-docs.com
 import { StaticWebAppService } from './services/staticwebapp.service';
 import { StampService } from './services/stamp.service';
 import { DetectorGistApiService } from './services/detectorgist-template-api.service';
+import { AlertService } from './services/alert.service';
 
 @NgModule({
   imports: [
@@ -67,7 +68,8 @@ export class SharedModule {
         AadAuthGuard,
         CaseCleansingApiService,
         UserSettingService,
-        DetectorGistApiService
+        DetectorGistApiService,
+        AlertService
       ]
     }
   }

--- a/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
+++ b/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
@@ -15,7 +15,8 @@
             "searchSuffix": "AZURE WEB APP",
             "emergingIssuesICMLookupEnabled": false,
             "displayName": "App",
-            "overviewPageMetricsId" : "applensoverviewmetrics_appservices"
+            "overviewPageMetricsId" : "applensoverviewmetrics_appservices",
+            "durianEnabled": true
         },
         {
             "service": "AseService",

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -94,7 +94,8 @@ export const TelemetryEventNames = {
     SolutionOrchestratorViewSupportingDataClicked: 'SolutionOrchestratorViewSupportingDataClicked',
     OpenSlotInNewTab: 'OpenSlotInNewTab',
     ResiliencyScoreReportButtonDisplayed: 'ResiliencyScoreReportButtonDisplayed',
-    ResiliencyScoreReportButtonClicked: 'ResiliencyScoreReportButtonClicked' 
+    ResiliencyScoreReportButtonClicked: 'ResiliencyScoreReportButtonClicked',
+    ResourceOutOfScopeUserResponse: 'ResourceOutOfScopeUserResponse',
 };
 
 export const TelemetrySource = {

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -195,6 +195,8 @@ namespace AppLensV3.Controllers
                 }
             }
 
+            headers.Add("x-ms-user-token", Request.Headers["Authorization"].ToString());
+            
             // For Publishing Detector Calls, validate if user has access to publish the detector
             if (invokeHeaders.Path.EndsWith("/diagnostics/publish", StringComparison.OrdinalIgnoreCase))
             {

--- a/ApplensBackend/Helpers/Constants.cs
+++ b/ApplensBackend/Helpers/Constants.cs
@@ -70,6 +70,8 @@ namespace AppLensV3.Helpers
         public const string VerbHeader = "x-ms-verb";
         public const string IsTemporaryAccessHeader = "IsTemporaryAccess";
         public const string TemporaryAccessExpiresHeader = "TemporaryAccessExpires";
+        public const string CustomerCaseNumberHeader = "x-ms-customer-casenumber";
+        public const string UserTokenHeader = "x-ms-user-token";
     }
 
     public static class DetectorGistTemplateServiceConstants


### PR DESCRIPTION
Main component:
1. Check if user needs a case number (logic is in the backend). Then display user a case number field.
![image](https://user-images.githubusercontent.com/8492235/167973213-66510ab5-ba6c-4738-8079-c680fe8cc1b5.png)

The case number field will be displayed only if durian is enabled for the certain product and the user needs case number to access.
![image](https://user-images.githubusercontent.com/8492235/167973308-fb8d71ee-6b51-48c0-b4f1-9fb8f7938f8a.png)


2. As user enters the case number and resource name and tries to get in, we validate the information and display any error like this
![image](https://user-images.githubusercontent.com/8492235/167973426-3a0853e2-a229-49ff-809b-9a425bd43fca.png)

Another scenario of bad case number
![image](https://user-images.githubusercontent.com/8492235/167973511-7529c768-1780-45c5-980d-29b5666b1df8.png)

3. If everything is alright, user enters AppLens and can access detectors

![image](https://user-images.githubusercontent.com/8492235/167973611-35d64900-5633-4649-97a7-52d4b0434d76.png)

