### PR TITLE
Fix for Gauge CSS 

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/guage-graphic/guage-graphic.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/guage-graphic/guage-graphic.component.scss
@@ -1,3 +1,5 @@
+@import "../../../../../app-service-diagnostics/src/styles.scss";
+
 .needle{
     z-index: 5;
     position: absolute;


### PR DESCRIPTION
Re-import the CSS for Gauge rendering.

![image](https://user-images.githubusercontent.com/20996681/195220189-11e77425-3a8c-4bc4-947e-e3294c6e978b.png)
