### PR TITLE
Store recent resource query params and update time string format

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
@@ -88,9 +88,11 @@ export class InitResolver implements Resolve<Observable<ResourceInfo>>{
         //Wait for getting UserSetting and update landingPage info before going to dashboard/detector page
         let recentResource: RecentResource = null;
         return this._resourceService.waitForInitialization().pipe(map(resourceInfo => {
+            const queryParams = route.queryParams;
             recentResource = {
                 resourceUri: resourceInfo.resourceUri,
-                kind: resourceInfo.kind
+                kind: resourceInfo.kind,
+                queryParams: queryParams
             };
             return resourceInfo;
         }), flatMap(resourceInfo => {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -13,7 +13,7 @@ import { UserSettingService } from '../../dashboard/services/user-setting.servic
 import { RecentResource } from '../../../shared/models/user-setting';
 import { ResourceDescriptor } from 'diagnostic-data'
 import { applensDocs } from '../../../shared/utilities/applens-docs-constant';
-import {DiagnosticApiService} from '../../../shared/services/diagnostic-api.service';
+import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.service';
 import { UserAccessStatus } from '../../../shared/models/alerts';
 const moment = momentNs;
 
@@ -171,7 +171,7 @@ export class MainComponent implements OnInit {
     }
   }
 
-  validateCaseNumber(){
+  validateCaseNumber() {
     if (!this.caseNumber || this.caseNumber.length < 12) {
       this.caseNumberValidationError = "Case number too short. It should be a minimum of 12 digits.";
       return false;
@@ -180,7 +180,7 @@ export class MainComponent implements OnInit {
       this.caseNumberValidationError = "Case number too long. It should be a maximum of 18 digits.";
       return false;
     }
-    if (this.caseNumber && this.caseNumber.length > 0 && isNaN(Number(this.caseNumber))){
+    if (this.caseNumber && this.caseNumber.length > 0 && isNaN(Number(this.caseNumber))) {
       this.caseNumberValidationError = `'${this.caseNumber}' is not a valid number.`;
       return false;
     }
@@ -203,7 +203,7 @@ export class MainComponent implements OnInit {
       else {
         this.displayLoader = false;
       }
-    },(err) => {
+    }, (err) => {
       if (err.status === 404) {
         //This means userAuthorization is not yet available on the backend
         this.caseNumberNeededForUser = false;
@@ -218,10 +218,10 @@ export class MainComponent implements OnInit {
       let errormsg = err.error;
       errormsg = errormsg.replace(/\\"/g, '"');
       errormsg = errormsg.replace(/\"/g, '"');
-        let errobj = JSON.parse(errormsg);
-        this.displayUserAccessError = true;
-        this.userAccessErrorMessage = errobj.DetailText;
-        this.displayLoader = false;
+      let errobj = JSON.parse(errormsg);
+      this.displayUserAccessError = true;
+      this.userAccessErrorMessage = errobj.DetailText;
+      this.displayLoader = false;
     });
   }
 
@@ -350,7 +350,7 @@ export class MainComponent implements OnInit {
     this._userSettingService.updateDefaultServiceType(this.selectedResourceType.id);
     if (this.caseNumberNeededForUser && (this.selectedResourceType && this.selectedResourceType.userAuthorizationEnabled)) {
       this.caseNumber = this.caseNumber.trim();
-      if (!this.validateCaseNumber()){
+      if (!this.validateCaseNumber()) {
         return;
       }
       this._diagnosticApiService.setCustomerCaseNumber(this.caseNumber);
@@ -382,7 +382,7 @@ export class MainComponent implements OnInit {
     let navigationExtras: NavigationExtras = {
       queryParams: {
         ...timeParams,
-        ...this.caseNumber? {caseNumber: this.caseNumber}: {}
+        ...this.caseNumber ? { caseNumber: this.caseNumber } : {}
       },
     }
 
@@ -421,7 +421,8 @@ export class MainComponent implements OnInit {
         imgSrc: resourceType ? resourceType.imgSrc : "",
         type: resourceType ? resourceType.displayName : "",
         kind: recentResource.kind,
-        resourceUri: recentResource.resourceUri
+        resourceUri: recentResource.resourceUri,
+        queryParams: recentResource.queryParams
       }
       if (type === "microsoft.web/sites") {
         this.updateDisplayWithKind(recentResource.kind, display);
@@ -431,7 +432,7 @@ export class MainComponent implements OnInit {
     return rows;
   }
 
-  private handleStampForRecentResource(recentResource: RecentResource) {
+  private handleStampForRecentResource(recentResource: RecentResource): RecentResourceDisplay {
     let stampName = null;
     const resourceType = this.enabledResourceTypes.find(t => t.resourceType.toLocaleLowerCase() === "stamps");
     let resourceUriRegExp = new RegExp('/infrastructure/stamps/([^/]+)', "i");
@@ -443,12 +444,13 @@ export class MainComponent implements OnInit {
     if (result && result.length > 0) {
       stampName = result[1];
     }
-    return {
+    return <RecentResourceDisplay>{
       name: stampName,
       imgSrc: resourceType ? resourceType.imgSrc : "",
       type: resourceType ? resourceType.displayName : "",
       kind: recentResource.kind,
-      resourceUri: recentResource.resourceUri.replace("infrastructure/stamps", "stamps")
+      resourceUri: recentResource.resourceUri.replace("infrastructure/stamps", "stamps"),
+      queryParams: recentResource.queryParams
     }
   }
 
@@ -466,20 +468,22 @@ export class MainComponent implements OnInit {
     }
   }
 
-  //Todo, once get startTime,endTime from database,replace with those get from detectorControlService
   private onNavigateRecentResource(recentResource: RecentResourceDisplay) {
     const startUtc = this._detectorControlService.startTime;
     const endUtc = this._detectorControlService.endTime;
 
-    let timeParams = {
-      startTime: startUtc ? startUtc.format('YYYY-MM-DDTHH:mm') : "",
-      endTime: endUtc ? endUtc.format('YYYY-MM-DDTHH:mm') : ""
+    const queryParams = recentResource.queryParams ? { ...recentResource.queryParams } : {};
+
+    if (!(moment.utc(queryParams["startTime"])).isValid()  || !(moment.utc(queryParams["endTime"])).isValid()) {
+      queryParams["startTime"] = startUtc ? startUtc.format(this._detectorControlService.stringFormat) : "";
+      queryParams["endTime"] = endUtc ? endUtc.format(this._detectorControlService.stringFormat) : "";
     }
 
-    let navigationExtras: NavigationExtras = {
-      queryParams: timeParams
+    const navigationExtras: NavigationExtras = {
+      queryParams: queryParams
     }
-    const route = recentResource.resourceUri
+
+    const route = recentResource.resourceUri;
     this._router.navigate([route], navigationExtras);
   }
 
@@ -492,8 +496,8 @@ export class MainComponent implements OnInit {
     this.resourceName = e.newValue.toString();
   }
 
-  navigateToUnauthorized(){
-    this._router.navigate(['unauthorized'], {queryParams: {isDurianEnabled: true}});
+  navigateToUnauthorized() {
+    this._router.navigate(['unauthorized'], { queryParams: { isDurianEnabled: true } });
   }
 
 }

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -7,7 +7,7 @@ import {
 import { HttpClient } from '@angular/common/http';
 import { IDropdownOption, IDropdownProps, PanelType, SpinnerSize } from 'office-ui-fabric-react';
 import { BehaviorSubject } from 'rxjs';
-import { DataTableResponseObject, DetectorControlService, GenericThemeService, HealthStatus } from 'diagnostic-data';
+import { DetectorControlService, GenericThemeService, HealthStatus } from 'diagnostic-data';
 import { AdalService } from 'adal-angular4';
 import { UserSettingService } from '../../dashboard/services/user-setting.service';
 import { RecentResource } from '../../../shared/models/user-setting';
@@ -474,7 +474,7 @@ export class MainComponent implements OnInit {
 
     const queryParams = recentResource.queryParams ? { ...recentResource.queryParams } : {};
 
-    if (!(moment.utc(queryParams["startTime"])).isValid()  || !(moment.utc(queryParams["endTime"])).isValid()) {
+    if (!this.checkTimeStringIsValid(queryParams["startTime"]) || !this.checkTimeStringIsValid(queryParams["endTime"])) {
       queryParams["startTime"] = startUtc ? startUtc.format(this._detectorControlService.stringFormat) : "";
       queryParams["endTime"] = endUtc ? endUtc.format(this._detectorControlService.stringFormat) : "";
     }
@@ -498,6 +498,12 @@ export class MainComponent implements OnInit {
 
   navigateToUnauthorized() {
     this._router.navigate(['unauthorized'], { queryParams: { isDurianEnabled: true } });
+  }
+
+  private checkTimeStringIsValid(timeString: string): boolean {
+    if (timeString == null || timeString.length === 0) return false;
+    const time:momentNs.Moment = moment.utc(timeString);
+    return time.isValid();
   }
 
 }

--- a/AngularApp/projects/applens/src/app/shared/models/user-setting.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/user-setting.ts
@@ -19,6 +19,7 @@ export interface UserPanelSetting {
 export interface RecentResource {
     kind: string;
     resourceUri: string;
+    queryParams: { [key: string]: string }
 }
 
 

--- a/AngularApp/projects/applens/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/site.service.ts
@@ -84,6 +84,6 @@ export class SiteService extends ResourceService {
         const priceTire = SkuUtilities.getPriceTireBySkuAndSize(siteSku.sku, siteSku.current_worker_size);
         const numberOfWorkers = siteSku.actual_number_of_workers;
         const aspName = siteSku.server_farm_name;
-        return `${aspName}(${priceTire}:${numberOfWorkers})`;
+        return `${aspName} (${priceTire}: ${numberOfWorkers})`;
     }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.html
@@ -8,11 +8,11 @@
         </fab-choice-group>
         <div *ngIf="showTimePicker" class="row">
           <div style="display: flex;" class="ml-3 mt-3">
-            <div class="mr-3 date-picker-label">Start </div>
-            <fab-date-picker contentClass="col-md-8" [minDate]="minDate" [maxDate]="maxDate"
+            <div class="mr-2 date-picker-label">Start </div>
+            <fab-date-picker [minDate]="minDate" [maxDate]="maxDate"
               placeholder="Select a date..." ariaLabel="Select start date" allowTextInput="true"
               showMonthPickerAsOverlay="true" (onSelectDate)="onSelectStartDateHandler($event)" [formatDate]="formatDate"
-              [value]="startDate" contentStyle="width:120px;">
+              [value]="startDate" [parseDateFromString]="parseDateFromString" contentStyle="width:130px;">
             </fab-date-picker>
             <fab-masked-text-field contentClass="col-md-4" maxLength="6" [(value)]="startClock"
               [iconProps]="{iconName: 'Clock'}" [mask]="'99:99'" [maskChar]="'-'" [validateOnFocusOut]="true"
@@ -22,11 +22,11 @@
           </div>
 
           <div style="display: flex;" class="ml-3 mt-3">
-            <div  class="mr-4 date-picker-label">End</div>
-            <fab-date-picker contentClass="col-md-8" [minDate]="minDate" [maxDate]="maxDate"
+            <div  class="mr-2 date-picker-label">End&nbsp;</div>
+            <fab-date-picker [minDate]="minDate" [maxDate]="maxDate"
               placeholder="Select a date..." ariaLabel="Select end date" allowTextInput="true"
               showMonthPickerAsOverlay="true" (onSelectDate)="onSelectEndDateHandler($event)" [formatDate]="formatDate"
-              [value]="endDate" contentStyle="width:120px">
+              [value]="endDate" [parseDateFromString]="parseDateFromString" contentStyle="width:130px">
             </fab-date-picker>
             <fab-masked-text-field contentClass="col-md-4" maxLength="6" [(value)]="endClock"
               [iconProps]="{iconName: 'Clock'}" [mask]="'99:99'" [maskChar]="'-'" [validateOnFocusOut]="true"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.ts
@@ -41,19 +41,29 @@ export class DetectorTimePickerComponent implements OnInit {
   endClock: string;
   timeDiffError: string = "";
 
-  isPublic : boolean = true;
+  isPublic: boolean = true;
 
   formatDate: IDatePickerProps['formatDate'] = (date) => {
     //only this format can do both fill in date and select date
-    return moment(date).format('M/D/YY');
+    console.log(date);
+    return moment(date).format('YYYY-MM-DD');
   };
+
+  parseDateFromString: IDatePickerProps['parseDateFromString'] = (s) => {
+    const dateStr = s || "";
+    const datePart = dateStr.split("-");
+    const year = datePart[0].length > 0 ? Number.parseInt(datePart[0], 10) : this.endDate.getFullYear();
+    const month = datePart[1].length > 0 ? Math.max(1, Math.min(12, parseInt(datePart[1], 10))) - 1 : this.endDate.getMonth();
+    const date = datePart[2].length > 1 ? Math.max(1, Math.min(31, parseInt(datePart[2], 10))) : this.endDate.getDate();
+    return new Date(year, month, date);
+  }
 
   choiceGroupOptions: IChoiceGroupOption[] =
     [
       { key: TimePickerOptions.Last1Hour, text: TimePickerOptions.Last1Hour, onClick: () => { this.setTime(1) } },
       { key: TimePickerOptions.Last6Hours, text: TimePickerOptions.Last6Hours, onClick: () => { this.setTime(6) } },
       { key: TimePickerOptions.Last12Hour, text: TimePickerOptions.Last12Hour, onClick: () => { this.setTime(12) } },
-      { key: TimePickerOptions.Last24Hours, text: TimePickerOptions.Last24Hours, onClick: () => { this.setTime(24) } },      
+      { key: TimePickerOptions.Last24Hours, text: TimePickerOptions.Last24Hours, onClick: () => { this.setTime(24) } },
       { key: TimePickerOptions.Custom, text: TimePickerOptions.Custom, onClick: () => { this.selectCustom() } },
     ];
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -160,7 +160,9 @@
 
 <ng-container *ngIf="!detectorDataLocalCopy && errorState">
   <div class="mt-3">
-    <ng-container *ngTemplateOutlet="detectorTimePickerPill"></ng-container>
+    <ng-container *ngIf="!hideDetectorControl && !insideDetectorList">
+      <ng-container *ngTemplateOutlet="detectorTimePickerPill"></ng-container>
+    </ng-container>
     <span class="critical-color" *ngIf="errorState.error && !isPublic"> Error: {{errorState.error}}</span>
     <span class="critical-color" *ngIf="isPublic && errorState || !errorState.error">Sorry, an error occurred. Please
       refresh the page and try again.</span>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -401,7 +401,7 @@ export class DetectorViewComponent implements OnInit {
   }
 
   getTimestampAsString(dateTime: Moment) {
-    return dateTime.format('DD-MMM-YY HH:mm') + ' UTC';
+    return dateTime.format(this.detectorControlService.stringFormat) + ' UTC';
   }
 
   getDowntimeLabel(d: DownTime) {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -330,9 +330,8 @@ export class DetectorControlService {
     if (updatedInfo && updatedInfo.selectedKey !== TimePickerOptions.Custom) {
       this.timePickerStrSub.next(updatedInfo.selectedText);
     } else {
-      const timeFormat = 'M/D/YY HH:mm';
-      const st = moment(this.startTimeString).format(timeFormat);
-      const et = moment(this.endTimeString).format(timeFormat);
+      const st = moment(this.startTimeString).format(this.stringFormat);
+      const et = moment(this.endTimeString).format(this.stringFormat);
       this.timePickerStrSub.next(`${st} to ${et}`);
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -75,6 +75,9 @@ export class DetectorControlService {
 
   constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
     this.internalClient = !config.isPublic;
+    this._duration = this.durationSelections[2];
+    this._startTime = moment.utc().subtract(this._duration.duration);
+    this._endTime = moment.utc().subtract(15,'minute');
   }
 
   public get update() {

--- a/ApplensBackend/Models/RecentResource.cs
+++ b/ApplensBackend/Models/RecentResource.cs
@@ -54,6 +54,7 @@ namespace AppLensV3.Models
     {
         public string ResourceUri { get; set; }
         public string Kind { get; set; }
+        public Dictionary<string,string> QueryParams { get; set; }
     }
 
     public class FavoriteDetectorProp


### PR DESCRIPTION
1. Store query params (startTime,endTime, caseId, ect...) when updating recent resource. 
    When click recent resource it will route to time period which fetching from cosmosDB instead of last 24 hours
2. Change time string format to **"YYYY-MM-DD HH:mm"** in time-picker and downtime selection to be consistency. And also allow to type as this format in date-picker
Todo, after this PR deployed. Also need to update time string format for downtime gist(DowntimesGist) and overview metric detector(applensoverviewmetrics_appservices)

![image](https://user-images.githubusercontent.com/23129934/171916412-4c13981c-d3a1-408b-973c-af40b91b97bc.png)


