### PR TITLE
Correcting intial load failure of Diagnostic tools for Linux

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -25,8 +25,8 @@ export class ConfigureStorageAccountComponent implements OnInit {
       }
 
       if (newStorageAccount.sasUri || newStorageAccount.connectionString) {
-        this.validationResult.BlobSasUri = newStorageAccount.sasUri;
-        this.validationResult.ConnectionString = newStorageAccount.connectionString;
+        this.validationResult.BlobSasUri = newStorageAccount.sasUri ? newStorageAccount.sasUri : '';
+        this.validationResult.ConnectionString = newStorageAccount.connectionString ? newStorageAccount.connectionString : '';
         this.validationResult.Validated = true;
         this.validationResult.ConfiguredAsAppSetting = true;
         this.StorageAccountValidated.emit(this.validationResult);

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas/daas.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas/daas.component.html
@@ -164,7 +164,7 @@
           <td>
             <ul style="list-style: none;padding:0">
               <li>
-                <a (click)="openLog(logFile, sessionHasBlobSasUri)" style="cursor: pointer">
+                <a (click)="openLog(logFile)" style="cursor: pointer">
                   {{ logFile.Name }}
                 </a>
               </li>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas/daas.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas/daas.component.ts
@@ -60,7 +60,6 @@ export class DaasComponent implements OnInit, OnDestroy {
   cancellingSession: boolean = false;
   collectionMode: SessionMode = SessionMode.CollectAndAnalyze;
   showInstanceWarning: boolean = false;
-  sessionHasBlobSasUri: boolean = false;
 
   activeInstance: ActiveInstance;
   logFiles: LogFile[] = [];
@@ -346,7 +345,6 @@ export class DaasComponent implements OnInit, OnDestroy {
           return false;
         }
 
-        this.sessionHasBlobSasUri = this.validationResult.BlobSasUri.length > 0;
         this.sessionInProgress = true;
         this.sessionStatus = 1;
         this.updateInstanceInformation();
@@ -444,7 +442,7 @@ export class DaasComponent implements OnInit, OnDestroy {
     }
   }
 
-  openLog(log: LogFile, hasBlobSasUri: boolean) {
+  openLog(log: LogFile) {
     this._windowService.open(`${log.RelativePath}`);
   }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/java-flight-recorder/java-flight-recorder.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/java-flight-recorder/java-flight-recorder.component.html
@@ -120,7 +120,7 @@
                     <td>
                         <ul style="list-style: none;padding:0">
                             <li>
-                                <a (click)="openLog(logFile, sessionHasBlobSasUri)" style="cursor: pointer">
+                                <a (click)="openLog(logFile)" style="cursor: pointer">
                                     {{ logFile.Name }}
                                 </a>
                             </li>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler/profiler.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/profiler/profiler.component.html
@@ -222,7 +222,7 @@
           <td>
             <ul style="list-style: none;padding:0">
               <li>
-                <a (click)="openLog(logFile, sessionHasBlobSasUri)" style="cursor: pointer">
+                <a (click)="openLog(logFile)" style="cursor: pointer">
                   {{ logFile.Name }}
                 </a>
               </li>


### PR DESCRIPTION
Linux Diagnostic tools are failing with an exception the first time the storage account is not configured. The PR fixes that issue and removes the unused variable.