### PR TITLE
Update SKU code getting from Observer

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -54,6 +54,7 @@ export class DashboardContainerComponent implements OnInit {
         }
 
         this.keys = Object.keys(this.resource);
+        this.keys.sort((a,b) => a.localeCompare(b));
         this.replaceResourceEmptyValue();
         if (serviceInputs.resourceType.toString().toLowerCase() == "stamps") {
           this.updateAdditionalStampInfo();

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -281,6 +281,7 @@ export class DashboardComponent implements OnDestroy {
         }
 
         this.keys = Object.keys(this.resource);
+        this.keys.sort((a,b) => a.localeCompare(b));
         this.replaceResourceEmptyValue();
         if (serviceInputs.resourceType.toString().toLowerCase() == "stamps") {
           this.updateAdditionalStampInfo();

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -30,6 +30,16 @@ namespace Observer {
         VnetName: string;
         LinuxFxVersion: string;
         WindowsFxVersion: string;
+        AppServicePlan?: string;
+    }
+
+    export interface ObserverSiteSku {
+        kind: string;
+        is_linux: boolean;
+        sku: string;
+        server_farm_name: string;
+        actual_number_of_workers: number;
+        current_worker_size: number;
     }
 
     export interface ObserverContainerAppInfo {

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -23,6 +23,10 @@ export class ObserverService {
       }));
   }
 
