### PR TITLE
Fix intermittent unauth issue and refactor code in auth handler

### DIFF
--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -121,7 +121,7 @@ namespace AppLensV3
 
             if (Environment.IsDevelopment())
             {
-                services.AddSingleton<IAuthorizationHandler, SecurityGroupLocalDevelopment>();
+                services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerLocalDevelopment>();
             }
             else
             {


### PR DESCRIPTION
In AppLens, because we used Dictionary and not ConcurrentDictionary for inmemory caching of user auth status, there is an intermittent issue that occurs sometimes due to multiple threads concurrently trying to modify the dictionary due to which user will get "Unauthorized access". Checking in AppInsights logs, nearly ~10 users see this intermittently at some point of time every week.

This PR fixes the issue.