### PR TITLE
Remove Duplicate Row Data and Update Start and End time

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
@@ -331,7 +331,11 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
             new Date(a[this.startTimestampColumnName]).getTime() -
             new Date(b[this.startTimestampColumnName]).getTime()
             );
-        });
+        })
+        .filter(
+            (value, index, arr) =>
+              arr.findIndex((v2) => JSON.stringify(v2) === JSON.stringify(value)) === index
+        );
     }
 
     private _getDifferenceInMinutes(currentTime: string, endTime: string) {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/time-series-graph/time-series-graph.component.ts
@@ -343,7 +343,7 @@ export class TimeSeriesGraphComponent extends DataRenderBaseComponent implements
       }
     
     private _getTimeStamp(datetimeString: string) {
-        return new Date(datetimeString.split('.')[0]).getTime();
+        return momentNs.utc(datetimeString).milliseconds(0).toDate().getTime();
     }
 
     private _getGreatestCommonFactor(timestamp: momentNs.Moment): momentNs.Duration {


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
When calculating the time difference in minutes for data that's rendered on the Gantt Chart, the milliseconds in the timestamp results in inaccurate calculation and rendering of data on the Gantt Chart. Also, when duplicate date is passed to the Gantt Chart, it results in nothing being rendered on the chart. This fix removes milliseconds from datetime to ensure accurate calculation of timestamps differences and it also removes duplicate row data.

## Related Work Item
<!--- Please provide the work item number as well as its link: -->
[AB#2632](https://dev.azure.com/app-service-diagnostics-portal/d760220e-01cd-406f-b520-62a6e0779471/_workitems/edit/2632)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~
~- [ ] This change requires a documentation update~

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
<!--- An example of a solution description -->
<!--- - creates a new rendering type -->
<!--- - refactors the code -->
<!--- - adds a new function/enum to render a bar chart -->
 - removes the milliseconds from the start and end time
 - removes duplicate row data

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

- In your terminal, run the following commands
       - `cd AngularApp` 
       - `npm run applens` 
 - Go to localhost:4200 and provide an app name e.g. `buggybakery` or `rekha-autoheal-test`
 - Create a new detector and add the following code

```
#load "geoutilities"

// *****PLEASE DO NOT MODIFY THIS PART*****
using Diagnostics.DataProviders;
using Diagnostics.ModelsAndUtils.Utilities;
using Diagnostics.ModelsAndUtils.Models;
using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
using Diagnostics.ModelsAndUtils.Attributes;
using Diagnostics.ModelsAndUtils.ScriptUtilities;
using Kusto.Data;
//*****END OF DO NOT MODIFY PART*****
private static string GetQuery(OperationContext<App> cxt, string siteRuntimeName, string startTime, string endTime, int Time_Grain)
{
    return
        $@"set query_results_cache_max_age = time(1d);
            StatsDWASWorkerProcessTenMinuteTable 
            | where {Utilities.TimeAndTenantFilterQuery(startTime, endTime, cxt.Resource, "TIMESTAMP")} 
            | where ApplicationPool =~ ""{siteRuntimeName}"" or ApplicationPool startswith ""{siteRuntimeName}__""
            | project TIMESTAMP, Tenant, ApplicationPool, RoleInstance
            | summarize by bin(TIMESTAMP, {Time_Grain}m), Tenant, RoleInstance, ApplicationPool
            | join kind=inner (
                RoleInstanceHeartbeat 
                | where {Utilities.TimeAndTenantFilterQuery(startTime, endTime, cxt.Resource)}
                | extend IsVMSS = iif(RoleInstance !startswith 'Small' and RoleInstance !startswith 'Medium' and RoleInstance !startswith 'Large', true, false)
                | extend VMID = iif(IsVMSS, VMID, '')            
                | summarize arg_max(PreciseTimeStamp, Details, VMID) by Tenant, RoleInstance, MachineName
                | project Tenant, RoleInstance, IP = Details, MachineName, VMID
            ) on RoleInstance , Tenant
            | project TIMESTAMP, EndTimestamp=datetime_add('minute',{Time_Grain}, TIMESTAMP), MachineName
            | order by TIMESTAMP asc";
}


[AppFilter(AppType = AppType.WebApp, PlatformType = PlatformType.Windows, StackType = StackType.All)]
[Definition(Id = "Gantt_chart_rendering", Name = "Gantt Chart Example", Author = "olushadare", Description = "")]
public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
{
    var hostingEnv = cxt.Resource.Stamp;
    string stampName = !string.IsNullOrWhiteSpace(hostingEnv.InternalName) ? hostingEnv.InternalName : hostingEnv.Name;
    string siteName = cxt.Resource.Name;
    var startTime = cxt.StartTime;
    var endTime = GeoUtilities.DateTimeToKustoFormat(GeoUtilities.ParseDateTimeUTC(cxt.EndTime).AddMinutes(-10));
    var timeDiff = GeoUtilities.ParseDateTimeUTC(endTime) - GeoUtilities.ParseDateTimeUTC(startTime);
    var Time_Grain = ((timeDiff.Days) / 2 + 1) * 10;
    var workerChangeTask = dp.Kusto.ExecuteQuery(GetQuery(cxt, siteName, startTime, endTime, Time_Grain), stampName, null, "GetWorkerProcessTenMinuteQuery");

    res.Dataset.Add(new DiagnosticData()
    {
        Table = await workerChangeTask,
        RenderingProperties = new TimeSeriesRendering(){
            Title = "Gantt Chart Example",
            GraphType = TimeSeriesType.GanttChart,
            SeriesColumns = new string[] { "MachineName" },
            StartTimestampColumnName = "TIMESTAMP",
            EndTimestampColumnName = "EndTimestamp"
        }
    });

    return res;
}
```
- Run the code

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
~- [ ] I have run the linter to catch any errors.~
- [x] There are no errors from my changes on this branch.
~- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone~
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
<img width="551" alt="image" src="https://user-images.githubusercontent.com/24648672/207477084-c82f7600-700c-4ba5-9bd5-4ad0d3a3fb0d.png">

<img width="549" alt="image" src="https://user-images.githubusercontent.com/24648672/207485266-4cc19318-3651-4438-9b22-550afe138819.png">


## Screenshots After Fix (if appropriate):

<img width="542" alt="image" src="https://user-images.githubusercontent.com/24648672/207476875-bcf772e9-fffd-4b73-b5f0-8d59a09808a0.png">


## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
