### PR TITLE
Fix Form Exception

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/form/form.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/form/form.component.ts
@@ -360,13 +360,13 @@ export class FormComponent extends DataRenderBaseComponent {
      //set visibility of selected children of dropdown option to true
     selectedChildren.forEach(element => {
         let formInput = allInputs.find(ip => ip.inputId == element);
-        formInput.isVisible = true;
+        if(formInput) formInput.isVisible = true;
     });
     // set visibility of other children linked with current dropdown to false
     let inputsToHide = currentDropdown["children"].filter(item => selectedChildren.indexOf(item) < 0);
     inputsToHide.forEach(element => {
         let formInput = allInputs.find(ip => ip.inputId == element);
-        formInput.isVisible = false;
+        if(formInput) formInput.isVisible = false;
     });
   }
 }


### PR DESCRIPTION
Fix for exception ``Cannot set properties of undefined (setting 'isVisible')``

[End To End Transaction](https://ms.portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%22c1972e9d-b3c7-4de4-acb3-681773b28ced%22%2C%22ResourceGroup%22%3A%22DiagnoseAndSolve%22%2C%22Name%22%3A%22DiagnoseAndSolvePortal%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252Fc1972e9d-b3c7-4de4-acb3-681773b28ced%252FresourceGroups%252FDiagnoseAndSolve%252Fproviders%252Fmicrosoft.insights%252Fcomponents%252FDiagnoseAndSolvePortal%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%22cf795900-d5c6-11ec-81ad-4b0b10f152db%22%2C%22timestamp%22%3A%222022-05-17T09%3A50%3A39.902Z%22%2C%22cacheId%22%3A%22ac75ed8c-97ea-4aba-86a9-d09e699dd205%22%2C%22eventTable%22%3A%22exceptions%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222022-05-17T17%3A15%3A59.286Z%22%7D%7D)

What I see is some detectors([Applens](https://applens.trafficmanager.net/subscriptions/30e7b10b-eab7-4bb2-8788-e3f7a2fc175e/resourceGroups/flank-rg-0121-0815/providers/Microsoft.Web/sites/flank-api-func-app-220516-2144/detectors/VM_Quota_Decider?startTime=2022-05-16T17:09&endTime=2022-05-17T16:53)) is using dropdown in the form just for selecting different options and hence id in dropdown selection doesn't match with form element id

