### PR TITLE
Pull self help content from Apollo API

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-support-topic.service.ts
@@ -8,14 +8,15 @@ import { OperatingSystem } from '../../../shared/models/site';
 import { VersioningHelper } from '../../../shared/utilities/versioningHelper';
 import { HttpClient } from '@angular/common/http';
 import {AuthService} from '../../../startup/services/auth.service';
+import { ArmService } from '../../../shared/services/arm.service';
 
 @Injectable()
 export class SiteSupportTopicService extends SupportTopicService {
 
   private _hardCodedSupportTopicIdMapping = [];
 
-  constructor(protected _http: HttpClient, protected _authService: AuthService, protected _diagnosticService: DiagnosticService, protected _webSiteService: WebSitesService, protected _telemetryService: TelemetryService) {
-    super(_http, _authService, _diagnosticService, _webSiteService, _telemetryService);
+  constructor(protected _http: HttpClient, protected _authService: AuthService, protected _diagnosticService: DiagnosticService, protected _webSiteService: WebSitesService, protected _telemetryService: TelemetryService, protected _armService: ArmService) {
+    super(_http, _authService, _diagnosticService, _webSiteService, _telemetryService, _armService);
 
     if (!VersioningHelper.isV2Subscription(_webSiteService.subscriptionId)) {
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -60,7 +60,7 @@ export class SupportTopicService {
         return result;
     }
 
-    public getSelfHelpContentApollo(): Observable<any> {
+    private getSelfHelpContentApollo(): Observable<any> {
         if (this.pesId && this.pesId.length > 0 && this.sapSupportTopicId && this.sapSupportTopicId.length > 0) {
             
             // To generate a unique apollo search Id, we use resource name, current timestamp and a guid.

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -7,6 +7,10 @@ import { DiagnosticService, DetectorMetaData, DetectorType, RenderingType, Keyst
 import * as momentNs from 'moment';
 import { ResourceService } from './resource.service';
 import { AuthService } from '../../startup/services/auth.service';
+import { ArmService } from '../../shared/services/arm.service';
+import { v4 as uuid } from 'uuid';
+import { ResponseMessageEnvelope } from '../../shared/models/responsemessageenvelope';
+import { cleanApolloSolutions } from '../utils/apollo-utils';
 
 const moment = momentNs;
 
@@ -14,6 +18,10 @@ const moment = momentNs;
 export class SupportTopicService {
 
     protected detectorTask: Observable<DetectorMetaData[]>;
+    protected apolloApiConfig = {
+        apiVersion: '2020-07-01-preview',
+        apolloResourceProvider: 'providers/Microsoft.Diagnostics/apollo'
+    };
     public supportTopicId: string = "";
     public pesId: string = "";
     public sapSupportTopicId: string = "";
@@ -43,10 +51,57 @@ export class SupportTopicService {
         "14748": ["32629421"]
     };
 
-    constructor(protected _http: HttpClient, protected _authService: AuthService, protected _diagnosticService: DiagnosticService, protected _resourceService: ResourceService, protected _telemetryService: TelemetryService) {
+    constructor(protected _http: HttpClient, protected _authService: AuthService, protected _diagnosticService: DiagnosticService, protected _resourceService: ResourceService, protected _telemetryService: TelemetryService, protected _armService: ArmService) {
     }
 
-    public getSelfHelpContentDocument(): Observable<any> {
+    private cleanSelfHelpContentApollo(selfHelpResponse) {
+        let docContent = selfHelpResponse.properties.content;
+        let result = cleanApolloSolutions(docContent);
+        return result;
+    }
+
+    public getSelfHelpContentApollo(): Observable<any> {
+        if (this.pesId && this.pesId.length > 0 && this.sapSupportTopicId && this.sapSupportTopicId.length > 0) {
+            
+            // To generate a unique apollo search Id, we use resource name, current timestamp and a guid.
+            let apolloResourceId = `${this._resourceService.resource.name}-${Math.floor(Date.now() / 1000)}-${uuid()}`;
+            let requestBody =
+            {
+                "properties" : {
+                  "triggerCriteria": [
+                    {
+                      "name": "SapId",
+                      "value": this.sapSupportTopicId
+                    }
+                  ],
+                  "parameters": {
+                    "SearchText": "error found"
+                  }
+                }
+            };
+            let resourceUri = `${this._resourceService.resource.id}/${this.apolloApiConfig.apolloResourceProvider}/${apolloResourceId}`;
+            return this._armService.putResource(resourceUri, requestBody, this.apolloApiConfig.apiVersion, true).pipe(map((response: ResponseMessageEnvelope<any>) => {
+                return this.cleanSelfHelpContentApollo(response);
+            }));
+        }
+    }
+
+    private cleanSelfHelpContentLegacy(selfHelpResponse) {
+        if (selfHelpResponse && selfHelpResponse.length > 0) {
+            var htmlContent = selfHelpResponse[0]["htmlContent"];
+            // Custom javascript code to remove top header from support document html string
+            var tmp = document.createElement("DIV");
+            tmp.innerHTML = htmlContent;
+            var h2s = tmp.getElementsByTagName("h2");
+            if (h2s && h2s.length > 0) {
+                h2s[0].remove();
+            }
+
+            return tmp.innerHTML;
+        }
+    }
+
+    private getSelfHelpContentLegacy(): Observable<any> {
         if (this.pesId && this.pesId.length > 0 && this.supportTopicId && this.supportTopicId.length > 0) {
             return this._authService.getStartupInfo().pipe(flatMap(res => {
                 var selfHelpContentForSupportTopicUrl = this.selfHelpContentUrl + "&productId=" + encodeURIComponent(this.pesId) + "&topicId=" + encodeURIComponent(this.supportTopicId);
@@ -56,10 +111,14 @@ export class SupportTopicService {
 
                 return this._http.get(selfHelpContentForSupportTopicUrl, {
                     headers: headers
-                });
+                }).pipe(map((response) => { return this.cleanSelfHelpContentLegacy(response); }));
             }));
         }
         return observableOf(null);
+    }
+
+    public getSelfHelpContentDocument(): Observable<any> {
+        return this.getSelfHelpContentApollo().pipe(map(res => res), catchError(err => { return this.getSelfHelpContentLegacy(); }));
     }
 
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -118,6 +118,7 @@ export class SupportTopicService {
     }
 
     public getSelfHelpContentDocument(): Observable<any> {
+        //Call Apollo API, if error then fallback on legacy API
         return this.getSelfHelpContentApollo().pipe(map(res => res), catchError(err => { return this.getSelfHelpContentLegacy(); }));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
@@ -1,0 +1,25 @@
+var isReplacementString = (inputStr) => {
+	return (inputStr.match(/<!--[a-z0-9\-]+-->/) != null);
+}
+
+var sectionParser = (content: string) => {
+	var headingSplits = content.split(/(<h[1-9]>.*<\/h[1-9]>)/);
+	var nonEmptyParts = headingSplits.filter(x => x.length > 1);
+	var sections: string[] = [];
+    if (nonEmptyParts && nonEmptyParts.length > 0) {
+        for (var i=0; i<nonEmptyParts.length; i++) {
+            if (/<h[1-9]>.*<\/h[1-9]>/.test(nonEmptyParts[i])) {
+                sections.push(nonEmptyParts[i] + nonEmptyParts[i+1]);
+                i++;
+            }
+        }
+    }
+	return sections;
+}
+
+export var cleanApolloSolutions = (docContent) => {
+	var sections = sectionParser(docContent);
+	var targetParts = sections.filter((x:string) => x.length > 1 && !isReplacementString(x));
+	targetParts = targetParts[0].includes("<h2>") || !targetParts[0].includes("a href") ? targetParts.slice(1, targetParts.length): targetParts;
+	return targetParts ? targetParts.join('\n'): '';
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
@@ -3,9 +3,12 @@ var isReplacementString = (inputStr) => {
 }
 
 var sectionParser = (content: string) => {
+	//Split on lines with header tag
 	var headingSplits = content.split(/(<h[1-9]>.*<\/h[1-9]>)/);
 	var nonEmptyParts = headingSplits.filter(x => x.length > 1);
 	var sections: string[] = [];
+
+	//Create sections from the splits
     if (nonEmptyParts && nonEmptyParts.length > 0) {
         for (var i=0; i<nonEmptyParts.length; i++) {
             if (/<h[1-9]>.*<\/h[1-9]>/.test(nonEmptyParts[i])) {
@@ -19,7 +22,10 @@ var sectionParser = (content: string) => {
 
 export var cleanApolloSolutions = (docContent) => {
 	var sections = sectionParser(docContent);
+	//Remove sections which have Apollo replacement string
 	var targetParts = sections.filter((x:string) => x.length > 1 && !isReplacementString(x));
+
+	//Also remove the FIRST SECTION if it has h2 tag or if it doesn't contain any links
 	targetParts = targetParts[0].includes("<h2>") || !targetParts[0].includes("a href") ? targetParts.slice(1, targetParts.length): targetParts;
 	return targetParts ? targetParts.join('\n'): '';
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.html
@@ -272,8 +272,7 @@
           <i aria-hidden="true" class="fa fa-file-text-o"></i>
         </div>
         <div class="list-item">
-          <div class="list-title">Recommended Docs</div>
-          <div>Documents to aid in troubleshooting</div>
+          <div class="list-title">Additional troubleshooting resources</div>
           <div class="support-doc-section">
             <markdown *ngIf="supportDocumentContent.length>0" [data]="supportDocumentContent"></markdown>
           </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -258,17 +258,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         if (!this.supportDocumentRendered) {
             this._supportTopicService.getSelfHelpContentDocument().subscribe(res => {
                 if (res && res.length > 0) {
-                    var htmlContent = res[0]["htmlContent"];
-                    // Custom javascript code to remove top header from support document html string
-                    var tmp = document.createElement("DIV");
-                    tmp.innerHTML = htmlContent;
-                    var h2s = tmp.getElementsByTagName("h2");
-                    if (h2s && h2s.length > 0) {
-                        h2s[0].remove();
-                    }
-
-                    // Set the innter html for support document display
-                    this.supportDocumentContent = tmp.innerHTML;
+                    this.supportDocumentContent = res;
                     this.supportDocumentRendered = true;
                 }
             });

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -142,7 +142,7 @@
   </div>
 </div>
 
-<data-container *ngIf="!isAnalysisView && supportDocumentRendered" [title]="'Recommended Docs'">
+<data-container *ngIf="!isAnalysisView && supportDocumentRendered" [title]="'Additional troubleshooting resources'">
   <markdown *ngIf="supportDocumentContent.length>0" #markdownDiv [data]="supportDocumentContent"></markdown>
 </data-container>
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -761,19 +761,8 @@ export class DetectorViewComponent implements OnInit {
     if (!this.supportDocumentRendered) {
       this._supportTopicService.getSelfHelpContentDocument().subscribe(res => {
         if (res && res.length > 0) {
-          var htmlContent = res[0]["htmlContent"];
-          // Custom javascript code to remove top header from support document html string
-          var tmp = document.createElement("DIV");
-          tmp.innerHTML = htmlContent;
-          var h2s = tmp.getElementsByTagName("h2");
-          if (h2s && h2s.length > 0) {
-            h2s[0].remove();
-          }
-
-          // Set the innter html for support document display
-          this.supportDocumentContent = tmp.innerHTML;
+          this.supportDocumentContent = res;
           this.supportDocumentRendered = true;
-
         }
       });
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
@@ -327,17 +327,7 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
             this._supportTopicService.getSelfHelpContentDocument().subscribe(res => {
                 this.azureGuidesShowLoader = false;
                 if (res && res.length > 0) {
-                    var htmlContent = res[0]["htmlContent"];
-                    // Custom javascript code to remove top header from support document html string
-                    var tmp = document.createElement("DIV");
-                    tmp.innerHTML = htmlContent;
-                    var h2s = tmp.getElementsByTagName("h2");
-                    if (h2s && h2s.length > 0) {
-                        h2s[0].remove();
-                    }
-
-                    // Set the innter html for support document display
-                    this.supportDocumentContent = tmp.innerHTML;
+                    this.supportDocumentContent = res;
                     this.supportDocumentRendered = true;
                 }
             }, (err) => {


### PR DESCRIPTION
We are making change to our self help content pulling mechanism as follows:
- First we talk to the Apollo API. If Apollo API returns a response, we clean it up and render it.
- If Apollo API fails, then we fallback on the earlier API we have been using.

Some screenshots with scenarios:
1. WebApps analysis view:
![image](https://user-images.githubusercontent.com/8492235/188245589-e09a5fa4-34b0-4a66-87a8-197b1dafa6bd.png)

2. WebApps detector view:
![image](https://user-images.githubusercontent.com/8492235/188245606-541db5e5-d0c4-4e9e-a309-cafd945f5849.png)

3. AKS analysis view:
![image](https://user-images.githubusercontent.com/8492235/188245575-df0e48cb-a709-43ba-b74f-219f866fd371.png)
