### PR TITLE
Fix for when an RP does not pass search parameter to Diagnostics backend

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -229,7 +229,7 @@ export class SupportTopicService {
                         });
                     }
                     
-                    if (matchingDetectors) {
+                    if (matchingDetectors && matchingDetectors.length > 0) {
                         if (matchingDetectors.length === 1 && matchingDetectors[0] && matchingDetectors[0].id) {
                             if (matchingDetectors[0].type === DetectorType.Analysis) {
                                 detectorPath = `/analysis/${matchingDetectors[0].id}`;

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -506,16 +506,25 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                     this.showPreLoader = false;
                     this.showPreLoadingError = false;
                     var searchResults: DetectorMetaData[] = results[0];
+                    var detectorList = results[1];
+                    var logDetail = "";
+
+                    // When this happens this means that the RP is not sending the search term parameter to Runtimehost API
+                    if (searchResults.length == detectorList.length) {
+                        searchResults = [];
+                        logDetail = "Search results is same as detector list. This means that the search term is not being sent to Runtimehost API";
+                    }
                     this.logEvent(TelemetryEventNames.SearchQueryResults, {
                         searchMode: this.searchMode,
                         searchId: this.searchId,
                         query: this.searchTerm, results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({
                             id: det.id,
                             score: det.score
-                        }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
+                        }))), ts: Math.floor((new Date()).getTime() / 1000).toString(),
+                        logDetail: logDetail
                     });
-                    var detectorList = results[1];
-                    if (detectorList) {
+                    
+                    if (detectorList && searchResults && searchResults.length > 0) {
                         searchResults.forEach(result => {
                             if (result.type === DetectorType.Detector) {
                                 this.insertInDetectorArray({ name: result.name, id: result.id, score: result.score });

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-search/detector-search.component.ts
@@ -280,10 +280,23 @@ export class DetectorSearchComponent extends DataRenderBaseComponent implements 
             }
             this.showPreLoader = false;
             var searchResults: DetectorMetaData[] = results[0];
-            this.logEvent(TelemetryEventNames.SearchQueryResults, { parentDetectorId: this.detector, searchId: this.searchId, query: this.searchTerm, results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({ id: det.id, score: det.score }))), ts: Math.floor((new Date()).getTime() / 1000).toString() });
             var detectorList = results[1];
+            var logDetail = "";
+            // When this happens this means that the RP is not sending the search term parameter to Runtimehost API
+            if (searchResults.length == detectorList.length) {
+                searchResults = [];
+                logDetail = "Search results is same as detector list. This means that the search term is not being sent to Runtimehost API";
+            }
+            this.logEvent(TelemetryEventNames.SearchQueryResults, {
+                parentDetectorId: this.detector,
+                searchId: this.searchId,
+                query: this.searchTerm,
+                results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({ id: det.id, score: det.score }))),
+                ts: Math.floor((new Date()).getTime() / 1000).toString(),
+                logDetail: logDetail
+            });
             var childrenOfParent = results[2];
-            if (detectorList) {
+            if (detectorList && searchResults && searchResults.length>0) {
                 searchResults.forEach(result => {
                     if ((result.id === this.detector) || (childrenOfParent.findIndex((x: string) => x.toLowerCase() == result.id.toLowerCase()) >= 0))
                     {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.ts
@@ -551,16 +551,25 @@ export class SolutionOrchestratorComponent extends DataRenderBaseComponent imple
                 //this.showPreLoader = true;
                 observableForkJoin([searchTask, detectorsTask]).subscribe(results => {
                     var searchResults: DetectorMetaData[] = results[0];
+                    var detectorList = results[1];
+                    var logDetail = "";
+                    
+                    // When this happens this means that the RP is not sending the search term parameter to Runtimehost API
+                    if (searchResults.length == detectorList.length) {
+                        searchResults = [];
+                        logDetail = "Search results is same as detector list. This means that the search term is not being sent to Runtimehost API";
+                    }
                     this.logEvent(TelemetryEventNames.SearchQueryResults, {
                         searchMode: this.searchMode,
                         searchId: this.searchId,
                         query: this.searchTerm, results: JSON.stringify(searchResults.map((det: DetectorMetaData) => new Object({
                             id: det.id,
                             score: det.score
-                        }))), ts: Math.floor((new Date()).getTime() / 1000).toString()
+                        }))), ts: Math.floor((new Date()).getTime() / 1000).toString(),
+                        logDetail: logDetail
                     });
-                    var detectorList = results[1];
-                    if (detectorList) {
+
+                    if (detectorList && searchResults && searchResults.length>0) {
                         searchResults.forEach(result => {
                             if (result.type === DetectorType.Detector) {
                                 this.insertInDetectorArray({ name: result.name, id: result.id, score: result.score });


### PR DESCRIPTION
Today if a product has Shield enabled but their RP does not pass the search term to our backend, then for the backend its basically a ListDetectors call and all detectors are returned, which are executed by Shield (without knowing that the RP messed up).

This will compare to catch this scenario in the Shield frontend and not run the all detectors list.