### PR TITLE
Remove AppInsights Specific header rendering for consistency

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-markdown/app-insights-markdown.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-markdown/app-insights-markdown.component.html
@@ -20,13 +20,13 @@
   <div *ngFor="let metadata of appInsightQueryMetaDataList;let i = index" class="dynamic-data-container">
 
     <data-container *ngIf="metadata.dataTable == null" [title]="metadata.title" [description]="metadata.description"
-      [applicationInsightContainerStyle]="1">
+      [applicationInsightContainerStyle]="0">
       <markdown [data]="getMetaDataMarkdown(metadata)"></markdown>
     </data-container>
 
     <div *ngIf="metadata.dataTable != null">
       <div *ngFor="let data of appInsightDataList;let i = index" class="dynamic-data-container">
-        <data-container [title]="data.title" [description]="data.description" [applicationInsightContainerStyle]="1">
+        <data-container [title]="data.title" [description]="data.description" [applicationInsightContainerStyle]="0">
           <dynamic-data [diagnosticData]="data.diagnosticData" [startTime]="startTime" [endTime]="endTime">
           </dynamic-data>
         </data-container>
@@ -111,7 +111,7 @@
         <div *ngIf="!loadingAppInsightsQueryData; else loadingAppInsightsData">
           <div *ngFor="let data of appInsightDataList;let i = index" class="dynamic-data-container">
             <data-container [title]="data.title" [description]="data.description"
-              [applicationInsightContainerStyle]="1">
+              [applicationInsightContainerStyle]="0">
               <dynamic-data [diagnosticData]="data.diagnosticData" [startTime]="startTime" [endTime]="endTime">
               </dynamic-data>
               <button type="button" class="btn btn-info app-insights-blade"


### PR DESCRIPTION
Temporarily removing the AppInsights specific headers to ensure the rendered output is consistent with the rest of the detector rendering. If you think AppInsights specific renderings need to be distinguished, we can think about improving this later in long term.

**Earlier**
----
![image](https://user-images.githubusercontent.com/5299838/177530951-90ebbfd9-007f-4efb-8991-0a3c3bad0e50.png)

**Now**
----
![image](https://user-images.githubusercontent.com/5299838/177531104-128b2fbe-bd59-4b17-8637-fc191f4be401.png)
