### PR TITLE
Fix for EventViewer not selecting cells

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table/fab-data-table.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-data-table/fab-data-table.component.ts
@@ -105,7 +105,7 @@ export class FabDataTableComponent implements AfterContentInit {
         this.fabDetailsList.selectionMode = SelectionMode.single; 
       }
       else{
-        this.fabDetailsList.selectionMode = SelectionMode.none; 
+        this.fabDetailsList.selectionMode = this.descriptionColumnName !== "" ? SelectionMode.single : SelectionMode.none; 
       }
       this.fabDetailsList.selection = this.selection;
 


### PR DESCRIPTION
## Overview
Fix for Event Viewer not getting clicked

## Related Work Item
Click on any of the Event log rows is not selecting the entry due to which the description cannot be viewed by end user

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update