### PR TITLE
Fix case submission flow broken navigation

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -868,8 +868,14 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                         }
                     }
                     else {
+                        // Case submission flow search result navigation
                         this.logEvent(TelemetryEventNames.SearchResultClicked, { searchMode: this.searchMode, searchId: this.searchId, detectorId: detectorId, rank: 0, title: clickDetectorEventProperties.ChildDetectorName, status: clickDetectorEventProperties.Status, ts: Math.floor((new Date()).getTime() / 1000).toString() });
-                        this._router.navigate([`../../../analysis/${this.analysisId}/search/detectors/${detectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', preserveFragment: true, queryParams: { searchTerm: this.searchTerm } });
+                        let dest = `../../../analysis/${this.analysisId}/search/detectors/${detectorId}`;
+                        if (this._activatedRoute.snapshot.paramMap.has("detectorName"))
+                        {
+                            dest = `../${detectorId}`;
+                        }
+                        this._router.navigate([dest], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', preserveFragment: true, queryParams: { searchTerm: this.searchTerm } });
                     }
                 }
                 else {


### PR DESCRIPTION
This PR is to fix the broken navigations in case submission flow caused by these routes:

Uncaught (in promise): Error: Cannot match any routes. URL Segment: 'resource/subscriptions/8aeff191-4048-4d78-beac-a31e870464ae/resourcegroups/indigo-services-prd-rg/providers/microsoft.web/sites/partscatalogintegrationservice-pro/integratedSolutions/**analysis/searchResultsAnalysis/analysis/searchResultsAnalysis**/search/detectors/appchanges'
Error: Cannot match any routes. URL Segment: 'resource/subscriptions/8aeff191-4048-4d78-beac-a31e870464ae/resourcegroups/indigo-services-prd-rg/providers/microsoft.web/sites/partscatalogintegrationservice-pro/integratedSolutions/analysis/searchResultsAnalysis/analysis/searchResultsAnalysis/search/detectors/appchanges'


https://dataexplorer.azure.com/clusters/u360sec/databases/KPISupportData?query=H4sIAAAAAAAAA3VQTWvjMBC9L+x/GHRJUlr3VBYWslBCD4FNCXXK7q0o0tQRtSUxM46T0h+/Y6cmhbA36X3NvHF1y4I0ndznzHvXHoo3BVLRhehTx0VEmcwKb8VuLaPK1uty757/KrioA0bZYI0NCh0fsfv+7QO6HRLCZrl6KDf3qzX8Alul6Q8/O5N4EIwcUoT5HMwf3HIQ5IcRNWCjB04tORwUZZtzIlnoNCRzzrFOxhAfbBUTS3A3/a43eHCYe/aLvCfApSg2RAZzy6dYSTm4pTeQ6EISdGJFVtCXqW77PL6Yv0o+vAakL76FjTEJNFbcTsscgVKrDQdrtsQX1i7IDq7+ayzg+ek3lFg1eoKfMDEALdVrKzuj76tz7Cd6yjOEpyNq0y07CsNB+NaA/pde642CSsfknqBqwDOlffBIPTS+H22DSp2BzTGfgDFlsCqvC/Qbcds0lsI76mHaKNPZNbzaUKPvN2SYa8s3fGGU6efW13A3g+1xCPgHVREVDJcCAAA=

cluster('Appsvcux.kusto.windows.net').database('APPSvcUX').ClientTelemetryNew
| where TIMESTAMP > ago(7d)
| where extension == "[Web](https://dataexplorer.azure.com/clusters/u360sec/databases/KPISupportData?query=H4sIAAAAAAAAA3VQTWvjMBC9L+x/GHRJUlr3VBYWslBCD4FNCXXK7q0o0tQRtSUxM46T0h+/Y6cmhbA36X3NvHF1y4I0ndznzHvXHoo3BVLRhehTx0VEmcwKb8VuLaPK1uty757/KrioA0bZYI0NCh0fsfv+7QO6HRLCZrl6KDf3qzX8Alul6Q8/O5N4EIwcUoT5HMwf3HIQ5IcRNWCjB04tORwUZZtzIlnoNCRzzrFOxhAfbBUTS3A3/a43eHCYe/aLvCfApSg2RAZzy6dYSTm4pTeQ6EISdGJFVtCXqW77PL6Yv0o+vAakL76FjTEJNFbcTsscgVKrDQdrtsQX1i7IDq7+ayzg+ek3lFg1eoKfMDEALdVrKzuj76tz7Cd6yjOEpyNq0y07CsNB+NaA/pde642CSsfknqBqwDOlffBIPTS+H22DSp2BzTGfgDFlsCqvC/Qbcds0lsI76mHaKNPZNbzaUKPvN2SYa8s3fGGU6efW13A3g+1xCPgHVREVDJcCAAA=)sitesExtension" and source == "SupportCenter"
| where action == "diagnostic-data-exception"
| where data contains "/supporttopicId" or data contains "/integratedSolutions"
| where actionModifier contains "Cannot match any routes"
| parse actionModifier with * "Cannot match any routes. URL Segment: '"  urlPath"'" *
| parse urlPath with "resource/subscriptions/" subId "/resourcegroups/" rgId "/providers/" providerName "/" providerType "/" resourceId "/" path
| summarize count(), failedPaths = make_set(urlPath, 5) by path