### PR TITLE
Starter commit for frame allowed origins

### DIFF
--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -171,6 +171,7 @@ namespace AppLensV3
 
             app.Use(async (context, next) =>
             {
+                context.Response.Headers.Add("Content-Security-Policy", "default-src: https:; frame-ancestors 'self' https://azuresupportcenter.msftcloudes.com/");
                 await next();
                 if (context.Response.StatusCode == 404 &&
                     !Path.HasExtension(context.Request.Path.Value) &&


### PR DESCRIPTION
## Overview
This PR aims to secure Applens by restricting who can embed AppLens in a browser iframe. This is needed for preventing against cross-site scripting attacks.

## Related Work Item
https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2823

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Solution description
To prevent cross origin iframing we are adding the Content-Security-Policy header that tells browsers to enforce restrictions on iframing of our website. We will allow only certain few endpoints like ASC to be able to iframe AppLens.

### This PR:
Adds a new response header to a enforce cross origin iframing restrictions.

## How Can This Be Tested? <span>&#128269;</span>
You can create a simple index.html file with <iframe src="APPLENS_PROJECT_URL"/> and see that it will not render the project in the IFrame.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Extra Notes
This is just a starter list of allowed origins, it will expand to include more ASC regions that I will add in this PR.
