### PR TITLE
Avoid polling DiagServer sessions if Storage not configured

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -91,7 +91,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     this.initHeading();
     if (this.showDetailedView) {
       this.checkSessions();
-      this.subscription = interval(30000).subscribe(res => {
+      this.subscription = interval(60000).subscribe(res => {
         this.checkSessions();
       });
 
@@ -118,13 +118,20 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
 
   getLinuxDiagnosticServerSessions(): Observable<Session[]> {
     let emptyArray: Session[] = [];
-    if (this.isWindowsApp){
+    if (this.isWindowsApp) {
       return of(emptyArray);
     }
 
     return this._daasService.isDiagServerEnabledForLinux(this.siteToBeDiagnosed).pipe(
       map((isEnabled) => {
         return isEnabled;
+      }),
+      mergeMap((isEnabled) => {
+        if (!isEnabled) {
+          return of(isEnabled);
+        } else {
+          return this._daasService.isStorageAccountConfiguredForDiagServer(this.siteToBeDiagnosed);
+        }
       }),
       mergeMap(isEnabled => {
         if (!isEnabled) {


### PR DESCRIPTION
Currently if DiagServer is enabled, the UI will make a call to /v2/sessions and this will fail with 404 if the storage account is not configured. With this change, we will only make the call if StorageAccount is configured thus avoiding any 404s. We are doing this so that 404s don't end up in customer's logs as that earlier ended up raising some tickets.

Also increasing the polling time for DaaS sessions from 30s to 60s