### PR TITLE
Show deep links on category tile

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.html
@@ -7,8 +7,15 @@
     <div class="tile-content">
       <h3 class="tile-title">{{category.name}}</h3>
       <p class="tile-description">{{category.description}}</p>
-      <p class="tile-keywords">Ex: {{keywords}}</p>
-      <a>Troubleshoot</a>
+      <div *ngIf="(!!category && !!category.categoryQuickLinks && category.categoryQuickLinks.length > 0); else keywordsTemplate ">
+        <div class="quick-link" *ngFor="let quickLink of category.categoryQuickLinks">
+          <a tabindex="0" (click)="clickCategoryQuickLink($event, quickLink)" (keyup.enter)="clickCategoryQuickLink($event, quickLink)">{{quickLink.displayText}}</a>
+        </div>
+      </div>
+      <ng-template #keywordsTemplate>
+        <p class="tile-keywords">Ex: {{keywords}}</p>
+        <a>Troubleshoot</a>
+      </ng-template>      
     </div>
   </div>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-tile-v4/category-tile-v4.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Category } from '../../../shared-v2/models/category';
+import { Category, CategoryQuickLinkDetails } from '../../../shared-v2/models/category';
 import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { NotificationService } from '../../../shared-v2/services/notification.service';
 import { LoggingV2Service } from '../../../shared-v2/services/logging-v2.service';
-import { DiagnosticService, DetectorMetaData, DetectorType, TelemetryService } from 'diagnostic-data';
+import { DiagnosticService, DetectorMetaData, DetectorType, TelemetryService, TelemetryEventNames } from 'diagnostic-data';
 import { ResourceService } from '../../../shared-v2/services/resource.service';
 import { PortalActionService } from '../../../shared/services/portal-action.service';
 
