### PR TITLE
clear branch input

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1827,5 +1827,11 @@ export class OnboardingFlowComponent implements OnInit {
 
   ngOnDestroy() {
     clearInterval(this.redirectTimer);
+    this._router.navigate([], {
+      queryParams: {
+        'branchInput': null,
+      },
+      queryParamsHandling: 'merge'
+    })
   }
 }


### PR DESCRIPTION
branch input would persist in the query params and cause errors when editing a different detector. this change clears the branch input query param when navigating away from the page