+  public getSiteSku(stamp: string, site: string): Observable<Observer.ObserverSiteSku> {
+    return this._diagnosticApiService.get<{ details: Observer.ObserverSiteSku }>(`api/stamps/${stamp}/sites/${site}/sku`).pipe(map(res => res.details));
+  }
+
   public getContainerApp(containerAppName: string): Observable<Observer.ObserverContainerAppResponse> {
     return this._diagnosticApiService.get<Observer.ObserverContainerAppResponse>(`api/containerapps/${containerAppName}`).pipe(
       map((containerAppRes: Observer.ObserverContainerAppResponse) => {

--- a/AngularApp/projects/applens/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/site.service.ts
@@ -1,31 +1,43 @@
-import { BehaviorSubject, Observable } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, flatMap, map, mergeMap } from 'rxjs/operators';
 import { Inject, Injectable } from '@angular/core';
 import { RESOURCE_SERVICE_INPUTS, ResourceServiceInputs, ResourceInfo } from '../models/resources';
 import { ObserverService } from './observer.service';
 import { ResourceService } from './resource.service';
 import { HttpResponse } from '@angular/common/http';
+import { SkuUtilities } from '../utilities/sku-utilities';
 
 @Injectable()
 export class SiteService extends ResourceService {
 
-  private _currentResource: BehaviorSubject<Observer.ObserverSiteInfo> = new BehaviorSubject(null);
+    private _currentResource: BehaviorSubject<Observer.ObserverSiteInfo> = new BehaviorSubject(null);
 
-  private _siteObject: Observer.ObserverSiteInfo;
+    private _siteObject: Observer.ObserverSiteInfo;
 
-  constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
-    super(inputs);
-  }
+    constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
+        super(inputs);
+    }
 
-  public startInitializationObservable() {
-    this._initialized = this._observerApiService.getSite(this._armResource.resourceName)
-      .pipe(map((observerResponse: Observer.ObserverSiteResponse) => {
-        this._observerResource = this._siteObject = this.getSiteFromObserverResponse(observerResponse);
-        this._currentResource.next(this._siteObject);
-        this.updatePesIdAndImgSrc();
-        return new ResourceInfo(this.getResourceName(),this.imgSrc,this.displayName,this.getCurrentResourceId(),this._siteObject.Kind);
-      }))
-  }
+    public startInitializationObservable() {
+        this._initialized = this._observerApiService.getSite(this._armResource.resourceName)
+            .pipe(
+                map((observerResponse: Observer.ObserverSiteResponse) => {
+                    const siteObject = this.getSiteFromObserverResponse(observerResponse);
+                    return siteObject;
+                }), flatMap(site => {
+                    return this._observerApiService.getSiteSku(site.InternalStampName, site.SiteName).pipe(
+                        map(siteSku => {
+                            site.AppServicePlan = this.getSiteASPAndSKu(siteSku);
+                            return site;
+                        }), catchError(_ => of(site)));
+                }), map(site => {
+                    this._observerResource = this._siteObject = site;
+                    this._currentResource.next(this._siteObject);
+                    this.updatePesIdAndImgSrc();
+
+                    return new ResourceInfo(this.getResourceName(), this.imgSrc, this.displayName, this.getCurrentResourceId(), this._siteObject.Kind);
+                }));
+    }
 
     public getCurrentResource(): Observable<any> {
         return this._currentResource;
@@ -66,5 +78,12 @@ export class SiteService extends ResourceService {
             this.displayName = "LINUX WEB APP";
             this.templateFileName = "LinuxApp";
         }
+    }
+
+    private getSiteASPAndSKu(siteSku: Observer.ObserverSiteSku): string {
+        const priceTire = SkuUtilities.getPriceTireBySkuAndSize(siteSku.sku, siteSku.current_worker_size);
+        const numberOfWorkers = siteSku.actual_number_of_workers;
+        const aspName = siteSku.server_farm_name;
+        return `${aspName}(${priceTire}:${numberOfWorkers})`;
     }
 }

--- a/AngularApp/projects/applens/src/app/shared/utilities/sku-utilities.ts
+++ b/AngularApp/projects/applens/src/app/shared/utilities/sku-utilities.ts
@@ -1,0 +1,143 @@
+export class SkuUtilities {
+    static getPriceTireBySkuAndSize(sku: string, workerSize: number): string {
+        let skuCode = sku;
+        switch (sku) {
+            case "Shared":
+                skuCode = "D1";
+                break;
+            case "Free":
+                skuCode = "F1";
+                break;
+            case "Basic":
+                if (workerSize === WorkerSizeOption.Small) {
+                    skuCode = "B1";
+                }
+                if (workerSize === WorkerSizeOption.Medium) {
+                    skuCode = "B2";
+                }
+                if (workerSize === WorkerSizeOption.Large) {
+                    skuCode = "B3";
+                }
+                break;
+            case "Standard":
+                if (workerSize === WorkerSizeOption.Small) {
+                    skuCode = "S1";
+                }
+                if (workerSize === WorkerSizeOption.Medium) {
+                    skuCode = "S2";
+                }
+                if (workerSize === WorkerSizeOption.Large) {
+                    skuCode = "S3";
+                }
+                break;
+            case "Premium":
+                if (workerSize === WorkerSizeOption.Small) {
+                    skuCode = "P1";
+                }
+                if (workerSize === WorkerSizeOption.Medium) {
+                    skuCode = "P2";
+                }
+                if (workerSize === WorkerSizeOption.Large) {
+                    skuCode = "P3";
+                }
+                break;
+            case "PremiumV2":
+                if (workerSize === WorkerSizeOption.D1) {
+                    skuCode = "P1v2";
+                }
+                if (workerSize === WorkerSizeOption.D2) {
+                    skuCode = "P2v2";
+                }
+                if (workerSize === WorkerSizeOption.D3) {
+                    skuCode = "P3v2";
+                }
+                break;
+            case "PremiumV3":
+                if (workerSize === WorkerSizeOption.SmallV3) {
+                    skuCode = "P1v3";
+                }
+                if (workerSize === WorkerSizeOption.MediumV3) {
+                    skuCode = "P2v3";
+                }
+                if (workerSize === WorkerSizeOption.LargeV3) {
+                    skuCode = "P3v3";
+                }
+                break;
+            case "Isolated":
+                if (workerSize === WorkerSizeOption.Small) {
+                    skuCode = "I1";
+                }
+                if (workerSize === WorkerSizeOption.Medium) {
+                    skuCode = "I2";
+                }
+                if (workerSize === WorkerSizeOption.Large) {
+                    skuCode = "I3";
+                }
+                break;
+            case "IsolatedV2":
+                if (workerSize === WorkerSizeOption.SmallV3) {
+                    skuCode = "I1v2";
+                }
+                if (workerSize === WorkerSizeOption.MediumV3) {
+                    skuCode = "I2v2";
+                }
+                if (workerSize === WorkerSizeOption.LargeV3) {
+                    skuCode = "I3v2";
+                }
+                break;
+            case "PremiumContainer":
+                if (workerSize === WorkerSizeOption.Small) {
+                    skuCode = "PC2";
+                }
+                if (workerSize === WorkerSizeOption.Medium) {
+                    skuCode = "PC3";
+                }
+                if (workerSize === WorkerSizeOption.Large) {
+                    skuCode = "PC4";
+                }
+                break;
+            case "ElasticPremium":
+                if (workerSize === WorkerSizeOption.D1) {
+                    skuCode = "EP1";
+                }
+                if (workerSize === WorkerSizeOption.D2) {
+                    skuCode = "EP2";
+                }
+                if (workerSize === WorkerSizeOption.D3) {
+                    skuCode = "EP3";
+                }
+                break;
+            case "WorkflowStandard":
+                if (workerSize === WorkerSizeOption.D1) {
+                    skuCode = "WS1";
+                }
+                if (workerSize === WorkerSizeOption.D2) {
+                    skuCode = "WS2";
+                }
+                if (workerSize === WorkerSizeOption.D3) {
+                    skuCode = "WS3";
+                }
+                break;
+            case "Dynamic":
+                skuCode = "Y1";
+                break;
+        }
+        return skuCode;
+    }
+}
+
+//https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.websites.models.workersizeoptions?view=azure-dotnet
+enum WorkerSizeOption {
+    Small,
+    Medium,
+    Large,
+    D1,
+    D2,
+    D3,
+    SmallV3,
+    MediumV3,
+    LargeV3,
+    NestedSmall,
+    NestedSmallLinux,
+    Default
+}

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -64,6 +64,14 @@ namespace AppLensV3
         }
 
         [HttpGet]