@@ -24,6 +24,23 @@ export class CategoryTileV4Component implements OnInit {
   ngOnInit() {
     this.categoryImgPath = this.generateImagePath(this.category.id);
     this.keywords = this.category.keywords.join(", ");
+  }
+  clickCategoryQuickLink(e:Event, quickLink:CategoryQuickLinkDetails):void {
+    e.stopPropagation();
+    this._telemetryService.logEvent(TelemetryEventNames.QuickLinkOnCategoryTileClicked, {
+      'categoryId': this.category.id,
+      'quickLinkType': quickLink.type,
+      'quickLinkId': quickLink.id,
+      'quickLinkDisplayText': quickLink.displayText
+    });
+
+    if(quickLink.type === DetectorType.Detector || quickLink.type === DetectorType.Analysis) {
+      this._portalService.openBladeDiagnoseDetectorId(this.category.id, quickLink.id, quickLink.type);
+    } else if (quickLink.type === DetectorType.CategoryOverview) {
+      this._portalService.openBladeDiagnoseCategoryBlade(this.category.id);
+    } else  if(quickLink.type === DetectorType.DiagnosticTool) {
+      this._portalService.openBladeDiagnosticToolId(quickLink.id, this.category.id);
+    }    
   }
 
   openBladeDiagnoseCategoryBlade() {

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.html
@@ -5,7 +5,13 @@
   </div>
   <div class="category-body">
     <p>{{category.description}}</p>
-    <div>
+    <div *ngIf="(!!category && !!category.categoryQuickLinks && category.categoryQuickLinks.length > 0); else keywordsTemplate">
+      <div class="quick-link" *ngFor="let quickLink of category.categoryQuickLinks">
+        <a tabindex="0" (click)="clickCategoryQuickLink($event, quickLink)" (keyup.enter)="clickCategoryQuickLink($event, quickLink)">{{quickLink.displayText}}</a>
+      </div>
+    </div>
+    <ng-template #keywordsTemplate>
+      <div>
         <span class="keyword-label">Keywords</span>
         <div class="keywords">
           <div class="keyword" [style.border-color]="category.color" *ngFor="let keyword of category.keywords">
@@ -13,6 +19,7 @@
           </div>
         </div>
       </div>
+    </ng-template>
   </div>
 
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-tile/category-tile.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Category } from '../../../shared-v2/models/category';
+import { Category, CategoryQuickLinkDetails } from '../../../shared-v2/models/category';
 import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { NotificationService } from '../../../shared-v2/services/notification.service';
 import { LoggingV2Service } from '../../../shared-v2/services/logging-v2.service';
-import { DiagnosticService, DetectorMetaData, DetectorType } from 'diagnostic-data';
+import { DiagnosticService, DetectorMetaData, DetectorType, TelemetryService, TelemetryEventNames } from 'diagnostic-data';
 import { ResourceService } from '../../../shared-v2/services/resource.service';
 
 @Component({
@@ -15,9 +15,24 @@ export class CategoryTileComponent implements OnInit {
 
   @Input() category: Category;
 
-  constructor(private _router: Router, private _activatedRoute: ActivatedRoute, private _notificationService: NotificationService, private _logger: LoggingV2Service, private _diagnosticService: DiagnosticService, private _resourceService: ResourceService) { }
+  constructor(private _router: Router, private _activatedRoute: ActivatedRoute, private _notificationService: NotificationService, private _logger: LoggingV2Service, private _diagnosticService: DiagnosticService, private _resourceService: ResourceService, private _telemetryService: TelemetryService) { }
 
   ngOnInit() {
+  }
+
+  clickCategoryQuickLink(e:Event, quickLink:CategoryQuickLinkDetails):void {
+    e.stopPropagation();
+    this._telemetryService.logEvent(TelemetryEventNames.QuickLinkOnCategoryTileClicked, {
+      'categoryId': this.category.id,
+      'quickLinkType': quickLink.type,
+      'quickLinkId': quickLink.id,
+      'quickLinkDisplayText': quickLink.displayText
+    });
+    if(quickLink.type === DetectorType.Detector) {
+      this._router.navigateByUrl(`resource${this._resourceService.resourceIdForRouting}/detectors/${quickLink.id}`);
+    } else if (quickLink.type === DetectorType.Analysis) {
+      this._router.navigateByUrl(`resource${this._resourceService.resourceIdForRouting}/analysis/${quickLink.id}`);
+    }
   }
 
   navigateToCategory(): void {

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -61,6 +61,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'LinuxAvailabilityAndPerformance',
         description: 'Check your app’s health and discover app or platform issues.',
         keywords: ['Downtime', '5xx', '4xx', 'CPU', 'Memory','SNAT'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'LinuxLogViewer',
+          displayText:'Application Logs'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'LinuxContainerCrash',
+            displayText:'Container Crash'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'http server errors',
+            displayText:'HTTP Server Errors'
+          }
+        ],
         color: 'rgb(208, 175, 239)',
         createFlowForCategory: false,
         chatEnabled: false
@@ -81,7 +97,7 @@ export class SitesCategoryService extends CategoryService {
         categoryQuickLinks:[{
           type:DetectorType.Detector,
           id:'EasyAuth',
-          displayText:'Authentication Configuration and Investigation (EasyAuth)'
+          displayText:'Investigate EasyAuth errors'
           },
           {
             type:DetectorType.Detector,
@@ -112,6 +128,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'linuxconfigurationandmanagement',
         description: 'Find out if your app service features are misconfigured.',
         keywords: ['Backups', 'Slots', 'Swaps', 'Scaling','IP Config'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'EasyAuth',
+          displayText:'Investigate EasyAuth errors'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'ipconfiguration',
+            displayText:'IP Address Configuration'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'allscalingoperations',
+            displayText:'All Scaling Operations'
+          }
+        ],
         color: 'rgb(249, 213, 180)',
         createFlowForCategory: true,
         chatEnabled: false
@@ -192,6 +224,17 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'LinuxBestPractices',
         description: 'Analyze your app for optimal performance and configurations.',
         keywords: ['Autoscale','AlwaysOn','Density','ARR','Health Check'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'ParentAvailabilityAndPerformance',
+          displayText:'Availability risks'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'ParentConfigurationManagement',
+            displayText:'Configuration risks'
+          }
+        ],
         color: 'rgb(208, 228, 176)',
         createFlowForCategory: true,
         chatEnabled: false
@@ -420,6 +463,22 @@ export class SitesCategoryService extends CategoryService {
           overviewDetectorId:'LinuxDiagnosticTools',
           description: 'Run proactive tools to automatically mitigate the app.',
           keywords: ['Auto-Heal'],
+          categoryQuickLinks:[{
+              type: DetectorType.DiagnosticTool,
+              id: ToolIds.AutoHealing,
+              displayText: 'Auto-Heal'
+            },
+            {
+              type: DetectorType.DiagnosticTool,
+              id: ToolIds.NetworkChecks,
+              displayText: 'Network Troubleshooter'
+            },
+            {
+              type: DetectorType.DiagnosticTool,
+              id: ToolIds.AdvancedAppRestart,
+              displayText: 'Advanced Application Restart'
+            }
+          ],
           color: 'rgb(170, 192, 208)',
           createFlowForCategory: false,
           overridePath: `resource${siteId}/diagnosticTools`

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -8,6 +8,8 @@ import { SiteFilteredItem } from '../models/site-filter';
 import { Sku } from '../../../shared/models/server-farm';
 import { WebSitesService } from './web-sites.service';
 import { ArmService } from '../../../shared/services/arm.service';
+import { DetectorType } from 'diagnostic-data';
+import { ToolIds } from '../../../shared/models/tools-constants';
 
 @Injectable()
 export class SitesCategoryService extends CategoryService {
@@ -25,6 +27,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'AvailabilityAndPerformanceWindows',
         description: 'Check your app’s health and discover app or platform issues.',
         keywords: ['Downtime', '5xx', '4xx', 'CPU', 'Memory','SNAT'],
+        categoryQuickLinks:[{
+          type:DetectorType.Analysis,
+          id:'appDownAnalysis',
+          displayText:'Web App Down'
+          },
+          {
+            type:DetectorType.Analysis,
+            id:'perfAnalysis',
+            displayText:'Web App Slow'
+          },
+          {
+            type:DetectorType.Analysis,
+            id:'webappcpu',
+            displayText:'High CPU Analysis'
+          }
+        ],
         color: 'rgb(208, 175, 239)',
         createFlowForCategory: false,
         chatEnabled: false
@@ -60,6 +78,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'ConfigurationAndManagement',
         description: 'Find out if your app service features are misconfigured.',
         keywords: ['Backups', 'Slots', 'Swaps', 'Scaling','IP Config'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'EasyAuth',
+          displayText:'Authentication Configuration and Investigation (EasyAuth)'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'ipconfiguration',
+            displayText:'IP Address Configuration'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'Migration',
+            displayText:'Migration Operations'
+          }
+        ],
         color: 'rgb(249, 213, 180)',
         createFlowForCategory: true,
         chatEnabled: false
@@ -95,6 +129,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'SSLandDomains',
         description: 'Discover issues with certificates and custom domains.',
         keywords: ['4xx','Permissions','Auth','Binding','Cert Failures'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'CustomDomainAndSSL',
+          displayText:'Binding & SSL Configuration'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'CertificateBindingOperations',
+            displayText:'Certificate Binding Operations'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'clientcertificateloadfailures',
+            displayText:'Client Certificate Failures'
+          }
+        ],
         color: 'rgb(186, 211, 245)',
         createFlowForCategory: true,
         chatEnabled: true
@@ -113,6 +163,17 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId: 'BestPractices',
         description: 'Analyze your app for optimal performance and configurations.',
         keywords: ['Autoscale','AlwaysOn','Density','ARR','Health Check'],
+        categoryQuickLinks:[{
+          type:DetectorType.Detector,
+          id:'ParentAvailabilityAndPerformance',
+          displayText:'Availability risks'
+          },
+          {
+            type:DetectorType.Detector,
+            id:'ParentConfigurationManagement',
+            displayText:'Configuration risks'
+          }
+        ],
         color: 'rgb(208, 228, 176)',
         createFlowForCategory: true,
         chatEnabled: false
@@ -325,6 +386,22 @@ export class SitesCategoryService extends CategoryService {
         overviewDetectorId:'DiagnosticTools',
         description: 'Run proactive tools to automatically mitigate the app.',
         keywords: ['Auto-Heal'],
+        categoryQuickLinks:[{
+          type: DetectorType.DiagnosticTool,
+          id: ToolIds.EventViewer,
+          displayText: 'Application Event Logs'
+          },
+          {
+            type: DetectorType.DiagnosticTool,
+            id: ToolIds.AutoHealing,
+            displayText: 'Auto-Heal'
+          },
+          {
+            type: DetectorType.DiagnosticTool,
+            id: ToolIds.AdvancedAppRestart,
+            displayText: 'Advanced Application Restart'
+          }
+        ],
         color: 'rgb(170, 192, 208)',
         createFlowForCategory: false,
         overridePath: `resource${siteId}/diagnosticTools`

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/models/category.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/models/category.ts
@@ -1,11 +1,20 @@
+import { DetectorType } from 'diagnostic-data';
+
 export interface Category {
     id: string;
     name: string;
     overviewDetectorId: string;
     description: string;
     keywords: string[];
+    categoryQuickLinks?: CategoryQuickLinkDetails[];
     color: string;
     createFlowForCategory: boolean;
     overridePath?: string;
     chatEnabled: boolean;
+}
+
+export interface CategoryQuickLinkDetails {
+    type: DetectorType;
+    id:string;
+    displayText:string;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -75,6 +75,7 @@ export const TelemetryEventNames = {
     OpenFeedbackPanel: 'OpenFeedbackPanel',
     RefreshClicked: 'RefreshClicked',
     QuickLinkClicked: 'QuickLinkClicked',
+    QuickLinkOnCategoryTileClicked: 'QuickLinkOnCategoryTileClicked',
     RiskTileClicked: 'RiskTileClicked',
     RiskTileLoaded: 'RiskTileLoaded',
     ArmConfigMergeError: 'ArmConfigMergeError',


### PR DESCRIPTION
Add deep link to most frequently used tools/detectors within the category tile on the home page.
Add logging to allow for easy data mining for understanding user behavior.

![image](https://user-images.githubusercontent.com/20996681/196495459-250c521c-83fa-4e32-8ab4-2739f192810d.png)

Home page for all other products remain unchanged.