### PR TITLE
Add Diagnostic tools for LogicApp standard on Diagnose And Solve portal.

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/home/components/category-nav/category-nav.component.ts
@@ -142,7 +142,7 @@ export class CategoryNavComponent implements OnInit {
             }
         });
         this.toolCategories.push(<SiteFilteredItem<any>>{
-            appType: AppType.WebApp | AppType.FunctionApp,
+            appType: AppType.WebApp | AppType.FunctionApp | AppType.WorkflowApp,
             platform: OperatingSystem.windows | OperatingSystem.linux | OperatingSystem.HyperV,
             sku: Sku.All,
             hostingEnvironmentKind: HostingEnvironmentKind.All,

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -195,7 +195,7 @@ export class SiteFeatureService extends FeatureService {
   addDiagnosticTools(resourceId: string) {
     this.diagnosticTools = [
       {
-        appType: AppType.WebApp | AppType.FunctionApp,
+        appType: AppType.WebApp | AppType.FunctionApp | AppType.WorkflowApp,
         platform: OperatingSystem.windows,
         sku: Sku.NotDynamic,
         hostingEnvironmentKind: HostingEnvironmentKind.All,
@@ -217,7 +217,7 @@ export class SiteFeatureService extends FeatureService {
         }
       },
       {
-        appType: AppType.WebApp | AppType.FunctionApp,
+        appType: AppType.WebApp | AppType.FunctionApp | AppType.WorkflowApp,
         platform: OperatingSystem.windows,
         sku: Sku.NotDynamic,
         hostingEnvironmentKind: HostingEnvironmentKind.All,
@@ -239,7 +239,7 @@ export class SiteFeatureService extends FeatureService {
         }
       },
       {
-        appType: AppType.WebApp | AppType.FunctionApp,
+        appType: AppType.WebApp | AppType.FunctionApp | AppType.WorkflowApp,
         platform: OperatingSystem.windows,
         sku: Sku.NotDynamic,
         hostingEnvironmentKind: HostingEnvironmentKind.All,
@@ -283,7 +283,7 @@ export class SiteFeatureService extends FeatureService {
         }
       },
       {
-        appType: AppType.WebApp | AppType.FunctionApp,
+        appType: AppType.WebApp | AppType.FunctionApp | AppType.WorkflowApp,
         platform: OperatingSystem.windows,
         sku: Sku.NotDynamic,
         hostingEnvironmentKind: HostingEnvironmentKind.All,
@@ -388,28 +388,6 @@ export class SiteFeatureService extends FeatureService {
               this._router.navigateByUrl(`resource${resourceId}/tools/networkchecks`);
             } else {
               this.navigateTo(resourceId, ToolIds.NetworkChecks);
-            }
-          })
-        }
-      },
-      {
-        appType: AppType.WorkflowApp,
-        platform: OperatingSystem.any,
-        sku: Sku.All,
-        hostingEnvironmentKind: HostingEnvironmentKind.All,
-        stack: '',
-        item: {
-          id: ToolIds.NetworkChecks,
-          name: ToolNames.NetworkChecks,
-          category: 'Networking',
-          description: '',
-          featureType: DetectorType.DiagnosticTool,
-          clickAction: this._createFeatureAction(ToolNames.NetworkChecks, 'Networking', () => {
-            //Need remove after A/B test
-            if (this.isLegacy) {
-              this._router.navigateByUrl(`resource${resourceId}/tools/networkchecks`);
-            } else {
-              this.navigateTo(resourceId, ToolIds.NetworkChecks, "Networking");
             }
           })
         }

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/site-feature.service.ts
@@ -393,6 +393,28 @@ export class SiteFeatureService extends FeatureService {
         }
       },
       {
+        appType: AppType.WorkflowApp,
+        platform: OperatingSystem.any,
+        sku: Sku.All,
+        hostingEnvironmentKind: HostingEnvironmentKind.All,
+        stack: '',
+        item: {
+          id: ToolIds.NetworkChecks,
+          name: ToolNames.NetworkChecks,
+          category: 'Networking',
+          description: '',
+          featureType: DetectorType.DiagnosticTool,
+          clickAction: this._createFeatureAction(ToolNames.NetworkChecks, 'Networking', () => {
+            //Need remove after A/B test
+            if (this.isLegacy) {
+              this._router.navigateByUrl(`resource${resourceId}/tools/networkchecks`);
+            } else {
+              this.navigateTo(resourceId, ToolIds.NetworkChecks, "Networking");
+            }
+          })
+        }
+      },
+      {
         appType: AppType.WebApp | AppType.FunctionApp,
         platform: OperatingSystem.linux,
         sku: Sku.Paid,

--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -537,6 +537,24 @@ export class SitesCategoryService extends CategoryService {
             createFlowForCategory: false,
             overridePath: `resource${siteId}/diagnosticTools`
           }
+        },
+        // For Workflow app on Windows
+        {
+          appType: AppType.WorkflowApp,
+          platform: OperatingSystem.windows,
+          stack: 'ASP.NET Core',
+          sku: Sku.NotDynamic,
+          hostingEnvironmentKind: HostingEnvironmentKind.All,
+          item: {
+            id: 'DiagnosticTools',
+            name: 'Diagnostic Tools',
+            overviewDetectorId:'DiagnosticTools',
+            description: 'Run proactive tools to automatically mitigate the app.',
+            keywords: ['Auto-Heal'],
+            color: 'rgb(170, 192, 208)',
+            createFlowForCategory: false,
+            overridePath: `resource${siteId}/diagnosticTools`
+          }
         }];
   }
 


### PR DESCRIPTION
Enabling Diagnostic Tools in portal for Logic App Standard.

![image](https://user-images.githubusercontent.com/20996681/197909984-eb73ccb1-b850-4b0b-b875-033c12eac61e.png)

![image](https://user-images.githubusercontent.com/20996681/197911454-8f432a85-93a0-4156-a42d-0a8bbe18dd97.png)

Will be powered by Overview detector
![image](https://user-images.githubusercontent.com/20996681/197911621-10c1e623-2a25-46c9-97cd-90144d9964b0.png)
