### PR TITLE
Showing error message for invalid time reading from query params

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
@@ -58,7 +58,7 @@ import { L2SideNavComponent } from './l2-side-nav/l2-side-nav.component';
 import { ApplensCommandBarService } from './services/applens-command-bar.service';
 import { ApplensGlobal as ApplensGlobals } from '../../applens-global';
 import { ResourceInfo } from '../../shared/models/resources';
-import { catchError, flatMap, map, take } from 'rxjs/operators';
+import { catchError, map, mergeMap, take } from 'rxjs/operators';
 import { RecentResource } from '../../shared/models/user-setting';
 import { UserSettingService } from './services/user-setting.service';
 import { ApplensDocsComponent } from './applens-docs/applens-docs.component';
@@ -103,8 +103,8 @@ export class InitResolver implements Resolve<Observable<ResourceInfo>>{
         this._detectorControlService.updateTimePickerInfo({
             selectedKey: TimePickerOptions.Custom,
             selectedText: TimePickerOptions.Custom,
-            startDate: new Date(startTime),
-            endDate: new Date(endTime)
+            startDate: new Date(this._detectorControlService.startTimeString),
+            endDate: new Date(this._detectorControlService.endTimeString)
         });
 
         //Wait for getting UserSetting and update landingPage info before going to dashboard/detector page
@@ -117,9 +117,9 @@ export class InitResolver implements Resolve<Observable<ResourceInfo>>{
                 queryParams: queryParams
             };
             return resourceInfo;
-        }), flatMap(resourceInfo => {
+        }), mergeMap(resourceInfo => {
             return this._userSettingService.getUserSetting().pipe(take(1), catchError(_ => of(null)), map(_ => resourceInfo));
-        }), flatMap(resourceInfo => {
+        }), mergeMap(resourceInfo => {
             return this._userSettingService.updateLandingInfo(recentResource).pipe(catchError(_ => of(null)), map(_ => resourceInfo));
         }));
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-time-picker/detector-time-picker.component.ts
@@ -22,7 +22,8 @@ export class DetectorTimePickerComponent implements OnInit {
   openTimePickerCallout: boolean = false;
   @Input() target: string = "";
   @Input() disableUpdateQueryParams: boolean = false;
-  @Output() updateTimerMessage: EventEmitter<string> = new EventEmitter();
+  //@Output() updateTimerMessage: EventEmitter<string> = new EventEmitter();
+  @Output() updateTimerErrorMessage: EventEmitter<string> = new EventEmitter();
   timePickerButtonStr: string = "";
   showCalendar: boolean = false;
   showTimePicker: boolean = false;
@@ -100,9 +101,6 @@ export class DetectorTimePickerComponent implements OnInit {
     this.openTimePickerCalloutObservable.subscribe(o => {
       this.openTimePickerCallout = o;
     });
-    this.detectorControlService.timePickerStrSub.subscribe(s => {
-      this.updateTimerMessage.next(s);
-    })
 
 
     this.detectorControlService.timePickerInfoSub.subscribe(timerPickerInfo => {
@@ -124,9 +122,10 @@ export class DetectorTimePickerComponent implements OnInit {
       }
     });
 
-    this.timeDiffError = '';
+    //this.timeDiffError = '';
     if (this.detectorControlService.timeRangeDefaulted) {
-      this.timeDiffError = this.detectorControlService.timeRangeErrorString;
+      //this.timeDiffError = this.detectorControlService.timeRangeErrorString;
+      this.updateTimerErrorMessage.emit(this.detectorControlService.timeRangeErrorString);
     }
 
     this.detectorControlService.update.subscribe(validUpdate => {
@@ -211,6 +210,7 @@ export class DetectorTimePickerComponent implements OnInit {
     if (this.timeDiffError === '') {
       this.detectorControlService.setCustomStartEnd(startDateWithTime, endDateWithTime);
       this.detectorControlService.updateTimePickerInfo(timePickerInfo);
+      this.updateTimerErrorMessage.emit("");
     }
     this.openTimePickerCallout = this.timeDiffError !== "";
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -46,87 +46,9 @@
   </div>
 </div>
 
+<div *ngIf="timePickerErrorStr !==''" class="error-time-picker-message">{{timePickerErrorStr}}</div>
+
 <div *ngIf="detectorDataLocalCopy">
-  <!-- <div *ngIf="((!hideDetectorHeader && !analysisMode) || isPopoutFromAnalysis) && !isInCaseSubmission()">
-    <section class="content-header">
-      <h2 style="display: flex;">
-        <div *ngIf="!isSystemInvoker && !insideDetectorList &&!isPublic" tabindex="0" id="detector-name">
-          {{detectorDataLocalCopy.metadata.name}}</div>
-        <div *ngIf="!isSystemInvoker && !insideDetectorList && !isPublic && detectorDataLocalCopy.metadata.description" class="blade-description">&nbsp;- &nbsp;</div>
-        <div class="blade-description">
-          <span *ngIf="!overWriteDetectorDescription || overWriteDetectorDescription.length === 0;else overwriteDescription">
-            {{detectorDataLocalCopy.metadata.description}}
-          </span>
-        </div>
-      </h2>
-      <section *ngIf="!isPublic">
-        <div class="description">By
-          <span style="padding:2px; color: #0066c0;">
-            <a *ngIf="authorInfo !== ''; else unknownAuthor" href="{{emailToAuthor}}">
-              {{authorInfo}}
-            </a>
-            <ng-template #unknownAuthor>
-              Unknown
-            </ng-template>
-          </span>
-        </div>
-      </section>
-      <div *ngIf="!insideDetectorList && !hideDetectorControl">
-        <div style="margin-top:10px">
-          <button (click)="toggleButtonView(Feedback)"
-            class="custom-button custom-button-align-left detector-button-list">
-            <span> {{feedbackButtonLabel}}</span>
-          </button>
-          <a *ngIf="!isPublic && authorInfo !== ''; else onlyToApplensTeam" class="custom-button detector-button-list"
-            href="{{emailToAuthor}}">
-            <span> Email Author</span>
-          </a>
-          <ng-template #onlyToApplensTeam>
-            <a *ngIf="!isPublic" class="custom-button-green detector-button-list" href="{{emailToApplensTeam}}">
-              <span> Email Author</span>
-            </a>
-          </ng-template>
-          <button (click)="toggleButtonView(Report)" class="custom-button detector-button-list">
-            <span *ngIf="buttonViewActiveComponent !== Report">Copy Report</span>
-            <span *ngIf="buttonViewActiveComponent === Report">Hide Report</span>
-          </button>
-        </div>
-        <div style="height:0px;overflow-y: hidden" [@expand]="buttonViewVisible ? 'shown' : 'hidden'">
-          <feedback *ngIf="buttonViewActiveComponent === Feedback" [showFeedbackForm]="buttonViewVisible"
-            (showFeedbackFormChange)="toggleButtonView(Feedback)" [source]="'appanalysis'"
-            [ratingEventProperties]="ratingEventProperties"></feedback>
-          <copy-insight-details *ngIf="detectorDataLocalCopy && buttonViewActiveComponent === Report"
-            [detectorResponse]="detectorDataLocalCopy"></copy-insight-details>
-        </div>
-      </div>
-    </section>
-    <hr>
-  </div> -->
-
-  <!-- <br *ngIf="isInCaseSubmission() && !isKeystoneView"> -->
-
-  <!-- <div *ngIf="isAnalysisView && supportsDownTime" class="dynamic-data-container">
-    <div class="downtime-container">
-      <span class="downtime-icon"><i class="fa fa-filter fa-lg" aria-hidden="true"></i></span>
-      <label for="downtimeFilter" tabindex="0" aria-label="Select a downtime to investigate."
-        role="text"><strong>Downtime</strong></label>
-      <fab-dropdown id="downtimeFilter" role="combobox" [options]="fabOptions" (onChange)="selectFabricKey($event)"
-        [defaultSelectedKey]="selectedKey" [disabled]="downtimeFilterDisabled"
-        [contentStyle]="'margin-top: -5px; margin-left: 5px;width:{{fabDropdownWidth}}px;min-width:336px'">
-      </fab-dropdown>
-    </div>
-    <div *ngIf="downtimeSelectionErrorStr!=''" class="errorMessage"
-      attr.aria-label="Error : {{downtimeSelectionErrorStr}}" tabindex="0" role="text">
-      <strong>Error :</strong> {{downtimeSelectionErrorStr}}<span style='vertical-align:super'>*</span>
-    </div>
-  </div> -->
-
-  <!-- <div style="margin-bottom: 24px;">
-    <span *ngIf="!overWriteDetectorDescription || overWriteDetectorDescription.length === 0;else overwriteDescription">
-      {{detectorDataLocalCopy.metadata.description}}
-    </span>
-  </div> -->
-
   <div *ngFor="let data of detectorDataLocalCopy.dataset  | renderfilter:isAnalysisView"
     [ngClass]="{'dynamic-data-container': !isRiskAlertDetector}">
     <dynamic-data [isRiskAlertDetector]="isRiskAlertDetector" [isAnalysisView]="isAnalysisView" [diagnosticData]="data"
@@ -140,13 +62,6 @@
 <data-container *ngIf="!isAnalysisView && supportDocumentRendered" [title]="'Additional troubleshooting resources'">
   <markdown *ngIf="supportDocumentContent.length>0" #markdownDiv [data]="supportDocumentContent"></markdown>
 </data-container>
-
-<!-- <div *ngIf="isAnalysisView && supportsDownTime && downTimes.length > 0 && !!selectedDownTime && !!selectedDownTime.StartTime && !!selectedDownTime.EndTime" class="dynamic-data-container" tabindex="0"
-  role="text"
-  attr.aria-label="Showing results from {{ getTimestampAsString(selectedDownTime.StartTime) }} to {{ getTimestampAsString(selectedDownTime.EndTime) }}">
-  <h2 aria-hidden="true">Showing results from {{ getTimestampAsString(selectedDownTime.StartTime) }} to
-    {{ getTimestampAsString(selectedDownTime.EndTime) }}</h2>
-</div> -->
 
 <cxp-chat-launcher *ngIf="showChatButton()" [trackingId]="cxpChatTrackingId" [chatUrl]="cxpChatUrl"
   [supportTopicId]="supportTopicId"></cxp-chat-launcher>
@@ -184,5 +99,5 @@
   </div>
 </ng-template>
 
-<detector-time-picker [target]="'#time-picker-button'" [openTimePickerCalloutObservable]="openTimePickerSubject">
+<detector-time-picker [target]="'#time-picker-button'" [openTimePickerCalloutObservable]="openTimePickerSubject" (updateTimerErrorMessage)="updateTimePickerErrorMessage($event)">
 </detector-time-picker>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.scss
@@ -87,3 +87,8 @@
     padding-top: 10px;
     color: $error-color;
 }
+.error-time-picker-message {
+    color: $error-color;
+    padding-bottom: 10px;
+    font-weight: 600;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.ts
@@ -78,6 +78,7 @@ export class DetectorViewComponent implements OnInit {
   downtimeButtonStr: string = "";
   openTimePickerSubject: BehaviorSubject<boolean> = new BehaviorSubject(false);
   timePickerButtonStr: string = "";
+  timePickerErrorStr: string = "";
   buttonStyle: IButtonStyles = {
     root: {
       // color: "#323130",
@@ -817,6 +818,10 @@ export class DetectorViewComponent implements OnInit {
     if (this.breadCrumb) {
       this._router.navigate([this.breadCrumb.fullPath], { queryParams: combinedParams });
     }
+  }
+
+  updateTimePickerErrorMessage(message: string) {
+    this.timePickerErrorStr = message;
   }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -52,7 +52,7 @@ export class DetectorControlService {
 
   private _refresh: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
 
-  public _effectiveLocale: string="";
+  public _effectiveLocale: string = "";
 
   private detectorQueryParams: BehaviorSubject<string> = new BehaviorSubject<string>("");
 
@@ -69,7 +69,7 @@ export class DetectorControlService {
     selectedText: TimePickerOptions.Last24Hours
   });
 
-  public changeFromTimePicker:boolean = false;
+  public changeFromTimePicker: boolean = false;
 
   public timePickerStrSub: BehaviorSubject<string> = new BehaviorSubject(TimePickerOptions.Last24Hours);
 
@@ -77,7 +77,7 @@ export class DetectorControlService {
     this.internalClient = !config.isPublic;
     this._duration = this.durationSelections[2];
     this._startTime = moment.utc().subtract(this._duration.duration);
-    this._endTime = moment.utc().subtract(15,'minute');
+    this._endTime = moment.utc().subtract(15, 'minute');
   }
 
   public get update() {
@@ -219,8 +219,7 @@ export class DetectorControlService {
     if (this.getTimeDurationError(start, end) === '') {
       this._startTime = startTime;
       this._endTime = endTime;
-      if (!refreshInstanceId)
-      {
+      if (!refreshInstanceId) {
         this._refreshData("V3ControlRefresh");
       }
     }
@@ -251,7 +250,7 @@ export class DetectorControlService {
           }
         }
         else {
-          this.timeRangeErrorString = `Time range set to last 24 hrs. Start and End date time must not be more than ${(this.allowedDurationInDays * 24).toString()} hrs apart, Start date must be within the past 30 days and end date must be 15 minutes less than the current time.`;
+          this.timeRangeErrorString = `Error: The selected time range is not allowed. The start time must be within the past 30 days. The end time must be within ${(this.allowedDurationInDays * 24).toString()} hours of the start time and at least 15 minutes before the current time. Time range has been set to the last 24 hours by default`
           this._endTime = moment.utc().subtract(16, 'minutes');
           this._startTime = this._endTime.clone().subtract(1, 'days');
         }
@@ -263,7 +262,7 @@ export class DetectorControlService {
   public selectDuration(duration: DurationSelector) {
     this._duration = duration;
     this._startTime = moment.utc().subtract(duration.duration);
-    this._endTime = moment.utc().subtract(15,'minute');
+    this._endTime = moment.utc().subtract(15, 'minute');
     this.setCustomStartEnd(this._startTime.format(this.stringFormat), this.endTime.format(this.stringFormat));
   }
 
@@ -325,7 +324,7 @@ export class DetectorControlService {
   }
 
   public get effectiveLocale(): string {
-      return this._effectiveLocale;
+    return this._effectiveLocale;
   }
 
   public updateTimePickerInfo(updatedInfo: TimePickerInfo) {


### PR DESCRIPTION
This PR is for,

- Update error message for invalid time, showing error message related to reading startTime and endTime from query params in the detector page instead of hiding in the time-picker dropdown

- Remove comment code and replace **flatMap** as **mergeMap** since flatMap is deprecated 

![image](https://user-images.githubusercontent.com/23129934/204621834-7611f9ae-354d-4d6b-bd6f-298ac265bfd9.png)
