### PR TITLE
Fix some resource info not showing

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.html
@@ -7,30 +7,70 @@
 <collapsible-list-fabric [collapsed]="false" [title]="'Resource Information'">
   <collapsible-list-item body>
     <div class="info-container">
-      <div *ngIf="observerLink !== ''" class="info-item">
-        <div class="info-item-key">Observer Link</div>
-        <div class="info-item-splitter">:</div>
-        <div class="observer-link">
-          <a href="{{observerLink}}" target="_blank">Observer Link<i class="hyper-link-icon ml-1" aria-hidden="true"></i></a>
-        </div>
-
-      </div>
-      <div *ngFor="let key of keys" class="info-item">
-        <div class="info-item-key sub-title">{{key}}</div>
-        <div class="info-item-splitter">:</div>
-        <div class="info-item-value" [innerHTML]="resource[key]">
-        </div>
-        <div class="info-item-copy">
-          <img *ngIf="resource[key] !== null && resource[key] !== undefined  && !checkWithHref(resource[key])" src="/assets/img/copy-icon.png" style="height: 12px; background-color:var(--imgButtonBackground);" (click)="copyToClipboard(resource[key], $event)" alt="Copy to clipboard" />
-        </div>
-      </div>
+      <table>
+        <tbody>
+          <tr *ngIf="observerLink !== ''">
+            <td>
+              <div class="info-item-key">Observer Link</div>
+            </td>
+            <td>
+              <div class="info-item-splitter">:</div>
+            </td>
+            <td>
+              <div class="info-item-value">
+                <a href="{{observerLink}}" target="_blank">Observer Link<i class="hyper-link-icon ml-1"
+                    aria-hidden="true"></i></a>
+              </div>
+            </td>
+          </tr>
+          <tr *ngFor="let keyPair of keyPairs">
+            <td>
+              <div class="info-item-key">{{keyPair[0]}}</div>
+            </td>
+            <td>
+              <div class="info-item-splitter">:</div>
+            </td>
+            <td>
+              <div class="info-item-value">{{resource[keyPair[0]]}}</div>
+            </td>
+            <td>
+              <div class="info-item-copy">
+                <img
+                  *ngIf="resource[keyPair[0]] !== null && resource[keyPair[0]] !== undefined  && !checkWithHref(resource[keyPair[0]])"
+                  src="/assets/img/copy-icon.png" style="height: 12px; background-color:var(--imgButtonBackground);"
+                  (click)="copyToClipboard(resource[keyPair[0]], $event)" alt="Copy to clipboard" />
+              </div>
+            </td>
+            <ng-container *ngIf="keyPair[1] !== ''">
+              <td>
+                <div class="info-item-key">{{keyPair[1]}}</div>
+              </td>
+              <td>
+                <div class="info-item-splitter">:</div>
+              </td>
+              <td>
+                <div class="info-item-value">{{resource[keyPair[1]]}}</div>
+              </td>
+              <td>
+                <div class="info-item-copy">
+                  <img
+                    *ngIf="resource[keyPair[1]] !== null && resource[keyPair[1]] !== undefined  && !checkWithHref(resource[keyPair[1]])"
+                    src="/assets/img/copy-icon.png" style="height: 12px; background-color:var(--imgButtonBackground);"
+                    (click)="copyToClipboard(resource[keyPair[1]], $event)" alt="Copy to clipboard" />
+                </div>
+              </td>
+            </ng-container>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </collapsible-list-item>
 </collapsible-list-fabric>
 <collapsible-list-fabric *ngIf="showMetrics" [collapsed]="false" [title]="'Metrics'">
   <collapsible-list-item body>
     <div>
-      <detector-container [detector]="_resourceService.overviewPageMetricsId" [hideDetectorControl]="true"></detector-container>
+      <detector-container [detector]="_resourceService.overviewPageMetricsId" [hideDetectorControl]="true">
+      </detector-container>
     </div>
   </collapsible-list-item>
 </collapsible-list-fabric>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.scss
@@ -1,44 +1,36 @@
 .info-container {
-    display: flex;
-    flex-wrap: wrap;
     font-size: 13px;
 }
 
-.observer-link {
-    flex:100%;
-    margin-bottom: 8px;
-}
 
 .info-item {
-    flex:50%;
     margin-top: 6px;
-    display: flex;
 }
 
 .info-item-key {
-    flex: 0 0 160px;
+    @extend .info-item;
+    width: 160px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
 }
 
 .info-item-value {
-    //flex: 1 0 auto;
+    @extend .info-item;
     color: var(--sectionTitle);
-    flex: 0 0 400px;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
+    min-width: 400px;
 }
 
 .info-item-splitter {
-    flex: 0 0 15px;
-    text-align: center;
+    @extend .info-item;
+    padding: 0px 15px;
 }
 
 .info-item-copy {
-    flex: 0 0 15px;
+    @extend .info-item;
     padding: 0px 15px;
+    max-width: 300px;
+    min-width: 150px;
 }
 
 .observer-link > a:focus {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -14,6 +14,7 @@ import { StartupService } from '../../../shared/services/startup.service';
 export class DashboardContainerComponent implements OnInit {
 
   keys: string[];
+  keyPairs: [string,string][] = [];
   resource: any;
   resourceReady: Observable<any>;
   resourceDetailsSub: Subscription;
@@ -60,6 +61,7 @@ export class DashboardContainerComponent implements OnInit {
         else {
           this.updateVentAndLinuxInfo();
         }
+        this.convertKeyToKeyPairs(this.keys);
       }
     });
   }
@@ -123,5 +125,15 @@ export class DashboardContainerComponent implements OnInit {
 
   checkWithHref(s: string) {
     return `${s}`.includes("a href");
+  }
+
+  private convertKeyToKeyPairs(keys:string[]) {
+    for(let i = 0;i < keys.length;i+=2) {
+      if(keys.length % 2 === 1 && i === keys.length - 1) {
+        this.keyPairs.push([keys[i], ""]);
+      } else {
+        this.keyPairs.push([keys[i],keys[i + 1]]);
+      }
+    }
   }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.html
@@ -94,7 +94,7 @@
           </a>
         </div>
         <div *ngFor="let key of keys">
-          <b>{{key}}:</b> &nbsp;<div [innerHTML]="resource[key]" style="display:inline"></div>&nbsp;<span *ngIf="resource[key] !== '' && !checkWithHref(resource[key])"><img
+          <b>{{key}}:</b> &nbsp;<div style="display:inline">{{resource[key]}}</div>&nbsp;<span *ngIf="resource[key] !== '' && !checkWithHref(resource[key])"><img
               src="/assets/img/copy-icon.png" style="height: 12px;background-color:var(--imgButtonBackground);"
               (click)="copyToClipboard(resource[key], $event)" alt="Copy to clipboard" /></span>
         </div>


### PR DESCRIPTION
Changed some styles for resource information in home page to fix bugs 
1. Fix for ASE resource information not showing up
2. Fix when zoom into 300% resource info will be overlapping with each other 
3. Fix when resource information is too long will get truncated. Now it will push to right as much as can be to give enough space for showing whole information

![image](https://user-images.githubusercontent.com/23129934/169224711-3cb181fd-e931-4774-b708-0e23c831a2a8.png)

