### PR TITLE
Update main-page-menu-options.ts

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
+++ b/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
@@ -24,7 +24,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       enabled: true,
       caseId: false,
       id: 'App Service Environment',
-      userAuthorizationEnabled: true
+      userAuthorizationEnabled: false
     },
     {
       resourceType: "Microsoft.Web/containerApps",
@@ -34,7 +34,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       enabled: true,
       caseId: false,
       id: 'Container App',
-      userAuthorizationEnabled: true
+      userAuthorizationEnabled: false
     }, {
       resourceType: "Microsoft.Web/staticSites",
       resourceTypeLabel: 'Static App Name Or Default Host Name',
@@ -43,7 +43,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       enabled: true,
       caseId: false,
       id: 'Static Web App',
-      userAuthorizationEnabled: true
+      userAuthorizationEnabled: false
     },
     {
       resourceType: "Microsoft.Compute/virtualMachines",
@@ -53,7 +53,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       enabled: true,
       caseId: false,
       id: 'Virtual Machine',
-      userAuthorizationEnabled: true
+      userAuthorizationEnabled: false
     },
     {
       resourceType: "ARMResourceId",
@@ -63,7 +63,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       enabled: true,
       caseId: false,
       id: 'ARM Resource ID',
-      userAuthorizationEnabled: true
+      userAuthorizationEnabled: false
     },
     {
       resourceType: null,


### PR DESCRIPTION
## Overview
By mistake, the userAuthorizationEnabled flag was set to true for other resource types (other than Microsoft.Web/sites). This does not mean the validation was enforced but still CSS users would be seeing the case number column. This PR reverts that mistake.

## Related Work Item
None

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
By mistake, the userAuthorizationEnabled flag was set to true for other resource types. This does not mean the validation was enforced but still CSS users would be seeing the case number column. This PR reverts that mistake.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.