### PR TITLE
Fix for tooltip background color config

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -647,7 +647,12 @@ export class HighchartsGraphComponent implements OnInit {
         }
     }
 
-    private _updateObject(obj: Object, replacement: any): Object {
+    private _updateObject(obj: any, replacement: any): Object {
+        //Not update tooltip background color as it will be break in the dark mode
+        if(replacement?.tooltip?.backgroundColor) {
+            delete replacement.tooltip.backgroundColor;
+        }
+
         // The option keys are different from nvd3. eg. In order to override default colors,
         // use "colors" as key  instead of "color"
         Object.keys(replacement).forEach(key => {


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->

This PR is for disabling configuring for tooltip background from detector code as it will break in the dark mode

## Related Work Item
<!--- Please provide the work item number as well as its link: -->

[WI 2822: Graph tool tip in dark mode is not legible ](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2822)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
Delete customized config for tooltip background color when updating graph options


## How Can This Be Tested? <span>&#128269;</span>

1. Go to portal or Applens in local, 
2. Set theme to dark mode
3. Go to "SNAT Port Exhaustion" detector 
4. Hover over on any graph and check if tooltip is legible 

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://user-images.githubusercontent.com/23129934/205354487-aaa211b3-e382-4fd6-beb3-0d646f6646b7.png)


## Screenshots After Fix (if appropriate):
![image](https://user-images.githubusercontent.com/23129934/205354845-aa8b132d-6756-44e2-ab89-7af1ea44bb50.png)
