### PR TITLE
AppInsights Encryption feature improvements and error handling

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/appinsights/appinsights.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/appinsights/appinsights.service.ts
@@ -78,7 +78,15 @@ export class AppInsightsService {
                 this.siteName = resourceUriParts.siteName;
                 this.slotName = resourceUriParts.slotName;
 
-                this.loadAppInsightsSettings(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName);
+                this._backendService.get<string>(`api/appsettings/AppInsights:UseCertificates`).subscribe(useCertificatesSetting => {
+                    if (useCertificatesSetting 
+                        && useCertificatesSetting.toString().toLowerCase() == 'true') {
+                            this.useAppSettingsForAppInsightEncryption = true;
+                    }
+                    this.loadAppInsightsSettings(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName);
+                }, error => {
+                    this.loadAppInsightsSettings(resourceUriParts.subscriptionId, resourceUriParts.resourceGroup, resourceUriParts.siteName, resourceUriParts.slotName);
+                });
             }
         });
     }
@@ -496,7 +504,7 @@ export class AppInsightsService {
     public getAppInsightsArmTag(resourceUri: string): Observable<any> {
         return this.getExistingTags(resourceUri).pipe(
             map(existingTags => {
-                if (existingTags[this.appInsightsTagName] != null) {
+                if (existingTags != null && existingTags[this.appInsightsTagName] != null) {
                     var appInsightsTag = JSON.parse(existingTags[this.appInsightsTagName]);
                     return appInsightsTag;
 

--- a/Backend/Controllers/AppSettingsController.cs
+++ b/Backend/Controllers/AppSettingsController.cs
@@ -17,7 +17,7 @@ namespace Backend.Controllers
         private IConfiguration config;
         private IWebHostEnvironment env;
 
-        private string[] AllowedSections = new string[] { "Arm", "ContentSearch", "DeepSearch", "ApplicationInsights", "ASD_ENVIRONMENT", "ASD_HOST", "AcceptOriginSuffix:Origins" };
+        private string[] AllowedSections = new string[] { "Arm", "ContentSearch", "DeepSearch", "ApplicationInsights", "ASD_ENVIRONMENT", "ASD_HOST", "AcceptOriginSuffix:Origins", "AppInsights:UseCertificates" };
 
         public AppSettingsController(IConfiguration configuration, IWebHostEnvironment env)
         {


### PR DESCRIPTION
- Fixed NULL check which was causing apps using the integration feature for the first time to fail if the site has no ARM tags
- Setting the value of `useAppSettingsForAppInsightEncryption `by reading it from the app setting `AppInsights:UseCertificates` (also whitelisted this app setting). This was done because I found issues when UI is using cache version and API is returning latest status for useCertificate to true, a mismatch was happening, and this was causing feature to break
- Added some exception handling and improved some error logging.