+        [Route("api/stamps/{stamp}/sites/{siteName}/sku")]
+        public async Task<IActionResult> GetSiteSku(string stamp,string siteName)
+        {
+            var siteSku = await _observerService.GetSiteSku(stamp, siteName);
+            return Ok(new { Details = siteSku.Content });
+        }
+
+        [HttpGet]
         [Route("api/hostingEnvironments/{hostingEnvironmentName}/postBody")]
         public async Task<IActionResult> GetHostingEnvironmentRequestBody(string hostingEnvironmentName)
         {

--- a/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/DiagnosticObserverClientService.cs
@@ -64,6 +64,12 @@ namespace AppLensV3
             return GetSiteInternal(stamp, siteName);
         }
 
+        public Task<ObserverResponse> GetSiteSku(string stamp, string siteName)
+        {
+            var path = $"stamps/{stamp}/sites/{siteName}/sku";
+            return GetAppInternal(path);
+        }
+
         public async Task<ObserverResponse> GetStaticWebApp(string defaultHostNameOrAppName)
         {
             return await GetStaticWebAppInternal(defaultHostNameOrAppName);

--- a/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/IObserverClientService.cs
@@ -23,5 +23,7 @@ namespace AppLensV3
         Task<ObserverResponse> GetSitePostBody(string stamp, string site);
 
         Task<ObserverResponse> GetStampBody(string stampName);
+
+        Task<ObserverResponse> GetSiteSku(string stamp, string site);
     }
 }

--- a/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
+++ b/ApplensBackend/Services/ObserverClientService/SupportObserverClientService.cs
@@ -120,6 +120,11 @@ namespace AppLensV3
             return await GetSiteInternal(SupportObserverApiEndpoint + "sites/" + siteName + "/adminsites");
         }
 
+        public async Task<ObserverResponse> GetSiteSku(string stamp,string siteName)
+        {
+            return await GetAppInternal($"{SupportObserverApiEndpoint}stamps/{stamp}/sites/{siteName}/sku", "GetSiteSku");
+        }
+
         /// <summary>
         /// Get container app details for containerAppName
         /// </summary>


### PR DESCRIPTION
As feature ask [Add App Service Plan Pricing tier and worker size to Applens tool](https://msazure.visualstudio.com/One/_workitems/edit/7290649).

Jeff created a new API(/api/stamps/stamp/sites/site/sku) in Observer to get SKU/Worker Size/Worker Count. Converted to price tire and showing as same format as shown in portal.


![image](https://user-images.githubusercontent.com/23129934/171472774-6b2c2420-f49a-4966-b6d2-bc42924e1635.png)


![image](https://user-images.githubusercontent.com/23129934/171472431-2fcc24d1-2023-4610-b970-228c0196fdd5.png)

