### PR TITLE
Removing Observer namespace + new ObserverSku

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ObserverService } from '../../../shared/services/observer.service';
+import { ObserverAseInfo } from '../../../shared/models/observer';
 
 @Component({
   selector: 'ase-finder',
@@ -11,7 +12,7 @@ export class AseFinderComponent implements OnInit {
 
   hostingEnvironment: string;
   loading: boolean = true;
-  matchingAse: Observer.ObserverAseInfo;
+  matchingAse: ObserverAseInfo;
   error: string;
   contentHeight: string;
 
@@ -35,7 +36,7 @@ export class AseFinderComponent implements OnInit {
     });
   }
 
-  navigateToAse(matchingAse: Observer.ObserverAseInfo) {
+  navigateToAse(matchingAse: ObserverAseInfo) {
     let resourceArray: string[] = [
       'subscriptions', matchingAse.CustomerSubscriptionId,
       'resourceGroups', matchingAse.ResourceGroupName,

--- a/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/containerapp/containerapp-finder/containerapp-finder.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ObserverContainerAppInfo } from '../../../shared/models/observer';
 import { ObserverService } from '../../../shared/services/observer.service';
 import { StartupService } from '../../../shared/services/startup.service';
 
@@ -14,7 +15,7 @@ export class ContainerAppFinderComponent implements OnInit {
   loading: boolean = true;
   error: string;
 
-  matchingSites: Observer.ObserverContainerAppInfo[] = [];
+  matchingSites: ObserverContainerAppInfo[] = [];
 
   contentHeight: string;
 
@@ -45,7 +46,7 @@ export class ContainerAppFinderComponent implements OnInit {
     });
   }
 
-  navigateToSite(matchingSite: Observer.ObserverContainerAppInfo) {
+  navigateToSite(matchingSite: ObserverContainerAppInfo) {
     let resourceArray: string[] = [
       'subscriptions', matchingSite.SubscriptionName,
       'resourceGroups', matchingSite.ResourceGroupName,

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -158,7 +158,8 @@ export class DashboardContainerComponent implements OnInit {
         'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
         'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString(): "",
         'ReportType': 'ResiliencyScore',  
-        'Error': error
+        'Error': error,
+        'Message': 'Error trying to retrieve showCoachmark from localStorage'
       }
       this._telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportInPrivateAccess, eventProperties);
     }
@@ -336,7 +337,8 @@ export class DashboardContainerComponent implements OnInit {
         'Subscription': this.subscriptionId,
         'TimeClicked': sT.toUTCString(),
         'ReportType': 'ResiliencyScore',
-        'Error': error
+        'Error': error,
+        'Message': 'Error trying to retrieve showCoachmark from localStorage'
       }
       this._telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportInPrivateAccess, eventProperties);
     }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -13,7 +13,7 @@ import { DetectorResponse, TelemetryEventNames, TelemetryService, ResiliencyScor
 import { SeverityLevel } from '@microsoft/applicationinsights-web';
 import { HttpClient } from '@angular/common/http';
 import { DetectorControlService } from 'diagnostic-data';
-import { Sku } from 'projects/app-service-diagnostics/src/app/shared/models/server-farm';
+import { ObserverSiteSku, ObserverSkuType } from '../../../shared/models/observer';
 
 @Component({
   selector: 'dashboard-container',
@@ -35,7 +35,7 @@ export class DashboardContainerComponent implements OnInit {
 
 // Variables used by Download Report button    
   detector: string = "";
-  siteSku: Observer.ObserverSiteSku;
+  siteSku: ObserverSiteSku;
   subscriptionId: string;
   displayDownloadReportButton: boolean = false;
   displayDownloadReportButtonStyle: any = {};
@@ -181,15 +181,15 @@ export class DashboardContainerComponent implements OnInit {
 
   // Check if the app is an App Service Windows Standard or higher SKU
   private checkIsWindowsApp() {
-    let _sku: Sku = Sku.All;      
-    _sku = Sku[this.siteSku.sku];
+    let _sku: ObserverSkuType = ObserverSkuType.All;
+    _sku = ObserverSkuType[this.siteSku.sku];
     return this.siteSku && this.getAppType(this.siteSku.kind.toLowerCase()) === "WebApp" && !this.siteSku.is_linux && _sku > 8; //Only for Web App (Windows) in Standard or higher SKU     
   }
 
   // Check if the app is an App Service Linux Standard or higher SKU
   private checkIsLinuxApp() {
-    let _sku: Sku = Sku.All;  
-    _sku = Sku[this.siteSku.sku];
+    let _sku: ObserverSkuType = ObserverSkuType.All;      
+    _sku = ObserverSkuType[this.siteSku.sku];
     return this.siteSku && this.getAppType(this.siteSku.kind.toLowerCase()) === "LinuxApp" && this.siteSku.is_linux && _sku > 8; //Only for Web App (Windows) in Standard or higher SKU 
   }
 

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
@@ -142,7 +142,8 @@ export class TabDataComponent implements OnInit {
         'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
         'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString() : "",
         'ReportType': 'ResiliencyScore',
-        'Error': error
+        'Error': error,
+        'Message': 'Error trying to retrieve showCoachmark from localStorage'
       }
       this._telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportInPrivateAccess, eventProperties);
     }
@@ -353,7 +354,8 @@ export class TabDataComponent implements OnInit {
         'Subscription': this.subscriptionId,
         'TimeClicked': sT.toUTCString(),
         'ReportType': 'ResiliencyScore',
-        'Error': error
+        'Error': error,
+        'Message': 'Error trying to retrieve showCoachmark from localStorage',
       }
       this._telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportInPrivateAccess, eventProperties);
     }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
@@ -12,7 +12,7 @@ import { ObserverService } from '../../../../shared/services/observer.service';
 import { SeverityLevel } from '@microsoft/applicationinsights-web';
 import { DirectionalHint } from 'office-ui-fabric-react';
 import { HttpClient } from '@angular/common/http';
-import { Sku } from 'projects/app-service-diagnostics/src/app/shared/models/server-farm';
+import { ObserverSiteSku, ObserverSkuType } from '../../../../shared/models/observer';
 
 @Component({
   selector: 'tab-data',
@@ -21,7 +21,7 @@ import { Sku } from 'projects/app-service-diagnostics/src/app/shared/models/serv
 })
 export class TabDataComponent implements OnInit {
 
-  constructor(private _route: ActivatedRoute, public resourceService: ResourceService, private _observerService: ObserverService, private _diagnosticApiService: ApplensDiagnosticService, private _detectorControlService: DetectorControlService, private _applensCommandBarService: ApplensCommandBarService, private _applensGlobal: ApplensGlobal, private _telemetryService: TelemetryService, private _http:HttpClient) { }
+  constructor(private _route: ActivatedRoute, public resourceService: ResourceService, private _observerService: ObserverService, private _diagnosticApiService: ApplensDiagnosticService, private _detectorControlService: DetectorControlService, private _applensCommandBarService: ApplensCommandBarService, private _applensGlobal: ApplensGlobal, private _telemetryService: TelemetryService, private _http: HttpClient) { }
 
   detectorResponse: DetectorResponse;
 
@@ -58,37 +58,33 @@ export class TabDataComponent implements OnInit {
   showPanel: boolean = false;
   panelMessage: string = "";
 
-// Variables used by Download Report button
-resourceReady: Observable<any>;
-resource: any;  
-siteSku: Observer.ObserverSiteSku;
-subscriptionId: string;
-displayDownloadReportButton: boolean = false;
-displayDownloadReportButtonStyle: any = {};
-downloadReportId: string;
-downloadReportText: string = "Download report";
-downloadReportIcon: any = { iconName: 'Download' };
-downloadReportButtonDisabled: boolean;
-downloadReportFileName: string;  
-coachmarkId: string;  
-showCoachmark: boolean = true;
-showTeachingBubble: boolean = false;
-generatedOn: string;
-coachmarkPositioningContainerProps = {
-  directionalHint: DirectionalHint.bottomLeftEdge,
-  doNotLayer: true
-};
-teachingBubbleCalloutProps = {
-  directionalHint: DirectionalHint.bottomLeftEdge
-};
-vfsFonts: any;
+  // Variables used by Download Report button
+  resourceReady: Observable<any>;
+  resource: any;
+  siteSku: ObserverSiteSku;
+  subscriptionId: string;
+  displayDownloadReportButton: boolean = false;
+  displayDownloadReportButtonStyle: any = {};
+  downloadReportId: string;
+  downloadReportText: string = "Download report";
+  downloadReportIcon: any = { iconName: 'Download' };
+  downloadReportButtonDisabled: boolean = false;
+  downloadReportFileName: string;
+  coachmarkId: string;
+  showCoachmark: boolean = true;
+  showTeachingBubble: boolean = false;
+  generatedOn: string;
+  coachmarkPositioningContainerProps = {
+    directionalHint: DirectionalHint.bottomLeftEdge,
+    doNotLayer: true
+  };
+  teachingBubbleCalloutProps = {
+    directionalHint: DirectionalHint.bottomLeftEdge
+  };
+  vfsFonts: any;
 
 
-ngOnInit() {
-    this._route.params.subscribe((params: Params) => {
-      this.subscriptionId = params["subscriptionId"];
-      this.refresh();
-    });
+  ngOnInit() {
     // If route query params contains detectorQueryParams, setting the values in shared service so it is accessible in all components
     this._route.queryParams.subscribe((queryParams: Params) => {
       if (queryParams.detectorQueryParams != undefined) {
@@ -97,7 +93,7 @@ ngOnInit() {
         this._detectorControlService.setDetectorQueryParams("");
       }
       this.analysisMode = this._route.snapshot.data['analysisMode'];
-      this.detector = this._route.snapshot.params['detector']? this._route.snapshot.params['detector']: null;
+      this.detector = this._route.snapshot.params['detector'] ? this._route.snapshot.params['detector'] : null;
       this._telemetryService.logEvent(TelemetryEventNames.DownloadReportButtonDisplayed, { 'DownloadReportButtonDisplayed': this.displayDownloadReportButton.toString(), 'Detector:': this.detector, 'SubscriptionId': this._route.parent.snapshot.params['subscriptionid'], 'Resource': this.resource.SiteName });
     });
 
@@ -109,7 +105,7 @@ ngOnInit() {
     }
     this.resourceReady = this.resourceService.getCurrentResource();
     this.resourceReady.subscribe(resource => {
-      if (resource) {  
+      if (resource) {
         this.resource = resource;
       }
     });
@@ -119,28 +115,16 @@ ngOnInit() {
       if (siteSku) {
         this.siteSku = siteSku;
       }
-      });
-    // Detecting whether Download Report button should be displayed or not
-    this.displayDownloadReportButton = this.detector === "ResiliencyScore" && (this.checkIsWindowsApp() || this.checkIsLinuxApp());
+    });
 
-    // Logging telemetry for Download Report button
-    const dRBDEventProperties = {
-      'ResiliencyScoreButtonDisplayed': this.displayDownloadReportButton.toString(),
-      'Subscription': this._route.parent.snapshot.params['subscriptionid'],
-      'Platform': this.siteSku.is_linux != undefined ? !this.siteSku.is_linux ? "Windows" : "Linux" : "",
-      'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
-      'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString(): "",
-      'ReportType': 'ResiliencyScore',      
-    };
-    this._telemetryService.logEvent(TelemetryEventNames.DownloadReportButtonDisplayed, dRBDEventProperties);
-    const loggingError = new Error();
-
-    // Enabling Download Report button
-    this.downloadReportButtonDisabled = false;
+    this._route.params.subscribe((params: Params) => {
+      this.subscriptionId = params["subscriptionId"];
+      this.refresh();
+    });
 
     //Get showCoachMark value(string) from local storage (if exists), then convert to boolean
     try {
-      if (this.displayDownloadReportButton){
+      if (this.displayDownloadReportButton) {
         if (localStorage.getItem("showCoachmark") != undefined) {
           this.showCoachmark = localStorage.getItem("showCoachmark") === "true";
         }
@@ -156,8 +140,8 @@ ngOnInit() {
         'Subscription': this._route.parent.snapshot.params['subscriptionid'],
         'Platform': this.siteSku.is_linux != undefined ? !this.siteSku.is_linux ? "Windows" : "Linux" : "",
         'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
-        'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString(): "",
-        'ReportType': 'ResiliencyScore',  
+        'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString() : "",
+        'ReportType': 'ResiliencyScore',
         'Error': error
       }
       this._telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportInPrivateAccess, eventProperties);
@@ -169,7 +153,7 @@ ngOnInit() {
     // Using this as an alternative to using the vfs_fonts.js build with PDFMake's build-vfs.js
     // as this file caused problems when being compiled in a library project like diagnostic-data
     //
-    this._http.get<any>('assets/vfs_fonts.json').subscribe((data: any) => {this.vfsFonts=data});
+    this._http.get<any>('assets/vfs_fonts.json').subscribe((data: any) => { this.vfsFonts = data });
   }
 
   refresh() {
@@ -187,6 +171,25 @@ ngOnInit() {
         this.pinnedDetector = favoriteDetectorIds.findIndex(d => d.toLowerCase() === this.detector.toLowerCase()) > -1;
       }
     });
+
+    // Detecting whether Download Report button should be displayed or not
+    this.displayDownloadReportButton = this.detector === "ResiliencyScore" && (this.checkIsWindowsApp() || this.checkIsLinuxApp());
+
+    // Detecting whether Download Report button should be displayed or not
+    this.displayDownloadReportButton = this.detector === "ResiliencyScore" && (this.checkIsWindowsApp() || this.checkIsLinuxApp());
+
+    // Logging telemetry for Download Report button
+    const dRBDEventProperties = {
+      'ResiliencyScoreButtonDisplayed': this.displayDownloadReportButton.toString(),
+      'Subscription': this._route.parent.snapshot.params['subscriptionid'],
+      'Platform': this.siteSku.is_linux != undefined ? !this.siteSku.is_linux ? "Windows" : "Linux" : "",
+      'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
+      'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString() : "",
+      'ReportType': 'ResiliencyScore',
+    };
+    this._telemetryService.logEvent(TelemetryEventNames.DownloadReportButtonDisplayed, dRBDEventProperties);
+    const loggingError = new Error();
+
   }
 
   refreshPage() {
@@ -275,15 +278,15 @@ ngOnInit() {
 
   // Check if the app is an App Service Windows Standard or higher SKU
   private checkIsWindowsApp() {
-    let _sku: Sku = Sku.All;      
-    _sku = Sku[this.siteSku.sku];
+    let _sku: ObserverSkuType = ObserverSkuType.All;
+    _sku = ObserverSkuType[this.siteSku.sku];
     return this.siteSku && this.getAppType(this.siteSku.kind.toLowerCase()) === "WebApp" && !this.siteSku.is_linux && _sku > 8; //Only for Web App (Windows) in Standard or higher SKU     
   }
 
   // Check if the app is an App Service Linux Standard or higher SKU
   private checkIsLinuxApp() {
-    let _sku: Sku = Sku.All;  
-    _sku = Sku[this.siteSku.sku];
+    let _sku: ObserverSkuType = ObserverSkuType.All;
+    _sku = ObserverSkuType[this.siteSku.sku];
     return this.siteSku && this.getAppType(this.siteSku.kind.toLowerCase()) === "LinuxApp" && this.siteSku.is_linux && _sku > 8; //Only for Web App (Windows) in Standard or higher SKU 
   }
 
@@ -292,26 +295,26 @@ ngOnInit() {
     if (kind && kind.toLowerCase().indexOf("workflowapp") !== -1) {
       return "WorkflowApp";
     } else if (kind && kind.toLowerCase().indexOf("functionapp") !== -1) {
-      return "FunctionApp";	
+      return "FunctionApp";
     } else if (kind && kind.toLowerCase().indexOf("linux") !== -1) {
-      return "LinuxApp";      
+      return "LinuxApp";
     } else return "WebApp";
   }
-  
 
-updateDownloadReportId() {
+
+  updateDownloadReportId() {
     const btns = document.querySelectorAll("button");
     const downloadButtonId = "downloadReportId";
     const coachMarkId = "fab-coachmark";
     let downloadButtonIndex = -1;
     if (btns && btns.length > 0) {
-      btns.forEach((btn,i) => {
-        if(btn.textContent.includes(this.downloadReportText)) {
+      btns.forEach((btn, i) => {
+        if (btn.textContent.includes(this.downloadReportText)) {
           downloadButtonIndex = i;
         }
       });
 
-      if(downloadButtonIndex >= 0 && downloadButtonIndex < btns.length && btns[downloadButtonIndex]) {
+      if (downloadButtonIndex >= 0 && downloadButtonIndex < btns.length && btns[downloadButtonIndex]) {
         const downloadButton = btns[downloadButtonIndex];
         downloadButton.setAttribute("id", downloadButtonId);
       }
@@ -322,7 +325,7 @@ updateDownloadReportId() {
   }
 
 
-  downloadReport() {   
+  downloadReport() {
     // Start time when download report button is clicked
     let sT = new Date();
 
@@ -364,7 +367,7 @@ updateDownloadReportId() {
         }
       }
     };
-    this.downloadReportButtonDisabled = true;    
+    this.downloadReportButtonDisabled = true;
 
     if (this._route.snapshot.params['detector']) {
       this.detector = this._route.snapshot.params['detector'];
@@ -383,7 +386,7 @@ updateDownloadReportId() {
 
 
     this._diagnosticApiService.getDetector("ResiliencyScore", this._detectorControlService.startTimeString, this._detectorControlService.endTimeString, this._detectorControlService.shouldRefresh, this._detectorControlService.isInternalView, additionalQueryString)
-      .subscribe((httpResponse: DetectorResponse) => {            
+      .subscribe((httpResponse: DetectorResponse) => {
         //If the page hasn't been refreshed this will use a cached request, so changing File Name to use the same name + "(cached)" to let them know they are seeing a cached version.
         let eT = new Date();
         let detectorTimeTaken = eT.getTime() - sT.getTime();
@@ -418,13 +421,13 @@ updateDownloadReportId() {
         loggingError.message = `Error calling ${this.detector} detector`;
         loggingError.stack = error;
         this._telemetryService.logException(loggingError);
-      });    
-  }  
+      });
+  }
 
 
   coachMarkViewed() {
-    if (!this.showTeachingBubble){
-      
+    if (!this.showTeachingBubble) {
+
       //
       // TeachingBubbles inherit from Callout react component and they have a 
       // some issue in the current version of the libaray with *ngIf and they are
@@ -454,7 +457,7 @@ updateDownloadReportId() {
     this.removeTeachingBubbleFromDom();
   }
 
-  showingTeachingBubble(){
+  showingTeachingBubble() {
     this.showTeachingBubble = true;
   }
 

--- a/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/site/site-finder/site-finder.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ObserverSiteInfo } from '../../../shared/models/observer';
 import { ObserverService } from '../../../shared/services/observer.service';
 import { StartupService } from '../../../shared/services/startup.service';
 
@@ -14,7 +15,7 @@ export class SiteFinderComponent implements OnInit {
   loading: boolean = true;
   error: string;
 
-  matchingSites: Observer.ObserverSiteInfo[] = [];
+  matchingSites: ObserverSiteInfo[] = [];
 
   contentHeight: string;
 
@@ -45,7 +46,7 @@ export class SiteFinderComponent implements OnInit {
     });
   }
 
-  navigateToSite(matchingSite: Observer.ObserverSiteInfo) {
+  navigateToSite(matchingSite: ObserverSiteInfo) {
     let resourceArray: string[] = [
       'subscriptions', matchingSite.Subscription,
       'resourceGroups', matchingSite.ResourceGroupName,

--- a/AngularApp/projects/applens/src/app/modules/stamp/stamp-finder/stamp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/stamp/stamp-finder/stamp-finder.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ObserverStampResponse } from '../../../shared/models/observer';
 import { ObserverService } from '../../../shared/services/observer.service';
 import { StartupService } from '../../../shared/services/startup.service';
 
@@ -14,7 +15,7 @@ export class StampFinderComponent implements OnInit {
   loading: boolean = true;
   error: string;
 
-  matchingStamps: Observer.ObserverStampResponse[] = [];
+  matchingStamps: ObserverStampResponse[] = [];
 
   contentHeight: string;
 
@@ -43,7 +44,7 @@ export class StampFinderComponent implements OnInit {
     });
   }
 
-  navigateToStamp(matchingStamp: Observer.ObserverStampResponse) {
+  navigateToStamp(matchingStamp: ObserverStampResponse) {
     let resourceArray: string[] = [
       'stamps', matchingStamp.name];
 

--- a/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/staticwebapp/staticwebapp-finder/staticwebapp-finder.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, NavigationExtras, Router } from "@angular/router";
+import { ObserverStaticWebAppInfo } from "../../../shared/models/observer";
 import { ObserverService } from "../../../shared/services/observer.service";
 import { StartupService } from "../../../shared/services/startup.service";
 
@@ -14,7 +15,7 @@ export class StaticWebAppFinderComponent implements OnInit {
   loading: boolean = true;
   error: string;
 
-  matchingSites: Observer.ObserverStaticWebAppInfo[] = [];
+  matchingSites: ObserverStaticWebAppInfo[] = [];
 
   contentHeight: string;
 
@@ -45,7 +46,7 @@ export class StaticWebAppFinderComponent implements OnInit {
     });
   }
 
-  navigateToSite(matchingSite: Observer.ObserverStaticWebAppInfo) {
+  navigateToSite(matchingSite: ObserverStaticWebAppInfo) {
     let resourceArray: string[] = [
       'subscriptions', matchingSite.SubscriptionName,
       'resourceGroups', matchingSite.ResourceGroupName,

--- a/AngularApp/projects/applens/src/app/shared/models/observer.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/observer.ts
@@ -1,189 +1,187 @@
-namespace Observer {
-    export interface ObserverSiteResponse {
-        siteName: string;
-        details: ObserverSiteInfo[];
-    }
+export interface ObserverSiteResponse {
+    siteName: string;
+    details: ObserverSiteInfo[];
+}
 
-    export interface ObserverContainerAppResponse {
-        containerAppName: string;
-        details: ObserverContainerAppInfo[];
-    }
+export interface ObserverContainerAppResponse {
+    containerAppName: string;
+    details: ObserverContainerAppInfo[];
+}
 
-    export interface ObserverStaticWebAppResponse {
-        defaultHostNameOrAppName: string;
-        details: ObserverStaticWebAppInfo[];
-        
-    }
-  
-    export interface ObserverSiteInfo {
-        SiteName: string;
-        StampName: string;
-        InternalStampName: string;
-        Subscription: string;
-        WebSpace: string;
-        ResourceGroupName: string;
-        SlotName: string;
-        GeomasterName: string;
-        GeomasterServiceAddress: string;
-        Kind: string,
-        IsLinux?: boolean;
-        VnetName: string;
-        LinuxFxVersion: string;
-        WindowsFxVersion: string;
-        AppServicePlan?: string;
-    }
+export interface ObserverStaticWebAppResponse {
+    defaultHostNameOrAppName: string;
+    details: ObserverStaticWebAppInfo[];
 
-    export interface ObserverSiteSku {
-        kind: string;
-        is_linux: boolean;
-        sku: string;
-        server_farm_name: string;
-        actual_number_of_workers: number;
-        current_worker_size: number;
-    }
+}
 
-    export interface ObserverContainerAppInfo {
-        ContainerAppName: string;
-        Tags: string;
-        ResourceGroupName: string;
-        SubscriptionName: string;
-        KubeEnvironmentName: string;
-        Fqdn: string;
-        Location: string;
-        GeoMasterName: string;
-        ServiceAddress: string;
-        Kind: string;
-        IsInAppNamespace: boolean;
-    }
+export interface ObserverSiteInfo {
+    SiteName: string;
+    StampName: string;
+    InternalStampName: string;
+    Subscription: string;
+    WebSpace: string;
+    ResourceGroupName: string;
+    SlotName: string;
+    GeomasterName: string;
+    GeomasterServiceAddress: string;
+    Kind: string,
+    IsLinux?: boolean;
+    VnetName: string;
+    LinuxFxVersion: string;
+    WindowsFxVersion: string;
+    AppServicePlan?: string;
+}
 
-    export interface ObserverStaticWebAppInfo {
-        ApiKey: string;
-        Branch: string;
-        BuildInfo: any[];
-        CustomDomains: string;
-        DefaultHostname: string;
-        GeoMasterInstance: string;
-        Name: string;
-        RepositoryUrl: string;
-        ResourceGroupName: string;
-        Sku: string;
-        StorageRing: string;
-        SubscriptionName: string;
-    }
+export interface ObserverSiteSku {
+    kind: string;
+    is_linux: boolean;
+    sku: string;
+    server_farm_name: string;
+    actual_number_of_workers: number;
+    current_worker_size: number;
+}
 
-    export interface ObserverSiteDetailsResponse {
-        siteName: string;
-        details: ObserverSiteDetailsInfo;
-    }
+export interface ObserverContainerAppInfo {
+    ContainerAppName: string;
+    Tags: string;
+    ResourceGroupName: string;
+    SubscriptionName: string;
+    KubeEnvironmentName: string;
+    Fqdn: string;
+    Location: string;
+    GeoMasterName: string;
+    ServiceAddress: string;
+    Kind: string;
+    IsInAppNamespace: boolean;
+}
 
-    export interface ObserverSiteDetailsInfo {
-        name: string;
-        tags: string;
-        kind: string;
-        namespacedescriptor: string;
-        islinux: boolean;
-        defaulthostname: string;
-        scmsitehostname: string;
-        webspace: string;
-        hostnames: any;
-        resourcegroup: string;
-        vnetname: string;
-        linuxfxversion: string;
-        stamp: any;
-    }
+export interface ObserverStaticWebAppInfo {
+    ApiKey: string;
+    Branch: string;
+    BuildInfo: any[];
+    CustomDomains: string;
+    DefaultHostname: string;
+    GeoMasterInstance: string;
+    Name: string;
+    RepositoryUrl: string;
+    ResourceGroupName: string;
+    Sku: string;
+    StorageRing: string;
+    SubscriptionName: string;
+}
 
-    export interface ObserverAseResponse {
-        details: ObserverAseInfo;
-    }
-  
-    export interface ObserverAseInfo {
-        ID: number;
-        Name: string;
-        LocationId: number;
-        PublicHost: string;
-        VNETName: string;
-        VNETId: string;
-        VNETSubnetName: string;
-        WebWorkerSize: string;
-        WebWorkerRoleCount: number;
-        MultiSize: string;
-        MultiRoleCount: number;
-        IPSSLAddressCount: number;
-        MonitoringDataAccountId: number;
-        SmallDedicatedWebWorkerSize: string;
-        SmallDedicatedWebWorkerRoleCount: number;
-        MediumDedicatedWebWorkerSize: string;
-        MediumDedicatedWebWorkerRoleCount: number;
-        LargeDedicatedWebWorkerSize: string;
-        LargeDedicatedWebWorkerRoleCount: number;
-        Allocated: boolean;
-        DatabaseEdition: string;
-        DatabaseServiceObjective: string;
-        MaximumNumberOfMachines: number;
-        UpgradeDomains: number;
-        VNETSubnetAddressRange: string;
-        DeploymentOrder: number;
-        AllowedMultiSizes?: null;
-        AllowedWorkerSizes?: null;
-        DefinitionsPath?: null;
-        SettingsPath?: null;
-        UserServiceEndpoint: string;
-        CustomerSubscriptionId: string;
-        VNETResourceGroup: string;
-        DeletedOn?: null;
-        DatabaseServerVersion: string;
-        Suspended: boolean;
-        ManualResumeOnly: boolean;
-        ExtraDefinitions: string;
-        InternalLoadBalancingMode: number;
-        ApiHubEnabled: boolean;
-        VNETSubscriptionId: string;
-        CustomBuild: boolean;
-        ClusterSettings?: null;
-        DnsSuffix?: null;
-        VNETResourceType: string;
-        DynamicCacheEnabled: boolean;
-        FileServerRoleCount: number;
-        EnvironmentType: number;
-        InternalStampName: string;
-        Subscription: string;
-        ResourceGroupName: string;
-        GeomasterName: string;
-        GeomasterServiceAddress: string;
-    }
+export interface ObserverSiteDetailsResponse {
+    siteName: string;
+    details: ObserverSiteDetailsInfo;
+}
 
-    export interface ObserverStampInfo {
-        Name: string;
-        SubscriptionId: string;
-        StampType: string;
-        DNS: string;
-        VIP: string;
-        DeploymentId: string;
-        Cluster: string;
-        IsFlexStamp: string;
-        GeoLocation: string;
-    }
+export interface ObserverSiteDetailsInfo {
+    name: string;
+    tags: string;
+    kind: string;
+    namespacedescriptor: string;
+    islinux: boolean;
+    defaulthostname: string;
+    scmsitehostname: string;
+    webspace: string;
+    hostnames: any;
+    resourcegroup: string;
+    vnetname: string;
+    linuxfxversion: string;
+    stamp: any;
+}
 
-    export interface ObserverStampResponse {
-        name: string;
-        details: any;
-    }
+export interface ObserverAseResponse {
+    details: ObserverAseInfo;
+}
 
-    export enum Sku {
-        Free = 1 << 0,
-        Shared = 1 << 1,
-        Dynamic = 1 << 2,
-        Basic = 1 << 3,
-        Standard = 1 << 4,
-        Premium = 1 << 5,
-        PremiumV2 = 1 << 6,
-        Isolated = 1 << 7,
-        PremiumContainer = 1 << 8, // 100000000
-        ElasticPremium = 1 << 9, // 1000000000
-        Paid = 1016,         // 1111111000
-        NotDynamicAndElasticPremium = 507,    // 111111011 Not Dynamic or ElasticPremium
-        NotDynamic = 1019,   // 1111111011
-        PaidDedicated =  504, // 111111000: Paid & Dedicated
-        All = (1 << 10) - 1           // 1111111111
-    }
-  }
+export interface ObserverAseInfo {
+    ID: number;
+    Name: string;
+    LocationId: number;
+    PublicHost: string;
+    VNETName: string;
+    VNETId: string;
+    VNETSubnetName: string;
+    WebWorkerSize: string;
+    WebWorkerRoleCount: number;
+    MultiSize: string;
+    MultiRoleCount: number;
+    IPSSLAddressCount: number;
+    MonitoringDataAccountId: number;
+    SmallDedicatedWebWorkerSize: string;
+    SmallDedicatedWebWorkerRoleCount: number;
+    MediumDedicatedWebWorkerSize: string;
+    MediumDedicatedWebWorkerRoleCount: number;
+    LargeDedicatedWebWorkerSize: string;
+    LargeDedicatedWebWorkerRoleCount: number;
+    Allocated: boolean;
+    DatabaseEdition: string;
+    DatabaseServiceObjective: string;
+    MaximumNumberOfMachines: number;
+    UpgradeDomains: number;
+    VNETSubnetAddressRange: string;
+    DeploymentOrder: number;
+    AllowedMultiSizes?: null;
+    AllowedWorkerSizes?: null;
+    DefinitionsPath?: null;
+    SettingsPath?: null;
+    UserServiceEndpoint: string;
+    CustomerSubscriptionId: string;
+    VNETResourceGroup: string;
+    DeletedOn?: null;
+    DatabaseServerVersion: string;
+    Suspended: boolean;
+    ManualResumeOnly: boolean;
+    ExtraDefinitions: string;
+    InternalLoadBalancingMode: number;
+    ApiHubEnabled: boolean;
+    VNETSubscriptionId: string;
+    CustomBuild: boolean;
+    ClusterSettings?: null;
+    DnsSuffix?: null;
+    VNETResourceType: string;
+    DynamicCacheEnabled: boolean;
+    FileServerRoleCount: number;
+    EnvironmentType: number;
+    InternalStampName: string;
+    Subscription: string;
+    ResourceGroupName: string;
+    GeomasterName: string;
+    GeomasterServiceAddress: string;
+}
+
+export interface ObserverStampInfo {
+    Name: string;
+    SubscriptionId: string;
+    StampType: string;
+    DNS: string;
+    VIP: string;
+    DeploymentId: string;
+    Cluster: string;
+    IsFlexStamp: string;
+    GeoLocation: string;
+}
+
+export interface ObserverStampResponse {
+    name: string;
+    details: any;
+}
+
+export enum ObserverSkuType {
+    Free = 1 << 0, //1
+    Shared = 1 << 1, //2
+    Dynamic = 1 << 2, //4
+    Standard = 1 << 3, //8
+    Premium = 1 << 4, //16
+    ElasticPremium = 1 << 5, //32
+    Isolated = 1 << 6, //64
+    Basic = 1 << 7, //128
+    PremiumV2 = 1 << 8, //256
+    PremiumV3 = 1 << 9, //512
+    IsolatedV2 = 1 << 10, //1024
+    IsolatedV3 = 1 << 11, //2048
+    LinuxFree = 1 << 12, //4096
+    Kubernetes = 1 << 13, //8192
+    All = (1 << 16) - 1 //65535
+}

--- a/AngularApp/projects/applens/src/app/shared/services/ase.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/ase.service.ts
@@ -4,13 +4,14 @@ import { Inject, Injectable } from '@angular/core';
 import { RESOURCE_SERVICE_INPUTS, ResourceServiceInputs, ResourceInfo } from '../models/resources';
 import { ObserverService } from './observer.service';
 import { ResourceService } from './resource.service';
+import { ObserverAseInfo, ObserverAseResponse } from '../models/observer';
 
 @Injectable()
 export class AseService extends ResourceService {
 
-  private _currentResource: BehaviorSubject<Observer.ObserverAseInfo> = new BehaviorSubject(null);
+  private _currentResource: BehaviorSubject<ObserverAseInfo> = new BehaviorSubject(null);
 
-  private _hostingEnvironmentResource: Observer.ObserverAseInfo;
+  private _hostingEnvironmentResource: ObserverAseInfo;
 
   constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
     super(inputs);
@@ -19,14 +20,14 @@ export class AseService extends ResourceService {
   public startInitializationObservable() {
     this._initialized = this._observerApiService.getAse(this._armResource.resourceName)
       .pipe(
-        map((observerResponse: Observer.ObserverAseResponse) => {
+        map((observerResponse: ObserverAseResponse) => {
         this._hostingEnvironmentResource = observerResponse.details;
         this._currentResource.next(observerResponse.details);
         return new ResourceInfo(this.getResourceName(),this.imgSrc,this.displayName,this.getCurrentResourceId());
       }));
   }
 
-  public getCurrentResource(): Observable<Observer.ObserverAseInfo> {
+  public getCurrentResource(): Observable<ObserverAseInfo> {
     return this._currentResource;
   }
 

--- a/AngularApp/projects/applens/src/app/shared/services/containerapp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/containerapp.service.ts
@@ -5,13 +5,14 @@ import { RESOURCE_SERVICE_INPUTS, ResourceServiceInputs, ResourceInfo } from '..
 import { ObserverService } from './observer.service';
 import { ResourceService } from './resource.service';
 import { HttpResponse } from '@angular/common/http';
+import { ObserverContainerAppInfo, ObserverContainerAppResponse } from '../models/observer';
 
 @Injectable()
 export class ContainerAppService extends ResourceService {
 
-  private _currentResource: BehaviorSubject<Observer.ObserverContainerAppInfo> = new BehaviorSubject(null);
+  private _currentResource: BehaviorSubject<ObserverContainerAppInfo> = new BehaviorSubject(null);
 
-  private _containerAppObject: Observer.ObserverContainerAppInfo;
+  private _containerAppObject: ObserverContainerAppInfo;
 
   constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
     super(inputs);
@@ -19,7 +20,7 @@ export class ContainerAppService extends ResourceService {
 
   public startInitializationObservable() {
     this._initialized = this._observerApiService.getContainerApp(this._armResource.resourceName)
-      .pipe(map((observerResponse: Observer.ObserverContainerAppResponse) => {
+      .pipe(map((observerResponse: ObserverContainerAppResponse) => {
         this._observerResource = this._containerAppObject = this.getContainerAppFromObserverResponse(observerResponse);
         this._currentResource.next(this._containerAppObject);
         return new ResourceInfo(this.getResourceName(),this.imgSrc,this.displayName,this.getCurrentResourceId());
@@ -30,7 +31,7 @@ export class ContainerAppService extends ResourceService {
         return this._currentResource;
     }
 
-    private getContainerAppFromObserverResponse(observerResponse: Observer.ObserverContainerAppResponse): Observer.ObserverContainerAppInfo {
+    private getContainerAppFromObserverResponse(observerResponse: ObserverContainerAppResponse): ObserverContainerAppInfo {
         return observerResponse.details.find(containerapp =>
           containerapp.SubscriptionName.toLowerCase() === this._armResource.subscriptionId.toLowerCase() &&
           containerapp.ResourceGroupName.toLowerCase() === this._armResource.resourceGroup.toLowerCase())

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { DiagnosticApiService } from './diagnostic-api.service';
 import { isArray } from 'util';
+import { ObserverAseResponse, ObserverContainerAppResponse, ObserverSiteDetailsResponse, ObserverSiteInfo, ObserverSiteResponse, ObserverSiteSku, ObserverStampResponse, ObserverStaticWebAppResponse } from '../models/observer';
 
 @Injectable()
 export class ObserverService {
@@ -12,9 +13,9 @@ export class ObserverService {
   // WARNING: This is broken logic because of bug in sites API
   //          Hostnames will be incorrect if there is another
   //          app with the same name. Pending fix from Hawk
-  public getSite(site: string): Observable<Observer.ObserverSiteResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/sites/${site}`).pipe(
-      map((siteRes: Observer.ObserverSiteResponse) => {
+  public getSite(site: string): Observable<ObserverSiteResponse> {
+    return this._diagnosticApiService.get<ObserverSiteResponse>(`api/sites/${site}`).pipe(
+      map((siteRes: ObserverSiteResponse) => {
         if (siteRes && siteRes.details && isArray(siteRes.details)) {
           siteRes.details.map(info => this.getSiteInfoWithSlot(info));
         }
@@ -23,13 +24,13 @@ export class ObserverService {
       }));
   }
 
-  public getSiteSku(stamp: string, site: string): Observable<Observer.ObserverSiteSku> {
-    return this._diagnosticApiService.get<{ details: Observer.ObserverSiteSku }>(`api/stamps/${stamp}/sites/${site}/sku`).pipe(map(res => res.details));
+  public getSiteSku(stamp: string, site: string): Observable<ObserverSiteSku> {
+    return this._diagnosticApiService.get<{ details: ObserverSiteSku }>(`api/stamps/${stamp}/sites/${site}/sku`).pipe(map(res => res.details));
   }
 
-  public getContainerApp(containerAppName: string): Observable<Observer.ObserverContainerAppResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverContainerAppResponse>(`api/containerapps/${containerAppName}`).pipe(
-      map((containerAppRes: Observer.ObserverContainerAppResponse) => {
+  public getContainerApp(containerAppName: string): Observable<ObserverContainerAppResponse> {
+    return this._diagnosticApiService.get<ObserverContainerAppResponse>(`api/containerapps/${containerAppName}`).pipe(
+      map((containerAppRes: ObserverContainerAppResponse) => {
         if (containerAppRes && containerAppRes.details && isArray(containerAppRes.details)) {
           containerAppRes.details.map(info => info);
         }
@@ -38,9 +39,9 @@ export class ObserverService {
       }));
   }
 
-  public getStaticWebApp(defaultHostNameOrAppName: string): Observable<Observer.ObserverStaticWebAppResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverStaticWebAppResponse>(`api/staticwebapps/${defaultHostNameOrAppName}`).pipe(
-      map((staticWebAppRes: Observer.ObserverStaticWebAppResponse) => {
+  public getStaticWebApp(defaultHostNameOrAppName: string): Observable<ObserverStaticWebAppResponse> {
+    return this._diagnosticApiService.get<ObserverStaticWebAppResponse>(`api/staticwebapps/${defaultHostNameOrAppName}`).pipe(
+      map((staticWebAppRes: ObserverStaticWebAppResponse) => {
         if (staticWebAppRes && staticWebAppRes.details && isArray(staticWebAppRes.details)) {
           staticWebAppRes.details.map(info => info);
         }
@@ -48,27 +49,27 @@ export class ObserverService {
       }));
   }
 
-  public getAse(ase: string): Observable<Observer.ObserverAseResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverAseResponse>(`api/hostingEnvironments/${ase}`);
+  public getAse(ase: string): Observable<ObserverAseResponse> {
+    return this._diagnosticApiService.get<ObserverAseResponse>(`api/hostingEnvironments/${ase}`);
   }
 
   public getSiteRequestBody(site: string, stamp: string) {
-    return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/stamps/${stamp}/sites/${site}/postBody`);
+    return this._diagnosticApiService.get<ObserverSiteResponse>(`api/stamps/${stamp}/sites/${site}/postBody`);
   }
 
   public getSiteRequestDetails(site: string, stamp: string) {
-    return this._diagnosticApiService.get<Observer.ObserverSiteDetailsResponse>(`api/stamps/${stamp}/sites/${site}/details`);
+    return this._diagnosticApiService.get<ObserverSiteDetailsResponse>(`api/stamps/${stamp}/sites/${site}/details`);
   }
 
   public getAseRequestBody(name: string) {
-    return this._diagnosticApiService.get<Observer.ObserverSiteResponse>(`api/hostingEnvironments/${name}/postBody`);
+    return this._diagnosticApiService.get<ObserverSiteResponse>(`api/hostingEnvironments/${name}/postBody`);
   }
 
-  public getStamp(stampName: string): Observable<Observer.ObserverStampResponse> {
-    return this._diagnosticApiService.get<Observer.ObserverStampResponse>(`api/stamps/${stampName}`);
+  public getStamp(stampName: string): Observable<ObserverStampResponse> {
+    return this._diagnosticApiService.get<ObserverStampResponse>(`api/stamps/${stampName}`);
   }
 
-  private getSiteInfoWithSlot(site: Observer.ObserverSiteInfo): Observer.ObserverSiteInfo {
+  private getSiteInfoWithSlot(site: ObserverSiteInfo): ObserverSiteInfo {
     const siteName = site.SiteName;
     let slot = '';
 

--- a/AngularApp/projects/applens/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/site.service.ts
@@ -6,13 +6,14 @@ import { ObserverService } from './observer.service';
 import { ResourceService } from './resource.service';
 import { HttpResponse } from '@angular/common/http';
 import { SkuUtilities } from '../utilities/sku-utilities';
+import { ObserverSiteInfo, ObserverSiteResponse, ObserverSiteSku } from '../models/observer';
 
 @Injectable()
 export class SiteService extends ResourceService {
 
-    private _currentResource: BehaviorSubject<Observer.ObserverSiteInfo> = new BehaviorSubject(null);
+    private _currentResource: BehaviorSubject<ObserverSiteInfo> = new BehaviorSubject(null);
 
-    private _siteObject: Observer.ObserverSiteInfo;
+    private _siteObject: ObserverSiteInfo;
 
     constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
         super(inputs);
@@ -21,7 +22,7 @@ export class SiteService extends ResourceService {
     public startInitializationObservable() {
         this._initialized = this._observerApiService.getSite(this._armResource.resourceName)
             .pipe(
-                map((observerResponse: Observer.ObserverSiteResponse) => {
+                map((observerResponse: ObserverSiteResponse) => {
                     const siteObject = this.getSiteFromObserverResponse(observerResponse);
                     return siteObject;
                 }), flatMap(site => {
@@ -55,7 +56,7 @@ export class SiteService extends ResourceService {
         return null;
     }
 
-    private getSiteFromObserverResponse(observerResponse: Observer.ObserverSiteResponse): Observer.ObserverSiteInfo {
+    private getSiteFromObserverResponse(observerResponse: ObserverSiteResponse): ObserverSiteInfo {
         return observerResponse.details.find(site =>
             site.Subscription.toLowerCase() === this._armResource.subscriptionId.toLowerCase() &&
             site.ResourceGroupName.toLowerCase() === this._armResource.resourceGroup.toLowerCase())
@@ -84,7 +85,7 @@ export class SiteService extends ResourceService {
         }
     }
 
-    private getSiteASPAndSKu(siteSku: Observer.ObserverSiteSku): string {
+    private getSiteASPAndSKu(siteSku: ObserverSiteSku): string {
         const priceTire = SkuUtilities.getPriceTireBySkuAndSize(siteSku.sku.toString(), siteSku.current_worker_size);
         const numberOfWorkers = siteSku.actual_number_of_workers;
         const aspName = siteSku.server_farm_name;

--- a/AngularApp/projects/applens/src/app/shared/services/stamp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/stamp.service.ts
@@ -7,13 +7,14 @@ import { ResourceService } from './resource.service';
 import { HttpResponse } from '@angular/common/http';
 import { DiagnosticApiService } from './diagnostic-api.service';
 import {DetectorControlService} from 'diagnostic-data';
+import { ObserverStampInfo, ObserverStampResponse } from '../models/observer';
 
 @Injectable()
 export class StampService extends ResourceService {
 
-  private _currentResource: BehaviorSubject<Observer.ObserverStampInfo> = new BehaviorSubject(null);
+  private _currentResource: BehaviorSubject<ObserverStampInfo> = new BehaviorSubject(null);
 
-  private _stampObject: Observer.ObserverStampInfo;
+  private _stampObject: ObserverStampInfo;
 
   constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService, protected _diagnosticApiService: DiagnosticApiService, protected _detectorControlService: DetectorControlService) {
     super(inputs);
@@ -21,7 +22,7 @@ export class StampService extends ResourceService {
 
   public startInitializationObservable() {
     this._initialized = this._observerApiService.getStamp(this._armResource.resourceName)
-      .pipe(map((observerResponse: Observer.ObserverStampResponse) => {
+      .pipe(map((observerResponse: ObserverStampResponse) => {
         this._observerResource = this._stampObject = this.getStampInfoFromObserverResponse(observerResponse);
         this._currentResource.next(this._stampObject);
         return new ResourceInfo(this.getResourceName(),this.imgSrc,this.displayName,this.getCurrentResourceId());
@@ -58,7 +59,7 @@ export class StampService extends ResourceService {
         }), catchError((err) => { return of({}); }));
       }
 
-    private getStampInfoFromObserverResponse(observerResponse: Observer.ObserverStampResponse): Observer.ObserverStampInfo {
+    private getStampInfoFromObserverResponse(observerResponse: ObserverStampResponse): ObserverStampInfo {
         return {
             Name: observerResponse.details.prod_environment.name,
             SubscriptionId: observerResponse.details.prod_environment.subscription_id,

--- a/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/staticwebapp.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from "@angular/core";
 import { of as observableOf, BehaviorSubject, Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { ObserverStaticWebAppInfo, ObserverStaticWebAppResponse } from "../models/observer";
 import { ResourceInfo, ResourceServiceInputs, RESOURCE_SERVICE_INPUTS } from "../models/resources";
 import { ObserverService } from "./observer.service";
 import { ResourceService } from "./resource.service";
@@ -9,7 +10,7 @@ import { ResourceService } from "./resource.service";
 export class StaticWebAppService extends ResourceService {
     private _currentResource: BehaviorSubject<any> = new BehaviorSubject(null);
 
-    private _staticWebAppObject: Observer.ObserverStaticWebAppInfo;
+    private _staticWebAppObject: ObserverStaticWebAppInfo;
 
 
     constructor(@Inject(RESOURCE_SERVICE_INPUTS) inputs: ResourceServiceInputs, protected _observerApiService: ObserverService) {
@@ -18,7 +19,7 @@ export class StaticWebAppService extends ResourceService {
 
     public startInitializationObservable() {
         this._initialized = this._observerApiService.getStaticWebApp(this._armResource.resourceName)
-            .pipe(map((observerResponse: Observer.ObserverStaticWebAppResponse) => {
+            .pipe(map((observerResponse: ObserverStaticWebAppResponse) => {
                 this._observerResource = this._staticWebAppObject = this.getStaticWebAppFromObserverResponse(observerResponse);
                 this._currentResource.next(this._staticWebAppObject);
                 return new ResourceInfo(this.getResourceName(), this.imgSrc, this.displayName, this.getCurrentResourceId());
@@ -34,7 +35,7 @@ export class StaticWebAppService extends ResourceService {
         }));
     }
 
-    private getStaticWebAppFromObserverResponse(observerResponse: Observer.ObserverStaticWebAppResponse): Observer.ObserverStaticWebAppInfo {
+    private getStaticWebAppFromObserverResponse(observerResponse: ObserverStaticWebAppResponse): ObserverStaticWebAppInfo {
         const response = observerResponse.details.find(staticWebApp =>
             staticWebApp.SubscriptionName.toLowerCase() === this._armResource.subscriptionId.toLowerCase() &&
             staticWebApp.ResourceGroupName.toLowerCase() === this._armResource.resourceGroup.toLowerCase());

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/resiliencyScoreReportHelper.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/resiliencyScoreReportHelper.ts
@@ -867,7 +867,7 @@ export class ResiliencyScoreReportHelper {
                 {
                     style: 'paragraph',
                     ul: [
-                        { text: ['Health Check is now Generally Available\n', { text: "https://azure.github.io/AppService/2020/08/24/healthcheck-on-app-service.htm", color: 'blue', link: "https://azure.github.io/AppService/2020/08/24/healthcheck-on-app-service.htm", alignment: 'left', decoration: 'underline' }] },
+                        { text: ['Health Check is now Generally Available\n', { text: "https://azure.github.io/AppService/2020/08/24/healthcheck-on-app-service.html", color: 'blue', link: "https://azure.github.io/AppService/2020/08/24/healthcheck-on-app-service.html", alignment: 'left', decoration: 'underline' }] },
                         { text: ['The Ultimate Guide to Running Healthy Apps in the Cloud – Set your Health Check path\n', { text: "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html#set-your-health-check-path", color: 'blue', link: "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html#set-your-health-check-path", alignment: 'left', decoration: 'underline' }] }
                     ],
                 },


### PR DESCRIPTION
- Fixing SKU enum from Observer in AppLens as it's different than the one used by the Sku used in app-service-diagnostics. This was causing for AppLens to not show ResiliencyScoreReport download button for IsolatedV2 and IsolatedV3 apps.
- Removed Observer namespace as it was causing issue with the new ObserverSku and we couldn't see the value to keep it
- Fixing typo in report for a link that had .htm instead of .html
- Adding Message to ResiliencyScoreReportInPrivateAccess logging events in AppLens