### PR TITLE
Check If DiagServer enabled via Environment variable

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -280,3 +280,13 @@ export interface Instance {
     machineName: string;
     instanceId: string;
 }
+
+export interface LinuxCommand {
+    command: string;
+}
+
+export interface LinuxCommandOutput {
+    Output: string;
+    Error: string;
+    ExitCode: number;
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
@@ -76,6 +76,8 @@ export class UriElementsService {
     private _daasDiagServerSettingsPath = this._daasDiagServerSessionsPath + "/settings";
     private _daasDiagServerValidateStorageAccountPath = this._daasDiagServerSessionsPath + '/validatestorageaccount';
 
+    private _commandPath = '/extensions/command';
+
     getSessionsUrl(site: SiteDaasInfo, useDiagnosticServerForLinux: boolean) {
         if (useDiagnosticServerForLinux) {
             return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasDiagServerSessionsPath;
@@ -177,6 +179,10 @@ export class UriElementsService {
 
     getLinuxDaasSettingsUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasDiagServerSettingsPath;
+    }
+
+    getLinuxCommandUrl(site: SiteDaasInfo) {
+        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._commandPath;
     }
 
     getStdoutSettingUrl(resourceUrl: string) {


### PR DESCRIPTION
The existing check in KuduLite which checks for DiagServer enabled has a bug as it assumes that missing App Setting `WEBSITE_USE_DIAGNOSTIC_SERVER `indicates that DiagServer is enabled which is incorrect. 

This code surfaced only after Kudulite role patching which happened last week and hence we missed catching this bug earlier.

As a workaround, I am just relying on Environment variable's value by calling KUDU's Command controller and passing the command as `printenv WEBSITE_USE_DIAGNOSTIC_SERVER`