### PR TITLE
Some refactoring and fix for form autofill when Durian shows error and some refactoring

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -25,6 +25,7 @@ import { TelemetryService } from 'diagnostic-data';
 import { TelemetryEventNames } from 'diagnostic-data';
 import { HttpErrorResponse } from '@angular/common/http';
 import { UserAccessStatus } from "../../../shared/models/alerts";
+import { defaultResourceTypes } from '../../../shared/utilities/main-page-menu-options';
 
 @Component({
   selector: 'dashboard',
@@ -108,6 +109,7 @@ export class DashboardComponent implements OnDestroy {
   alertDialogProps = {isBlocking: true}
   dialogType: DialogType = DialogType.normal;
   crossSubJustification: string = '';
+  defaultResourceTypes = defaultResourceTypes;
 
   constructor(public resourceService: ResourceService, private startupService: StartupService,  private _detectorControlService: DetectorControlService,
     private _router: Router, private _activatedRoute: ActivatedRoute, private _navigator: FeatureNavigationService,
@@ -189,10 +191,12 @@ export class DashboardComponent implements OnDestroy {
 
   navigateBackToHomePage() {
     let resourceInfo = this._startupService.getResourceInfo();
+    let resourceProviderFull = `${resourceInfo.provider}/${resourceInfo.resourceTypeName}`.toLowerCase();
+    let mainPageResourceType = this.defaultResourceTypes.find(x => x.resourceType && x.resourceType.toLowerCase() === resourceProviderFull);
     let queryParams = {
       caseNumber: this._diagnosticApiService.CustomerCaseNumber,
       errorMessage: this.accessError,
-      resourceType: `${resourceInfo.provider}/${resourceInfo.resourceTypeName}`,
+      resourceType: mainPageResourceType? mainPageResourceType.resourceType: "",
       resourceName: resourceInfo.resourceName,
       resourceId: this._resourceService.getCurrentResourceId()
     };

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
@@ -19,7 +19,7 @@
       <div style="width: 50%;">
         <div class="section"
           *ngIf="caseNumberNeededForUser && (selectedResourceType && selectedResourceType.userAuthorizationEnabled)">
-          <fab-text-field [ariaLabel]="'Customer case number'" (onChange)="updateCaseNumber($event)"
+          <fab-text-field [ariaLabel]="'Customer case number'" [defaultValue]="caseNumber" (onChange)="updateCaseNumber($event)"
             [placeholder]="caseNumberPlaceholder" [label]="'Case Number'" [required]="true"
             [styles]="fabTextFieldStyles">
           </fab-text-field>
@@ -38,8 +38,8 @@
         <div class="view-resource-link"><a tabindex="0" (click)="openResourcePanel()">View all supported resource
             types</a></div>
         <div class="section" style="margin-top: 15px;">
-          <fab-text-field [ariaLabel]="selectedResourceType.resourceTypeLabel" (onChange)="updateResourceName($event)"
-            [placeholder]="'Type ' + selectedResourceType.resourceTypeLabel"
+          <fab-text-field [ariaLabel]="selectedResourceType.resourceTypeLabel" [defaultValue]="resourceName" (onChange)="updateResourceName($event)"
+           [placeholder]="'Type ' + selectedResourceType.resourceTypeLabel"
             (keyup.enter)="onSubmit()" [required]="true" [label]="selectedResourceType.resourceTypeLabel"
             [styles]="fabTextFieldStyles">
           </fab-text-field>

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -13,6 +13,7 @@ import { UserSettingService } from '../../dashboard/services/user-setting.servic
 import { RecentResource } from '../../../shared/models/user-setting';
 import { ResourceDescriptor } from 'diagnostic-data'
 import { applensDocs } from '../../../shared/utilities/applens-docs-constant';
+import { defaultResourceTypes } from '../../../shared/utilities/main-page-menu-options';
 import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.service';
 import { UserAccessStatus } from '../../../shared/models/alerts';
 const moment = momentNs;
@@ -47,77 +48,7 @@ export class MainComponent implements OnInit {
   displayUserAccessError: boolean = false;
   caseNumberPlaceholder: string = "Type 'internal' for internal resources"
 
-  defaultResourceTypes: ResourceTypeState[] = [
-    {
-      resourceType: "Microsoft.Web/sites",
-      resourceTypeLabel: 'App name',
-      routeName: (name) => `sites/${name}`,
-      displayName: 'App Service',
-      enabled: true,
-      caseId: false,
-      id: 'App Service',
-      userAuthorizationEnabled: true
-    },
-    {
-      resourceType: "Microsoft.Web/hostingEnvironments",
-      resourceTypeLabel: 'ASE name',
-      routeName: (name) => `hostingEnvironments/${name}`,
-      displayName: 'App Service Environment',
-      enabled: true,
-      caseId: false,
-      id: 'App Service Environment',
-      userAuthorizationEnabled: false
-    },
-    {
-      resourceType: "Microsoft.Web/containerApps",
-      resourceTypeLabel: 'Container App Name',
-      routeName: (name) => `containerapps/${name}`,
-      displayName: 'Container App',
-      enabled: true,
-      caseId: false,
-      id: 'Container App',
-      userAuthorizationEnabled: false
-    }, {
-      resourceType: "Microsoft.Web/staticSites",
-      resourceTypeLabel: 'Static App Name Or Default Host Name',
-      routeName: (name) => `staticwebapps/${name}`,
-      displayName: 'Static Web App',
-      enabled: true,
-      caseId: false,
-      id: 'Static Web App',
-      userAuthorizationEnabled: false
-    },
-    {
-      resourceType: "Microsoft.Compute/virtualMachines",
-      resourceTypeLabel: 'Virtual machine Id',
-      routeName: (name) => this.getFakeArmResource('Microsoft.Compute', 'virtualMachines', name),
-      displayName: 'Virtual Machine',
-      enabled: true,
-      caseId: false,
-      id: 'Virtual Machine',
-      userAuthorizationEnabled: false
-    },
-    {
-      resourceType: "ARMResourceId",
-      resourceTypeLabel: 'ARM Resource ID',
-      routeName: (name) => `${name}`,
-      displayName: 'ARM Resource ID',
-      enabled: true,
-      caseId: false,
-      id: 'ARM Resource ID',
-      userAuthorizationEnabled: false
-    },
-    {
-      resourceType: null,
-      resourceTypeLabel: 'Stamp name',
-      routeName: (name) => `stampfinder/${name}`,
-      displayName: 'Internal Stamp',
-      enabled: true,
-      caseId: false,
-      id: 'Internal Stamp',
-      userAuthorizationEnabled: false
-    }
-  ];
+  defaultResourceTypes: ResourceTypeState[] = defaultResourceTypes;
   resourceTypes: ResourceTypeState[] = [];
   startTime: momentNs.Moment;
   endTime: momentNs.Moment;
@@ -184,10 +115,12 @@ export class MainComponent implements OnInit {
       let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === this._activatedRoute.snapshot.queryParams['resourceType'].toLowerCase());
       if (!foundResourceType) {
         this.selectedResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === "armresourceid");
-        this.resourceName = this._activatedRoute.snapshot.queryParams['resourceId'];
       }
       else {
         this.selectedResourceType = foundResourceType;
+      }
+      if (this.selectedResourceType.resourceType == "ARMResourceId") {
+        this.resourceName = this._activatedRoute.snapshot.queryParams['resourceId'];
       }
     }
   }
@@ -414,11 +347,6 @@ export class MainComponent implements OnInit {
 
   caseCleansingNavigate() {
     this._router.navigate(["caseCleansing"]);
-  }
-
-  private getFakeArmResource(rpName: string, serviceName: string, resourceName: string): string {
-    let fakeRes = `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Fake-RG/providers/${rpName}/${serviceName}/${resourceName}`;
-    return fakeRes;
   }
 
   openTimePicker() {

--- a/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
+++ b/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
@@ -1,0 +1,78 @@
+import {ResourceTypeState} from "../models/resources";
+
+function getFakeArmResource(rpName: string, serviceName: string, resourceName: string): string {
+    let fakeRes = `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Fake-RG/providers/${rpName}/${serviceName}/${resourceName}`;
+    return fakeRes;
+}
+
+export const defaultResourceTypes: ResourceTypeState[] = [
+    {
+      resourceType: "Microsoft.Web/sites",
+      resourceTypeLabel: 'App name',
+      routeName: (name) => `sites/${name}`,
+      displayName: 'App Service',
+      enabled: true,
+      caseId: false,
+      id: 'App Service',
+      userAuthorizationEnabled: true
+    },
+    {
+      resourceType: "Microsoft.Web/hostingEnvironments",
+      resourceTypeLabel: 'ASE name',
+      routeName: (name) => `hostingEnvironments/${name}`,
+      displayName: 'App Service Environment',
+      enabled: true,
+      caseId: false,
+      id: 'App Service Environment',
+      userAuthorizationEnabled: true
+    },
+    {
+      resourceType: "Microsoft.Web/containerApps",
+      resourceTypeLabel: 'Container App Name',
+      routeName: (name) => `containerapps/${name}`,
+      displayName: 'Container App',
+      enabled: true,
+      caseId: false,
+      id: 'Container App',
+      userAuthorizationEnabled: true
+    }, {
+      resourceType: "Microsoft.Web/staticSites",
+      resourceTypeLabel: 'Static App Name Or Default Host Name',
+      routeName: (name) => `staticwebapps/${name}`,
+      displayName: 'Static Web App',
+      enabled: true,
+      caseId: false,
+      id: 'Static Web App',
+      userAuthorizationEnabled: true
+    },
+    {
+      resourceType: "Microsoft.Compute/virtualMachines",
+      resourceTypeLabel: 'Virtual machine Id',
+      routeName: (name) => getFakeArmResource('Microsoft.Compute', 'virtualMachines', name),
+      displayName: 'Virtual Machine',
+      enabled: true,
+      caseId: false,
+      id: 'Virtual Machine',
+      userAuthorizationEnabled: true
+    },
+    {
+      resourceType: "ARMResourceId",
+      resourceTypeLabel: 'ARM Resource ID',
+      routeName: (name) => `${name}`,
+      displayName: 'ARM Resource ID',
+      enabled: true,
+      caseId: false,
+      id: 'ARM Resource ID',
+      userAuthorizationEnabled: true
+    },
+    {
+      resourceType: null,
+      resourceTypeLabel: 'Stamp name',
+      routeName: (name) => `stampfinder/${name}`,
+      displayName: 'Internal Stamp',
+      enabled: true,
+      caseId: false,
+      id: 'Internal Stamp',
+      userAuthorizationEnabled: false
+    }
+];


### PR DESCRIPTION
In PR [1774](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/pull/1774) we had made a change to fix a bug with fab-text-field that interrupts user typing. However as a result two-way binding is lost for the fields and we are unable to pre-populate the fields after Durian shows error.
![image](https://user-images.githubusercontent.com/8492235/201250972-7647b522-dbb3-40e5-aec5-35c3b87becae.png)


This PR ensures that we are able to pre-populate those fields (using defaultValue), together with ensuring that the fix in the original last PR is maintained.
![image](https://user-images.githubusercontent.com/8492235/201250933-d9ba5670-0df2-402e-adb3-725f89a0c0c9.png)
