### PR TITLE
Correcting definitions for MarkdownModule to fix custom styles in markdown

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
@@ -535,7 +535,6 @@ export const DashboardModuleRoutes: ModuleWithProviders<DashboardModule> = Route
             // to avoid passing the same options over and over in each components of your App
             iconlibrary: 'glyph'
         }),
-        MarkdownModule.forRoot(),
         MonacoEditorModule.forRoot() // use forRoot() in main app module only.
     ],
     providers: [


### PR DESCRIPTION
Correcting definitions for MarkdownModule to fix custom styles in markdown. The line that I am removing was overriding the existing MarkdownModule definition

```
       MarkdownModule.forRoot({
            sanitize: SecurityContext.STYLE
        }),
```

## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

## Related Work Item
<!--- Please provide the work item number as well as its link: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
<!--- An example of a solution description -->
<!--- - creates a new rendering type -->
<!--- - refactors the code -->
<!--- - adds a new function/enum to render a bar chart -->

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

## Checklist <span>&#9989;</span>
- [ ] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [ ] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [ ] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
