### PR TITLE
Use Network Troubleshooter to TCP Ping websites and wrap management requests

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
@@ -2,11 +2,11 @@ import { TelemetryService } from 'diagnostic-data';
 import { Globals } from 'projects/app-service-diagnostics/src/app/globals';
 import { stringify } from 'querystring';
 import { ResponseMessageEnvelope } from '../../../models/responsemessageenvelope';
-import { Site, SiteInfoMetaData } from '../../../models/site';
 import { NetworkTroubleshooterPostAPIBody, Credentials, CredentialReference, ResourceMetadata, NetworkTroubleshooterPostTcpPingBody, WrappedManagementApiBody } from '../../../models/network-troubleshooter/post-request-body'
+import { Site, SiteInfoMetaData } from '../../../models/site';
 import { ArmService } from '../../../services/arm.service';
 import { SiteService } from '../../../services/site.service';
-import { unwrapResolvedMetadata } from '@angular/compiler';
+
 
 enum ConnectionCheckStatus { success, timeout, hostNotFound, blocked, refused }
 export enum OutboundType { SWIFT, gateway };
@@ -129,9 +129,7 @@ export class DiagProvider {
 
     public async postNetworkTroubleshooterApiAsync(api: string, body: any, timeoutInSec: number = 15): Promise<any> {
         var params = "api-version=2015-08-01";
-        //TODO: Temporary switch to calling SCM - revert to calling ARM once ARM manifest is updated
-        var prefix = `management.azure.com/${this._siteInfo.resourceUri}`;
-        //var prefix = `${this.scmHostName}/NetworkValidationChecker`;
+        var prefix = `management.azure.com/${this._siteInfo.resourceUri}/NetworkValidationChecker`;
         var stack = new Error("error_message_placeholder").stack;
         var promise = this._armService.post(`https://${prefix}/${api}?${params}`, body)
             .toPromise()

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/diag-provider.ts
@@ -175,7 +175,7 @@ export class DiagProvider {
         {
           throw Error("No response received when calling the network troubleshooter endpoint via postNetworkTroubleshooterApiAsync().");
         }
-        return unwrapResolvedMetadata(response);
+        return DiagProvider.unWrapManagementRequest(response);
     }
 
     public getKuduApiAsync(uri: string, instance?: string, timeoutInSec: number = 15, scm = false): Promise<any> {
@@ -287,7 +287,9 @@ export class DiagProvider {
         var requestBody = new NetworkTroubleshooterPostTcpPingBody();
         requestBody.Host = hostname;
         requestBody.Port = port;
-        var response: any = await this.postNetworkTroubleshooterApiAsync("tcpPingCheck", requestBody, timeout);
+        var wrappedBody = DiagProvider.wrapManagementRequest(requestBody);
+        var wrappedResponse: any = await this.postNetworkTroubleshooterApiAsync("tcpPingCheck", wrappedBody, timeout);
+        var response = DiagProvider.unWrapManagementRequest(wrappedResponse)
         if (response == null)
         {
           throw Error("No response received when calling the Network Troubleshooter for tcpPingNetworkTroubleshooterAsync().");

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/flowMisc.js
@@ -685,7 +685,28 @@ export function addSubnetSelectionDropDownView(siteInfo, diagProvider, flowMgr, 
 export async function checkNetworkTroubleshooterApiAsync(diagProvider) {
     var params = [];
     params.push("api-version=2015-08-01");
-    // TODO: determine/create an api that tells us if the backend is available to handle requests
+
+    // TODO :: Use the GET endpoint for the Network Troubleshooter to return version/status for health.
+    // This is currently not accessible through management plane. Possible to use SCM or to open route
+    // Temp - Use TCPPing to cover the functionality
+    var healthyTarget  = "www.microsoft.com";
+    var healthyPort = 80;
+    var tcpPingPromise = diagProvider.tcpPingNetworkTroubleshooterAsync(healthyTarget, healthyPort).catch(e => {
+        logDebugMessage(e);
+        return {};
+    });
+    var response = await tcpPingPromise;
+    var isAccessible = false;
+    if (response == null) {
+        throw new Error("Unexpected Null response in CheckNetworkTroubleShooterApiAsync for Tcppingpromise");
+    }
+    else
+    {
+        // ConnectionCheckStatus is a Enum defined in Diag-Provider.ts but, not exported that represents states all other than 0 is fail
+        isAccessible = response.status == 0;
+    }
+
+   // TODO: determine/create an api that tells us if the backend is available to handle requests
     //var versionInfo = await diagProvider.getDaaSExtApiAsync("Version",params);
     var isAccessible = true;
     /*if(versionInfo.status == "200") {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
@@ -17,10 +17,10 @@ export var functionsFlow = {
     async func(siteInfo, diagProvider, flowMgr) {
 
         var isKuduAccessiblePromise = null;
-        if (siteInfo.kind.includes("linux") || siteInfo.kind.includes("container")) {
+        if (siteInfo.kind.includes("container")) {
             isKuduAccessiblePromise = false;
         } else {
-            isKuduAccessiblePromise = checkKuduAvailabilityAsync(diagProvider, flowMgr);
+            isKuduAccessiblePromise = true; //checkKuduAvailabilityAsync(diagProvider, flowMgr);
         }
         var dnsServers = null;
         var vnetConfigChecker = new VnetIntegrationConfigChecker(siteInfo, diagProvider);
@@ -44,7 +44,7 @@ export var functionsFlow = {
         }
 
         if (!await isKuduAccessiblePromise) {
-            if (siteInfo.kind.includes("linux") || siteInfo.kind.includes("container")) {
+            if (siteInfo.kind.includes("container")) {
                 flowMgr.addView(new CommonWordings().connectivityCheckUnsupported.get());
             } else {
                 flowMgr.addView(new VnetDnsWordings().cannotCheckWithoutKudu.get("Functions settings"));
@@ -445,8 +445,8 @@ async function runConnectivityCheckAsync(hostname, port, dnsServers, diagProvide
     var tcpPingResult = await tcpPingPromise;
     var status = tcpPingResult.status;
     if (status == 0) {
-        // Suppress successful checks to avoid clutter
-        //subChecks.push({ title: `TCP ping to ${hostname} was successful`, level: 0 });
+        // Suppress successful checks to avoid clutter TODO CLINK : REDO
+        subChecks.push({ title: `TCP ping to ${hostname} was successful`, level: 0 });
     } else if (status == 1) {
         var markdown = `Connectivity test failed at TCP level for hostname **${hostname}** via resolved IP address ${resolvedIp}.  ` +
             "This means the endpoint was not reachable at the network transport layer. Possible reasons can be:" +

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
@@ -402,7 +402,7 @@ async function runConnectivityCheckAsync(hostname, port, dnsServers, diagProvide
     })();
 
     //TODO: Perform tcpping validation through NetworkValidationChecker endpoint instead of kudu
-    var tcpPingPromise = diagProvider.tcpPingAsync(hostname, port).catch(e => {
+    var tcpPingPromise = diagProvider.tcpPingNetworkTroubleshooterAsync(hostname, port).catch(e => {
         logDebugMessage(e);
         return {};
     });

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/network-checks/network-check-flows/functionsFlow.js
@@ -17,10 +17,10 @@ export var functionsFlow = {
     async func(siteInfo, diagProvider, flowMgr) {
 
         var isKuduAccessiblePromise = null;
-        if (siteInfo.kind.includes("container")) {
+        if (siteInfo.kind.includes("linux") ||siteInfo.kind.includes("container")) {
             isKuduAccessiblePromise = false;
         } else {
-            isKuduAccessiblePromise = true; //checkKuduAvailabilityAsync(diagProvider, flowMgr);
+            isKuduAccessiblePromise = checkKuduAvailabilityAsync(diagProvider, flowMgr);
         }
         var dnsServers = null;
         var vnetConfigChecker = new VnetIntegrationConfigChecker(siteInfo, diagProvider);
@@ -44,7 +44,7 @@ export var functionsFlow = {
         }
 
         if (!await isKuduAccessiblePromise) {
-            if (siteInfo.kind.includes("container")) {
+            if (siteInfo.kind.includes("linux") || siteInfo.kind.includes("container")) {
                 flowMgr.addView(new CommonWordings().connectivityCheckUnsupported.get());
             } else {
                 flowMgr.addView(new VnetDnsWordings().cannotCheckWithoutKudu.get("Functions settings"));
@@ -445,7 +445,6 @@ async function runConnectivityCheckAsync(hostname, port, dnsServers, diagProvide
     var tcpPingResult = await tcpPingPromise;
     var status = tcpPingResult.status;
     if (status == 0) {
-        // Suppress successful checks to avoid clutter TODO CLINK : REDO
         subChecks.push({ title: `TCP ping to ${hostname} was successful`, level: 0 });
     } else if (status == 1) {
         var markdown = `Connectivity test failed at TCP level for hostname **${hostname}** via resolved IP address ${resolvedIp}.  ` +

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/network-troubleshooter/post-request-body.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/network-troubleshooter/post-request-body.ts
@@ -4,6 +4,11 @@ export class NetworkTroubleshooterPostAPIBody {
     ResourceMetadata: ResourceMetadata;
 }
 
+export class NetworkTroubleshooterPostTcpPingBody {
+    Host: string;
+    Port: number;
+}
+
 export class Credentials {
     CredentialType: string;
     CredentialReference: CredentialReference;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/network-troubleshooter/post-request-body.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/network-troubleshooter/post-request-body.ts
@@ -1,3 +1,7 @@
+export class WrappedManagementApiBody {
+    Properties: any
+}
+
 export class NetworkTroubleshooterPostAPIBody {
     ProviderType: string;
     Credentials: Credentials;


### PR DESCRIPTION
Updated code with unwrap/wrap for management api requests. 
Added new method that uses NetworkTroubleshooter to run TCP Pings. Received a 200 response testing on Balag-win-ep2 app FunctionApp.

Prior to change : 
Run Kudu Bash command to TCP ping Host:Port 
Stream stdout, split by /r/n, capture results for all responses from TCP Ping

Now : 
Use NetworkTroubleshooter API to execute TCP Ping against host. 