### PR TITLE
Add bread crumb to go back in portal

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/globals.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/globals.ts
@@ -1,7 +1,8 @@
-import { Injectable, Injector, isDevMode } from '@angular/core';
+import { Injectable , isDevMode } from '@angular/core';
 import { Message } from './supportbot/models/message';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
+import { BreadcrumbNavigationItem } from 'diagnostic-data';
 
 
 
@@ -10,14 +11,6 @@ export class Globals {
   messages: Message[] = [];
   messagesData: { [id: string]: any } = {};
   set openGeniePanel(value: boolean) {
-    //if set openFeedback to true,update messages and open genie
-    if (value) {
-      // this.updateMsgFromLocalStorage();
-    }
-    //if set openFeedback to false,save messages and close genie
-    else {
-      //this.saveMsgToLocalStorage();
-    }
     this._openGeniePanel = value;
   };
   get openGeniePanel() {
@@ -32,21 +25,11 @@ export class Globals {
   openRiskAlertsPanel: boolean = false;
   callStackDetails = { managedException: "", callStack: "" };
   showCommAlertSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  breadCrumb: BreadcrumbNavigationItem = null;
 
-  private localStorageKey: string = "genieChat";
   constructor(private activatedRoute: ActivatedRoute) {
   }
 
-  saveMsgToLocalStorage() {
-    const savedMsg = this.messages.map(msg => {
-      const copiedMsg = { ...msg };
-      if (typeof copiedMsg.component === "function") {
-        copiedMsg.component = copiedMsg.component.name;
-      }
-      return copiedMsg;
-    });
-    localStorage.setItem(this.localStorageKey, JSON.stringify(savedMsg));
-  }
 
   //get detector or category(for categoryoverview) name for feedback
   getDetectorName(): string {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/breadcrumb.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/breadcrumb.service.ts
@@ -8,16 +8,16 @@ import { ApplensDiagnosticService } from "./applens-diagnostic.service";
 
 @Injectable()
 export class BreadcrumbService {
-    private readonly defaultBreadcrumbItem: BreadcrumbNavigationItem = {
-        name: "Home"
-    };
-    public breadcrumbSubject: BehaviorSubject<BreadcrumbNavigationItem[]> = new BehaviorSubject([this.defaultBreadcrumbItem]);
+    private defaultBreadcrumbItem: BreadcrumbNavigationItem;
+    public breadcrumbSubject: BehaviorSubject<BreadcrumbNavigationItem[]> = new BehaviorSubject([]);
     private resourceId: string = "";
     private get breadcrumbList() {
         return this.breadcrumbSubject.getValue();
     }
     constructor(private _router: Router, private _diagnosticService: ApplensDiagnosticService, private _activatedRoute: ActivatedRoute, private _detectorControl: DetectorControlService) {
         this.resourceId = this._diagnosticService.resourceId;
+        this.defaultBreadcrumbItem = { name: "Home", fullPath: this.resourceId };
+        this.breadcrumbSubject.next([this.defaultBreadcrumbItem]);
     }
 
     public updateBreadCrumbSubject(breadcrumbItem: BreadcrumbNavigationItem) {
@@ -33,19 +33,18 @@ export class BreadcrumbService {
     public navigate(item: BreadcrumbNavigationItem) {
         const copiedList = [...this.breadcrumbList];
         const itemIndex = copiedList.findIndex(i => i.name === item.name);
-        let routingParams ={};
-        if(itemIndex === 0) {
+        let routingParams = {};
+        if (itemIndex === 0) {
             this.resetBreadCrumbSubject();
-        } else if(itemIndex > 0) {
+        } else if (itemIndex > 0) {
             //Remove all items includes the one you clicked
-            routingParams = copiedList[itemIndex].queryParams != undefined? copiedList[itemIndex].queryParams: routingParams;
+            routingParams = copiedList[itemIndex].queryParams != undefined ? copiedList[itemIndex].queryParams : routingParams;
             const removeItemCount = copiedList.length - itemIndex;
             copiedList.splice(itemIndex, removeItemCount);
             this.breadcrumbSubject.next(copiedList);
         }
 
-        if (!!routingParams["startTime"] && !!routingParams["endTime"])
-        {
+        if (!!routingParams["startTime"] && !!routingParams["endTime"]) {
             this._detectorControl.setCustomStartEnd(routingParams["startTime"], routingParams["endTime"], "BreadCrumbControl");
             //Todo, detector control service should able to read and infer TimePickerOptions from startTime and endTime
             this._detectorControl.updateTimePickerInfo({
@@ -56,18 +55,8 @@ export class BreadcrumbService {
             });
         }
 
-        if (item.name === "Home" && item.id == undefined) {
-            this._router.navigate([this.resourceId], {  queryParams: routingParams });
-            return;
-        }
-
-        if (item && item.isDetector) {
-            this._router.navigate([`${this.resourceId}/detectors/${item.id}`], { queryParams: routingParams });
-            return;
-        }
-
-        if (item && !item.isDetector) {
-            this._router.navigate([`${this.resourceId}/analysis/${item.id}`], { queryParams: routingParams });
+        if (item) {
+            this._router.navigate([item.fullPath], { queryParams: routingParams });
             return;
         }
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list-analysis/detector-list-analysis.component.ts
@@ -31,13 +31,13 @@ import * as momentNs from 'moment';
 const moment = momentNs;
 
 import { ILinkProps, PanelType } from 'office-ui-fabric-react';
-import { GenericBreadcrumbService } from '../../services/generic-breadcrumb.service';
+import { BreadcrumbNavigationItem, GenericBreadcrumbService } from '../../services/generic-breadcrumb.service';
 import { GenericUserSettingService } from '../../services/generic-user-setting.service';
 import { GenericFeatureService } from '../../services/generic-feature-service';
 
 const WAIT_TIME_IN_SECONDS_TO_ALLOW_DOWNTIME_INTERACTION: number = 58;
 const PERCENT_CHILD_DETECTORS_COMPLETED_TO_ALLOW_DOWNTIME_INTERACTION: number = 0.9;
-const DEFAULT_DESCRIPTION_FOR_DETECTORS_WITH_NO_INSIGHT:string = 'View more details here';
+const DEFAULT_DESCRIPTION_FOR_DETECTORS_WITH_NO_INSIGHT: string = 'View more details here';
 
 @Component({
     selector: 'detector-list-analysis',
@@ -127,8 +127,8 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
     solutionPanelOpenSubject: BehaviorSubject<boolean> = new BehaviorSubject(false);
     solutionTitle: string = "";
     expandIssuedAnalysisChecks: boolean = false;
-    allDetectors:DetectorMetaData[] = [];
-    
+    allDetectors: DetectorMetaData[] = [];
+
 
     constructor(public _activatedRoute: ActivatedRoute, private _router: Router,
         private _diagnosticService: DiagnosticService, private _detectorControl: DetectorControlService,
@@ -354,7 +354,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                             if (this.analysisId == "supportTopicAnalysis") {
                                 this.showAppInsightsSection = false;
                                 this._diagnosticService.getDetectors().subscribe(detectorList => {
-                                    if (detectorList) {                                        
+                                    if (detectorList) {
                                         this._supportTopicService.getMatchingDetectors().subscribe(matchingDetectors => {
                                             var analysisToProcess: string[] = [];
                                             matchingDetectors.forEach(matchingDetector => {
@@ -524,7 +524,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                         }))), ts: Math.floor((new Date()).getTime() / 1000).toString(),
                         logDetail: logDetail
                     });
-                    
+
                     if (detectorList && searchResults && searchResults.length > 0) {
                         searchResults.forEach(result => {
                             if (result.type === DetectorType.Detector) {
@@ -613,33 +613,33 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
     }
 
-    containsAnyDisplayableRenderingType(response:DetectorResponse):boolean {
-        let DetctorNonDisplayableRenderingTypes:RenderingType[] = [
-            RenderingType.DetectorList, 
-            RenderingType.DownTime, 
+    containsAnyDisplayableRenderingType(response: DetectorResponse): boolean {
+        let DetctorNonDisplayableRenderingTypes: RenderingType[] = [
+            RenderingType.DetectorList,
+            RenderingType.DownTime,
             RenderingType.AppInsightEnablement
-        ];        
-        let index = response.dataset.findIndex(set => 
-            DetctorNonDisplayableRenderingTypes.find(renderingType=>renderingType === (<Rendering>set.renderingProperties).type ) == undefined 
-            );
+        ];
+        let index = response.dataset.findIndex(set =>
+            DetctorNonDisplayableRenderingTypes.find(renderingType => renderingType === (<Rendering>set.renderingProperties).type) == undefined
+        );
         return index > -1;
     }
 
-    containsChildDetectors(response:DetectorResponse):boolean {
-        return response.dataset.findIndex(set=> (<Rendering>set.renderingProperties).type === RenderingType.DetectorList) > -1;
+    containsChildDetectors(response: DetectorResponse): boolean {
+        return response.dataset.findIndex(set => (<Rendering>set.renderingProperties).type === RenderingType.DetectorList) > -1;
     }
 
-    processParentChildHierarchy(response:DetectorResponse, currDowntime:DownTime, containsDownTime:boolean) {
-        if(this.containsChildDetectors(response)) {
-            let currDetectorList:DetectorMetaData[] = [];
+    processParentChildHierarchy(response: DetectorResponse, currDowntime: DownTime, containsDownTime: boolean) {
+        if (this.containsChildDetectors(response)) {
+            let currDetectorList: DetectorMetaData[] = [];
             response.dataset.forEach(diagnosticData => {
-                if((<Rendering>diagnosticData.renderingProperties).type === RenderingType.DetectorList) {
+                if ((<Rendering>diagnosticData.renderingProperties).type === RenderingType.DetectorList) {
                     // Doesn't support cross resource child detectors yet.
-                    let currChildDetectorRendering:DetectorListRendering = <DetectorListRendering>diagnosticData.renderingProperties;
-                    if(!!currChildDetectorRendering.detectorIds && currChildDetectorRendering.detectorIds.length > 0) {
+                    let currChildDetectorRendering: DetectorListRendering = <DetectorListRendering>diagnosticData.renderingProperties;
+                    if (!!currChildDetectorRendering.detectorIds && currChildDetectorRendering.detectorIds.length > 0) {
                         currChildDetectorRendering.detectorIds.forEach(childDetectorId => {
-                            let matchingDetector = this.allDetectors.find(d=>d.id == childDetectorId);
-                            if(!!matchingDetector && !!matchingDetector.name && !!matchingDetector.id &&
+                            let matchingDetector = this.allDetectors.find(d => d.id == childDetectorId);
+                            if (!!matchingDetector && !!matchingDetector.name && !!matchingDetector.id &&
                                 this.insertInDetectorArray({ name: matchingDetector.name, id: matchingDetector.id })) {
                                 currDetectorList.push(matchingDetector);
                             }
@@ -648,20 +648,20 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                 }
             });
 
-            if(currDetectorList.length > 0) {
+            if (currDetectorList.length > 0) {
                 this.startDetectorRendering(currDetectorList, currDowntime, containsDownTime, true);
             }
         }
     }
 
-    insertInDetectorViewModel(detectorViewModel:any):boolean {
-        if(!this.detectorViewModels || (!!this.detectorViewModels && this.detectorViewModels.length < 1)) {
+    insertInDetectorViewModel(detectorViewModel: any): boolean {
+        if (!this.detectorViewModels || (!!this.detectorViewModels && this.detectorViewModels.length < 1)) {
             this.detectorViewModels.push(detectorViewModel);
             return true;
-        } 
+        }
         else {
-            if(this.detectorViewModels.findIndex(currViewModel=> 
-                (<DetectorMetaData>currViewModel.metadata).id == (<DetectorMetaData>detectorViewModel.metadata).id  && 
+            if (this.detectorViewModels.findIndex(currViewModel =>
+                (<DetectorMetaData>currViewModel.metadata).id == (<DetectorMetaData>detectorViewModel.metadata).id &&
                 currViewModel.startTime == detectorViewModel.startTime &&
                 currViewModel.endTime == detectorViewModel.endTime
             ) < 0) {
@@ -672,24 +672,24 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         return false;
     }
 
-    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime: boolean, isReEntry:boolean = false) {
+    startDetectorRendering(detectorList, downTime: DownTime, containsDownTime: boolean, isReEntry: boolean = false) {
         if (this.showWebSearchTimeout) {
             clearTimeout(this.showWebSearchTimeout);
         }
         this.showWebSearchTimeout = setTimeout(() => { this.showWebSearch = true; }, 3000);
 
-        if(!isReEntry) {
+        if (!isReEntry) {
             this.allDetectors = detectorList;
             this.issueDetectedViewModels = [];
         }
-        
+
         const requests: Observable<any>[] = [];
 
         this.detectorMetaData = detectorList.filter(detector => this.detectors.findIndex(d => d.id === detector.id) >= 0);
-        
+
         // Because startDetectorRendering is being called in a recursive manner, insert elements into detectorViewModels only if the current viewModel is not already in it.
         let viewModelsToProcess = this.detectorMetaData.map(detector => this.getDetectorViewModel(detector, downTime, containsDownTime));
-        if(!isReEntry) {
+        if (!isReEntry) {
             this.detectorViewModels = viewModelsToProcess;
         }
         else {
@@ -721,16 +721,16 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                             this.issueDetectedViewModels.push(issueDetectedViewModel);
                             this.issueDetectedViewModels = this.issueDetectedViewModels.sort((n1, n2) => n1.model.status - n2.model.status);
                         } else {
-                            if(this.containsAnyDisplayableRenderingType(response)) {
+                            if (this.containsAnyDisplayableRenderingType(response)) {
                                 let insight = this.getDetectorInsight(viewModelsToProcess[index]);
-                                if(!insight) {
+                                if (!insight) {
                                     // The detector loaded successfully, however did not generate an insight.
                                     insight = { title: DEFAULT_DESCRIPTION_FOR_DETECTORS_WITH_NO_INSIGHT, description: '' };
-                                    if(!viewModelsToProcess[index].status || viewModelsToProcess[index].status == HealthStatus.None ) {
+                                    if (!viewModelsToProcess[index].status || viewModelsToProcess[index].status == HealthStatus.None) {
                                         viewModelsToProcess[index].status = HealthStatus.Info;
                                     }
                                 }
-                            
+
                                 let successViewModel = { model: viewModelsToProcess[index], insightTitle: insight.title, insightDescription: insight.description };
 
                                 if (this.successfulViewModels.length > 0) {
@@ -802,7 +802,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         return detectorList.filter(element => (element.analysisTypes != null && element.analysisTypes.length > 0 && element.analysisTypes.findIndex(x => x == analysisId) >= 0)).map(element => { return { name: element.name, id: element.id }; });
     }
 
-    insertInDetectorArray(detectorItem):boolean {
+    insertInDetectorArray(detectorItem): boolean {
         if (this.withinGenie) {
             if (this.detectors.findIndex(x => x.id === detectorItem.id) < 0 && detectorItem.score >= this.targetedScore) {
                 this.detectors.push(detectorItem);
@@ -950,9 +950,9 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
             this._router.navigate([`../../../../${this.analysisId}/search`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm } });
         }
         else {
-            if (this.analysisId === 'supportTopicAnalysis' && this.searchTerm) {                
-                if(this.detectorId == '') {
-                    this._router.navigate([`../../${this.analysisId}/dynamic`],  { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm }, replaceUrl: true });
+            if (this.analysisId === 'supportTopicAnalysis' && this.searchTerm) {
+                if (this.detectorId == '') {
+                    this._router.navigate([`../../${this.analysisId}/dynamic`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm }, replaceUrl: true });
                 }
                 else {
                     this._router.navigate([`../../../../${this.analysisId}/dynamic/`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', queryParams: { searchTerm: this.searchTerm }, replaceUrl: true });
@@ -1036,7 +1036,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                             relativeTo: this._activatedRoute,
                             queryParamsHandling: 'merge',
                             preserveFragment: true,
-                            queryParams: { startTime: viewModel.model.startTime, endTime: viewModel.model.endTime, searchTerm: this.searchTerm } 
+                            queryParams: { startTime: viewModel.model.startTime, endTime: viewModel.model.endTime, searchTerm: this.searchTerm }
                         });
                     }
                     else {
@@ -1053,7 +1053,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                     startDate: new Date(viewModel.model.startTime),
                                     endDate: new Date(viewModel.model.endTime)
                                 });
-                                this.updateBreadcrumb();
+                                this.updateBreadcrumb(viewModel);
 
                                 //Remove queryParams startTimeChildDetector and endTimeChildDetector. Update startTime and endTime to downtime period
                                 const updatedParams = { ...queryParams };
@@ -1065,7 +1065,7 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
                                 this._router.navigate([`../../detectors/${detectorId}`], { relativeTo: this._activatedRoute, queryParams: updatedParams });
                             }
                             else {
-                                this.updateBreadcrumb();
+                                this.updateBreadcrumb(viewModel);
                                 this._router.navigate([`../../detectors/${detectorId}`], { relativeTo: this._activatedRoute, queryParamsHandling: 'merge', preserveFragment: true });
                             }
                         }
@@ -1148,15 +1148,30 @@ export class DetectorListAnalysisComponent extends DataRenderBaseComponent imple
         }
     }
 
-    private updateBreadcrumb() {
-        if (this.isPublic || this.withinGenie) return;
+    private updateBreadcrumb(viewModel: any) {
+        if (this.withinGenie) {
+            return;
+        }
 
-        const queryParams = this._activatedRoute.snapshot.queryParams;
-        this._genericBreadcrumbService.updateBreadCrumbSubject({
+        const queryParams = { ...this._activatedRoute.snapshot.queryParams };
+        if (viewModel.model.startTime != null) {
+            queryParams.startTimeChildDetector = viewModel.model.startTime
+        }
+        if (viewModel.model.endTime != null) {
+            queryParams.endTimeChildDetector = viewModel.model.endTime
+        }
+
+        const fullPath = this._router.url.split("?")[0];
+
+        const breadcrumbItem: BreadcrumbNavigationItem = {
             name: this.analysisName,
-            id: this.analysisId,
-            isDetector: false,
+            fullPath: fullPath,
             queryParams: queryParams
-        });
+        };
+        if (this.isPublic) {
+            this._globals.breadCrumb = breadcrumbItem;
+        } else {
+            this._genericBreadcrumbService.updateBreadCrumbSubject(breadcrumbItem);
+        }
     }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.ts
@@ -20,10 +20,11 @@ import { Solution } from '../solution/solution';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PortalActionGenericService } from '../../services/portal-action.service';
 import { UriUtilities } from '../../utilities/uri-utilities';
-import { GenericBreadcrumbService } from '../../services/generic-breadcrumb.service';
+import { BreadcrumbNavigationItem, GenericBreadcrumbService } from '../../services/generic-breadcrumb.service';
 import { ILinkProps } from 'office-ui-fabric-react';
 import { SolutionService } from '../../services/solution.service';
 import { GenericUserSettingService } from '../../services/generic-user-setting.service';
+import { GenieGlobals } from '../../services/genie.service';
 
 @Component({
   selector: 'detector-list',
@@ -69,7 +70,7 @@ export class DetectorListComponent extends DataRenderBaseComponent {
 
   constructor(private _diagnosticService: DiagnosticService, protected telemetryService: TelemetryService, private _detectorControl: DetectorControlService, private _solutionService: SolutionService,
     private parseResourceService: ParseResourceService, @Inject(DIAGNOSTIC_DATA_CONFIG) private config: DiagnosticDataConfig, private _router: Router,
-    private _activatedRoute: ActivatedRoute, private _portalActionService: PortalActionGenericService, private _breadcrumbService: GenericBreadcrumbService, private _genericUserSettingsService: GenericUserSettingService) {
+    private _activatedRoute: ActivatedRoute, private _portalActionService: PortalActionGenericService, private _breadcrumbService: GenericBreadcrumbService, private _genericUserSettingsService: GenericUserSettingService, private _globals: GenieGlobals) {
     super(telemetryService);
     this.isPublic = this.config && this.config.isPublic;
 
@@ -416,6 +417,7 @@ export class DetectorListComponent extends DataRenderBaseComponent {
           else if (this.isPublic) {
             const url = this._router.url.split("?")[0];
             const routeUrl = url.endsWith("/overview") ? `../detectors/${targetDetector}` : `../../detectors/${targetDetector}`;
+            this.updateBreadcrumb(combinedParams);
             this._router.navigate([routeUrl], {
               queryParams: combinedParams,
               relativeTo: this._activatedRoute
@@ -423,14 +425,7 @@ export class DetectorListComponent extends DataRenderBaseComponent {
           }
           else {
             const resourceId = this._diagnosticService.resourceId;
-            if (!this.isPublic) {
-              this._breadcrumbService.updateBreadCrumbSubject({
-                name: this.detectorName,
-                id: this.detector,
-                isDetector: true,
-                queryParams: combinedParams
-              });
-            }
+            this.updateBreadcrumb(combinedParams);
             this._router.navigate([`${resourceId}/detectors/${targetDetector}`], { queryParams: combinedParams });
           }
         }
@@ -472,6 +467,20 @@ export class DetectorListComponent extends DataRenderBaseComponent {
         DetectorId: detectorId,
         Status: status
       });
+    }
+  }
+
+  private updateBreadcrumb(queryParams: any) {
+    const fullPath = this._router.url.split("?")[0];
+    const breadcrumbItem: BreadcrumbNavigationItem = {
+        name: this.detectorName,
+        queryParams: queryParams,
+        fullPath: fullPath
+    };
+    if (this.isPublic) {
+        this._globals.breadCrumb = breadcrumbItem;
+    } else {
+        this._breadcrumbService.updateBreadCrumbSubject(breadcrumbItem);
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -14,14 +14,9 @@
   </div>
 </h2>
 
-<div *ngIf="detectorDataLocalCopy" class="detector-control">
-  <!-- Debug -->
-  <!-- <div>isAnalysisView: {{isAnalysisView}}</div>
-  <div>hideDetectorHeader: {{hideDetectorHeader}}</div>
-  <div>isPublic: {{isPublic}}</div>
-  <div>isSystemInvoker: {{isSystemInvoker}}</div> -->
-  <!-- <div>supportsDownTime {{supportsDownTime}}</div> -->
+<a *ngIf="breadCrumb &&breadCrumb.name && isPublic" (click)="navigateForBreadCrumb()" (keyup.enter)="navigateForBreadCrumb()">Go Back to {{breadCrumb.name}}</a>
 
+<div *ngIf="detectorDataLocalCopy" class="detector-control">
   <div *ngIf="!hideDetectorControl && !insideDetectorList">
     <ng-container *ngTemplateOutlet="detectorTimePickerPill"></ng-container>
   </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -18,8 +18,9 @@ import { IButtonStyles } from 'office-ui-fabric-react/lib/components/Button';
 import { IChoiceGroupOption } from 'office-ui-fabric-react/lib/components/ChoiceGroup';
 import { IDropdownOption } from 'office-ui-fabric-react/lib/components/Dropdown';
 import { IIconProps } from 'office-ui-fabric-react/lib/components/Icon';
-import { filter } from 'rxjs/operators';
 import { GenericUserSettingService } from '../../services/generic-user-setting.service';
+import { GenieGlobals } from '../../services/genie.service';
+import { BreadcrumbNavigationItem } from '../../services/generic-breadcrumb.service';
 
 const moment = momentNs;
 const minSupportedDowntimeDuration: number = 10;
@@ -79,7 +80,7 @@ export class DetectorViewComponent implements OnInit {
   timePickerButtonStr: string = "";
   buttonStyle: IButtonStyles = {
     root: {
-     // color: "#323130",
+      // color: "#323130",
       borderRadius: "12px",
       margin: " 0px 5px",
       background: "rgba(0, 120, 212, 0.1)",
@@ -91,7 +92,7 @@ export class DetectorViewComponent implements OnInit {
       border: "2px solid black",
     }
   }
-  iconStyles:IIconProps["styles"] = {
+  iconStyles: IIconProps["styles"] = {
     root: {
       color: "#0078d4"
     }
@@ -127,7 +128,7 @@ export class DetectorViewComponent implements OnInit {
   @Input() isKeystoneView: boolean = false;
   @Input() isRiskAlertDetector: boolean = false;
   @Input() overWriteDetectorDescription: string = "";
-  @Input() overWriteDetectorName:string = "";
+  @Input() overWriteDetectorName: string = "";
   feedbackButtonLabel: string = 'Send Feedback';
   hideShieldComponent: boolean = false;
 
@@ -176,18 +177,21 @@ export class DetectorViewComponent implements OnInit {
 
   @Output() downTimeChanged: EventEmitter<DownTime> = new EventEmitter<DownTime>();
   private isLegacy: boolean;
+  public breadCrumb: BreadcrumbNavigationItem;
 
   constructor(@Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig, private telemetryService: TelemetryService,
-    private detectorControlService: DetectorControlService, private _supportTopicService: GenericSupportTopicService, private _cxpChatService: CXPChatService, protected _route: ActivatedRoute, private versionService: VersionService, private _router: Router, private _genericUserSettingsService: GenericUserSettingService) {
+    private detectorControlService: DetectorControlService, private _supportTopicService: GenericSupportTopicService, private _cxpChatService: CXPChatService, protected _route: ActivatedRoute, private versionService: VersionService, private _router: Router, private _genericUserSettingsService: GenericUserSettingService, private _global: GenieGlobals) {
     this.isPublic = config && config.isPublic;
     this.feedbackButtonLabel = this.isPublic ? 'Send Feedback' : 'Rate Detector';
   }
 
   ngOnInit() {
     if (this._route.snapshot.data.tabKey == 'Monitoring' || this._route.snapshot.data.tabKey == 'Analytics')
-        this.buttonStyle = {root:{display: "none"}};
+      this.buttonStyle = { root: { display: "none" } };
     this.versionService.isLegacySub.subscribe(isLegacy => this.isLegacy = isLegacy);
     this._route.params.subscribe(p => {
+      this.breadCrumb = { ...this._global.breadCrumb };
+      this._global.breadCrumb = null;
       this.loadDetector();
     });
 
@@ -228,23 +232,18 @@ export class DetectorViewComponent implements OnInit {
 
   protected loadDetector() {
     this.detectorResponseSubject.subscribe((data: DetectorResponse) => {
-      if (!this.isPublic)
-      {
-        this._genericUserSettingsService.isWaterfallViewMode().subscribe(isWaterfallViewMode =>
-            {
-                if (isWaterfallViewMode)
-                {
-                    this.detectorDataLocalCopy = data;
-                }
-                else
-                {
-                    this.detectorDataLocalCopy = this.mergeDetectorListResponse(data);
-                }
-            });
-      }
-      else
-      {
+      if (!this.isPublic) {
+        this._genericUserSettingsService.isWaterfallViewMode().subscribe(isWaterfallViewMode => {
+          if (isWaterfallViewMode) {
+            this.detectorDataLocalCopy = data;
+          }
+          else {
             this.detectorDataLocalCopy = this.mergeDetectorListResponse(data);
+          }
+        });
+      }
+      else {
+        this.detectorDataLocalCopy = this.mergeDetectorListResponse(data);
       }
 
 
@@ -515,10 +514,10 @@ export class DetectorViewComponent implements OnInit {
 
       this.fabChoiceGroupOptions.push(this.getDefaultFabricDownTimeEntry());
       const defaultDowntime = this.downTimes.find(x => x.isSelected);
-      if(defaultDowntime != null) {
+      if (defaultDowntime != null) {
         this.selectedKey = this.getKeyForDownTime(defaultDowntime);
         this.selectedDownTime = defaultDowntime;
-      } else if(this.fabChoiceGroupOptions.length > 0) {
+      } else if (this.fabChoiceGroupOptions.length > 0) {
         this.selectedKey = this.fabChoiceGroupOptions[0].key;
         this.selectedDownTime = this.fabChoiceGroupOptions.length > 1 ? this.downTimes[0] : this.getDefaultDowntimeEntry();
       }
@@ -743,7 +742,7 @@ export class DetectorViewComponent implements OnInit {
 
   renderCXPChatButton() {
     if (this.cxpChatTrackingId === '' && this.cxpChatUrl === '') {
-      let effectiveSupportTopicId:string = '';
+      let effectiveSupportTopicId: string = '';
       effectiveSupportTopicId = (this._supportTopicService && this._supportTopicService.sapSupportTopicId) ? this._supportTopicService.sapSupportTopicId : this._supportTopicService.supportTopicId;
       if (this._supportTopicService && this._cxpChatService && this._cxpChatService.isSupportTopicEnabledForLiveChat(effectiveSupportTopicId)) {
         this.cxpChatTrackingId = this._cxpChatService.generateTrackingId(effectiveSupportTopicId);
@@ -779,29 +778,29 @@ export class DetectorViewComponent implements OnInit {
   }
 
   //Merge all child detectors and put it into last place
-  private mergeDetectorListResponse(response: DetectorResponse):DetectorResponse {
+  private mergeDetectorListResponse(response: DetectorResponse): DetectorResponse {
 
-    if(!response || !response.dataset || !response.dataset.find(d => d.renderingProperties.type === RenderingType.DetectorList)) return response;
+    if (!response || !response.dataset || !response.dataset.find(d => d.renderingProperties.type === RenderingType.DetectorList)) return response;
 
-    const mergedResponse = {...response};
+    const mergedResponse = { ...response };
     let lastIndex = 0;
-    const detectorIds:string[] = [];
-    for(let i = 0;i < response.dataset.length;i++){
+    const detectorIds: string[] = [];
+    for (let i = 0; i < response.dataset.length; i++) {
       const data = response.dataset[i];
       const isVisible = (<Rendering>data.renderingProperties).isVisible;
-      if(data.renderingProperties.type === RenderingType.DetectorList && isVisible !== false){
+      if (data.renderingProperties.type === RenderingType.DetectorList && isVisible !== false) {
         lastIndex = i;
-        const detectors:string[] = data.renderingProperties.detectorIds ? data.renderingProperties.detectorIds : [];
+        const detectors: string[] = data.renderingProperties.detectorIds ? data.renderingProperties.detectorIds : [];
         detectorIds.push(...detectors);
       }
     }
 
-    const dataSet = mergedResponse.dataset.filter((data,index) => {
+    const dataSet = mergedResponse.dataset.filter((data, index) => {
       return data.renderingProperties.type !== RenderingType.DetectorList || index === lastIndex;
     });
 
     const detectorMetaData = dataSet.find(d => d.renderingProperties.type === RenderingType.DetectorList);
-    if(detectorMetaData){
+    if (detectorMetaData) {
       detectorMetaData.renderingProperties.detectorIds = detectorIds;
     }
 
@@ -811,6 +810,12 @@ export class DetectorViewComponent implements OnInit {
 
   closeDownTimeCallOut() {
     this.showDowntimeCallout = false;
+  }
+
+  navigateForBreadCrumb() {
+    if (this.breadCrumb) {
+      this._router.navigate([this.breadCrumb.fullPath], { queryParams: this.breadCrumb.queryParams });
+    }
   }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -813,8 +813,9 @@ export class DetectorViewComponent implements OnInit {
   }
 
   navigateForBreadCrumb() {
+    const combinedParams = {...this._route.snapshot.queryParams, ...this.breadCrumb.queryParams};
     if (this.breadCrumb) {
-      this._router.navigate([this.breadCrumb.fullPath], { queryParams: this.breadCrumb.queryParams });
+      this._router.navigate([this.breadCrumb.fullPath], { queryParams: combinedParams });
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/generic-breadcrumb.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/generic-breadcrumb.service.ts
@@ -9,7 +9,6 @@ export class GenericBreadcrumbService {
 
 export interface BreadcrumbNavigationItem {
     name: string;
-    id?: string;
-    isDetector?: boolean;
+    fullPath: string;
     queryParams?: any;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/services/genie.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/genie.service.ts
@@ -1,5 +1,6 @@
 import { Injectable} from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { BreadcrumbNavigationItem } from './generic-breadcrumb.service';
 
 @Injectable({
     providedIn: 'root'
@@ -10,6 +11,7 @@ export class GenieGlobals {
     openGeniePanel: boolean = false;
     openFeedback: boolean = false;
     messagesData: { [id: string]: any } = {};
+    breadCrumb: BreadcrumbNavigationItem = null;
 
     getDetectorName():string {
         return "";


### PR DESCRIPTION
Add Go back button to enable go back from child detector to analysis or parent detector

In Diag&Solve blade,
![image](https://user-images.githubusercontent.com/23129934/202060674-43454f37-058a-495c-90b0-38a73f4756d3.png)

In case submission
![image](https://user-images.githubusercontent.com/23129934/202060798-0ed330d5-a772-495e-8afe-91c225109e86.png)
