### PR TITLE
Add focus for applens icon

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.html
+++ b/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.html
@@ -1,7 +1,7 @@
 <header>
   <nav class="navbar-fixed-top header-nav" role="navigation">
     <div style="display: flex;">
-      <div class="header-title" role="button" (click)="navigateToLandingPage()" (keyup.enter)="navigateToLandingPage()">
+      <div class="header-title" role="button" tabindex="0" (click)="navigateToLandingPage()" (keyup.enter)="navigateToLandingPage()">
         <img [src]="applensLogo" alt="Applens" class="header-img">
         <div class="ml-3" style="font-weight: 600;">AppLens {{envTag}}</div>
       </div>


### PR DESCRIPTION
Fix for accessibility bug [[Keyboard Navigation - AppLens- Welcome] 'App Lens (prod)' control available on the top of screen is not keyboard accessible](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2368)