### PR TITLE
Fix applens accessibility bugs

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/genie/message-flow/genie-feedback/genie-feedback.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/genie/message-flow/genie-feedback/genie-feedback.component.ts
@@ -21,7 +21,7 @@ export class GenieFeedbackComponent extends ButtonMessageComponent {
     [
       {
         id: "Sad",
-        text: "dissatisfied "
+        text: "dissatisfied"
       },
       {
         id: "EmojiNeutral",

--- a/AngularApp/projects/applens/src/app/collapsible-menu/components/collapsible-menu-item/collapsible-menu-item.component.html
+++ b/AngularApp/projects/applens/src/app/collapsible-menu/components/collapsible-menu-item/collapsible-menu-item.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="false">
 <div *ngIf="matchesSearchTerm || alwaysShowItem">
-    <div class="menu-item" (click)="handleClick()" (keyup.enter)="handleClick()">
+    <div tabindex="0" class="menu-item" (click)="handleClick()" (keyup.enter)="handleClick()">
       <!-- <div class="mr-3" *ngIf=" menuItem.subItems && menuItem.subItems.length > 0">
         <fab-icon [iconName]="iconName"></fab-icon>
       </div> -->
@@ -14,8 +14,9 @@
 </div>
 </ng-container>
 
+
 <div *ngIf="matchesSearchTerm" class="menu-item-container" [class.selected]="isSelected()" >
-    <div class="menu-item" (click)="handleClick()"  [style.padding-left]="getPadding()" [style.font-size]="getFontSize()">
+    <div tabindex="0" (keyup.enter)="handleClick()" class="menu-item" (click)="handleClick()"  [style.padding-left]="getPadding()" [style.font-size]="getFontSize()">
         <i class="fa expand-icon" *ngIf=" menuItem.subItems && menuItem.subItems.length > 0" [class.fa-caret-right]="!menuItem.expanded" [class.fa-caret-down]="menuItem.expanded"></i>
         <i class="fa" *ngIf="menuItem.icon" [ngClass]="menuItem.icon"></i>
         <span class="menu-label" [innerHtml]="menuItem.label | searchmatch:searchValueLocal"></span>

--- a/AngularApp/projects/applens/src/app/collapsible-menu/components/section-divider/section-divider.component.html
+++ b/AngularApp/projects/applens/src/app/collapsible-menu/components/section-divider/section-divider.component.html
@@ -1,4 +1,4 @@
-<div class="section-divider" [class.not-expandable]="!collapsible" (click)="expanded = !expanded">
+<div tabindex="0" (keyup.enter)="expanded = !expanded" class="section-divider" [class.not-expandable]="!collapsible" (click)="expanded = !expanded">
   <div>
     <ng-content select=".menu-icon"></ng-content>
     </div>
@@ -8,7 +8,6 @@
   <div class="menu-expand-icon">
       <span class="fa section-expand-icon" *ngIf="collapsible" [class.fa-angle-down]="!expanded && !disableExpandIcon" [class.fa-angle-up]="expanded && !disableExpandIcon"></span>
   </div>
-
 </div>
 <div class="section-children">
   <div class="expandable-content" [@expand]="collapsible && expanded ? 'shown' : 'hidden'">

--- a/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.html
@@ -16,7 +16,7 @@
             <p class="panel-text">{{site.SubscriptionName}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
             <p class="panel-text">{{site.KubeEnvironmentName}}</p>
-            <a tabindex="0" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+            <a tabindex="0" (keyup.enter)="navigateToSite(site)" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>
       </div>

--- a/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.html
@@ -16,7 +16,7 @@
             <p class="panel-text">{{site.SubscriptionName}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
             <p class="panel-text">{{site.KubeEnvironmentName}}</p>
-            <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+            <a tabindex="0" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>
       </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
@@ -1,11 +1,11 @@
 <aside class="main-sidebar">
   <section class="sidebar" id="sidebar">
     <collapsible-menu theme="light">
-      <search-box (searchValueChange)="updateSearch($event)" [searchValue]="searchValue"></search-box>
+      <search-box tabindex="0" (searchValueChange)="updateSearch($event)" [searchValue]="searchValue"></search-box>
       <!-- <fab-search-box #fabSearchBox1 [value]="searchValue" (onChange)="updateSearchValue($event)" [styles]="searchBoxStyles" (onFocus)="focusSearchBox()" [placeholder]="searchPlaceHolder"></fab-search-box> -->
       <menu-scroll>
         <section-divider [label]="'Overview'" [selected]="isSectionHeaderSelected('')" [initiallyExpanded]="false"
-          [collapsible]="false" (click)="navigateToOverview()">
+          [collapsible]="false" (click)="navigateToOverview()" (keyup.enter)="navigateToOverview()">
           <i class="fa fa-info fa-fw menu-icon menu-icon-create" aria-hidden="true"></i>
           <collapsible-menu-item *ngFor="let item of overview" [menuItem]="item"></collapsible-menu-item>
         </section-divider>

--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
@@ -17,7 +17,7 @@
             <p class="panel-text">{{site.Subscription}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
             <p class="panel-text">{{site.StampName}}</p>
-            <a tabindex="0" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+            <a tabindex="0" (keyup.enter)="navigateToSite(site)" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>
       </div>

--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.html
@@ -17,7 +17,7 @@
             <p class="panel-text">{{site.Subscription}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
             <p class="panel-text">{{site.StampName}}</p>
-            <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+            <a tabindex="0" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>
       </div>

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.html
@@ -16,7 +16,7 @@
             <p class="panel-text">{{site.SubscriptionName}}</p>
             <p class="panel-text">{{site.ResourceGroupName}}</p>
             <p class="panel-text">{{site.DefaultHostname}}</p>
-            <a (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
+            <a tabindex="0" (keyup.enter)="navigateToSite(site)" (click)="navigateToSite(site)" class="btn btn-primary">Select</a>
           </div>
         </div>
       </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fabric-feedback/fabric-feedback.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fabric-feedback/fabric-feedback.component.html
@@ -11,7 +11,7 @@
         <div class="feedback-panel-icons" id="feedback-icons">
           <div *ngFor="let feedbackIcon of feedbackIcons;let i = index" (click)="setRating(i)"
             [ngClass]="{'selected-icon':rating - 1 === i}" class="feedback-icon hover-item" style="padding: 5px;"
-            (keyup.enter)="setRating(i)" tabindex="0" role="button">
+            (keyup.enter)="setRating(i)" tabindex="0" role="button" name="feedback-icon-rating">
             <fab-icon [iconName]="feedbackIcon.id" [ariaLabel]="feedbackIcon.text"></fab-icon>
             <div class="tooltiptext">{{feedbackIcon.text}}</div>
           </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fabric-feedback/fabric-feedback.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fabric-feedback/fabric-feedback.component.ts
@@ -27,7 +27,7 @@ export class FabricFeedbackComponent implements AfterViewInit, OnInit, OnDestroy
     [
       {
         id: "Sad",
-        text: "dissatisfied "
+        text: "dissatisfied"
       },
       {
         id: "EmojiNeutral",
@@ -150,6 +150,12 @@ export class FabricFeedbackComponent implements AfterViewInit, OnInit, OnDestroy
     }else if (this.feedbackPanelConfig.url != window.location.href.split("?")[0]){
       this.feedbackPanelConfig.url = window.location.href.split("?")[0];
     }
+
+    if (document.getElementsByName("feedback-icon-rating") != undefined && document.getElementsByName("feedback-icon-rating").length>0 && document.getElementsByName("feedback-icon-rating")[0] != undefined)
+    {
+        (<HTMLElement>document.getElementsByName("feedback-icon-rating")[0]).focus();
+    }
+
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
[Bug 2317](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2317): [Keyboard Navigation - AppLens- Multiple Cheesecake] Tiles controls available under "Multiple sites with the name 'Cheesecake' found. Pick the correct one:" are not accessible using keyboard

[Bug 2327](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2327): [Keyboard Navigation - AppLens- Cheese cake app] Focus doesn't land on the first interactive control of 'Feedback' screen when feedback control is activated

[Bug 2337](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2337): [Keyboard Navigation - AppLens- Web App down] Focus order is incorrect while navigating on 'All Detectors' pane appearing on 'Web App Down' screen of App Lens

