### PR TITLE
Log user alias at entry time in Applens

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -14,6 +14,7 @@ import { SeverityLevel } from '@microsoft/applicationinsights-web';
 import { HttpClient } from '@angular/common/http';
 import { DetectorControlService } from 'diagnostic-data';
 import { ObserverSiteSku, ObserverSkuType } from '../../../shared/models/observer';
+import { AdalService } from 'adal-angular4';
 
 @Component({
   selector: 'dashboard-container',
@@ -57,7 +58,7 @@ export class DashboardContainerComponent implements OnInit {
   };
   vfsFonts: any;
 
-    constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _applensDiagnosticApiService: ApplensDiagnosticService,  private _observerService: ObserverService, private _applensGlobal: ApplensGlobal,  private _activatedRoute: ActivatedRoute, private _telemetryService: TelemetryService, private _http:HttpClient, private _detectorControlService: DetectorControlService) {
+    constructor(public _resourceService: ResourceService, private _startupService: StartupService, private _diagnosticApiService: DiagnosticApiService, private _applensDiagnosticApiService: ApplensDiagnosticService,  private _observerService: ObserverService, private _applensGlobal: ApplensGlobal,  private _activatedRoute: ActivatedRoute, private _telemetryService: TelemetryService, private _http:HttpClient, private _detectorControlService: DetectorControlService, private _adalService: AdalService) {
     let caseNumber = this._activatedRoute.snapshot.queryParams['caseNumber']? this._activatedRoute.snapshot.queryParams['caseNumber']: (this._activatedRoute.snapshot.queryParams['srId']? this._activatedRoute.snapshot.queryParams['srId']: null);
     this.detector = this._activatedRoute.snapshot.queryParams['detector']? this._activatedRoute.snapshot.queryParams['detector']: null;
     if(caseNumber && AppLensCloudRegionUtility.getASCCloudSpecificBaseUri()) {
@@ -70,6 +71,9 @@ export class DashboardContainerComponent implements OnInit {
     this.subscriptionId = this._activatedRoute.snapshot.queryParams['subscriptionId'];
     this.showMetrics = !(this._resourceService.overviewPageMetricsId == undefined || this._resourceService.overviewPageMetricsId == "");
     let serviceInputs = this._startupService.getInputs();
+    let alias = Object.keys(this._adalService.userInfo.profile).length > 0 ? this._adalService.userInfo.profile.upn : '';
+    let userId = alias.replace('@microsoft.com', '').toLowerCase();
+    this._telemetryService.logEvent(TelemetryEventNames.HomePageLogUser, {"userId": userId});
     this.resourceReady = this._resourceService.getCurrentResource();
     this._applensGlobal.updateHeader("");
     this.resourceReady.subscribe(resource => {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -109,6 +109,7 @@ export const TelemetryEventNames = {
     ICMTemplateManagementPage: 'ICMTemplateManagementPage',
     ICMTeamTemplateLoaded: 'ICMTeamTemplateLoaded',
     ICMTeamTemplateUpdate: 'ICMTeamTemplateUpdate',
+    HomePageLogUser: 'HomePageLogUser',
 };
 
 export const TelemetrySource = {


### PR DESCRIPTION
## Overview
Adds logging of user's alias against the session id when they enter Applens. This helps in feature usage analysis and debugging when a certain user faces problems.

## Related Work Item
None

## Type of change

Logging

- [x] New feature (non-breaking change which adds functionality)

## How Can This Be Tested? <span>&#128269;</span>
Can look into the logging events in browser network trace to confirm logging is happening. Eventually we will search for the logged event in AppInsights.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.
