### PR TITLE
Fixed 🐛 Command injection in nodemailer

### DIFF
--- a/AngularApp/package-lock.json
+++ b/AngularApp/package-lock.json
@@ -9670,7 +9670,7 @@
         "hipchat-notifier": "^1.1.0",
         "loggly": "^1.1.0",
         "mailgun-js": "^0.18.0",
-        "nodemailer": "^2.5.0",
+        "nodemailer": "^6.6.1",
         "redis": "^2.7.1",
         "semver": "^5.5.0",
         "slack-node": "~0.2.0",


### PR DESCRIPTION
## Description Sumarry:
This affects the package nodemailer before 6.4.16. Use of crafted recipient email addresses may result in arbitrary command flag injection in sendmail transport for sending mails.

**CVE-2020-7769**
`9.8 / 10`
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`