### PR TITLE
Handle case number needed error gracefully

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -195,6 +195,7 @@ export class DashboardComponent implements OnDestroy {
     let resourceProviderFull = `${resourceInfo.provider}/${resourceInfo.resourceTypeName}`.toLowerCase();
     let mainPageResourceType = this.defaultResourceTypes.find(x => x.resourceType && x.resourceType.toLowerCase() === resourceProviderFull);
     let queryParams = {
+      ...(this.accessError.includes("User is not allowed to access this resource without a case number") ? { caseNumberNeeded: "true" } : {}),
       caseNumber: this._diagnosticApiService.CustomerCaseNumber,
       errorMessage: this.accessError,
       resourceType: mainPageResourceType? mainPageResourceType.resourceType: "armresourceid",

--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -196,7 +196,7 @@ export class DashboardComponent implements OnDestroy {
     let mainPageResourceType = this.defaultResourceTypes.find(x => x.resourceType && x.resourceType.toLowerCase() === resourceProviderFull);
     let queryParams = {
       ...(this.accessError.includes("User is not allowed to access this resource without a case number") ? { caseNumberNeeded: "true" } : {}),
-      caseNumber: this._diagnosticApiService.CustomerCaseNumber,
+      ...(this._diagnosticApiService.CustomerCaseNumber? {caseNumber: this._diagnosticApiService.CustomerCaseNumber}: {}),
       errorMessage: this.accessError,
       resourceType: mainPageResourceType? mainPageResourceType.resourceType: "armresourceid",
       resourceName: resourceInfo.resourceName,

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
@@ -18,7 +18,7 @@
       </div>
       <div style="width: 50%;">
         <div class="section"
-          *ngIf="caseNumberNeededForUser && (selectedResourceType && selectedResourceType.userAuthorizationEnabled)">
+        *ngIf="caseNumberNeededForProduct || (caseNumberNeededForUser && (selectedResourceType && selectedResourceType.userAuthorizationEnabled))">
           <fab-text-field [ariaLabel]="'Customer case number'" [defaultValue]="caseNumber" (onChange)="updateCaseNumber($event)"
             [placeholder]="caseNumberPlaceholder" [label]="'Case Number'" [required]="true"
             [styles]="fabTextFieldStyles">

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -105,7 +105,7 @@ export class MainComponent implements OnInit {
       this.resourceTypes = this.resourceTypes.filter(resourceType => !resourceType.caseId);
     }
 
-    if (this._activatedRoute.snapshot.queryParams['caseNumber'] && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "undefined") {
+    if (this._activatedRoute.snapshot.queryParams['caseNumber'] && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "null" && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "undefined") {
       this.caseNumber = this._activatedRoute.snapshot.queryParams['caseNumber'];
     }
     if (this._activatedRoute.snapshot.queryParams['resourceName']) {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -105,7 +105,7 @@ export class MainComponent implements OnInit {
       this.resourceTypes = this.resourceTypes.filter(resourceType => !resourceType.caseId);
     }
 
-    if (this._activatedRoute.snapshot.queryParams['caseNumber'] && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "null" && this._activatedRoute.snapshot.queryParams['caseNumber'] !== "undefined") {
+    if (this._activatedRoute.snapshot.queryParams['caseNumber']) {
       this.caseNumber = this._activatedRoute.snapshot.queryParams['caseNumber'];
     }
     if (this._activatedRoute.snapshot.queryParams['resourceName']) {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -42,6 +42,7 @@ export class MainComponent implements OnInit {
   displayLoader: boolean = false;
   loaderSize = SpinnerSize.large;
   caseNumberNeededForUser: boolean = false;
+  caseNumberNeededForProduct: boolean = false;
   caseNumber: string = '';
   caseNumberValidationError: string = null;
   accessErrorMessage: string = '';
@@ -112,6 +113,9 @@ export class MainComponent implements OnInit {
     }
     if (this._activatedRoute.snapshot.queryParams['errorMessage']) {
       this.accessErrorMessage = this._activatedRoute.snapshot.queryParams['errorMessage'];
+    }
+    if (this._activatedRoute.snapshot.queryParams['caseNumberNeeded']) {
+      this.caseNumberNeededForProduct = true;
     }
     if (this._activatedRoute.snapshot.queryParams['resourceType']) {
       let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === this._activatedRoute.snapshot.queryParams['resourceType'].toLowerCase());


### PR DESCRIPTION
## Overview
Since we are planning to expand Durian to more products, we will have some scenarios where Durian configuration is not in sync between Applens and Runtimehost. This can cause some bad situations where the user is stuck. This PR adds a very critical logic to handle error gracefully even if there is a configuration mismatch. This particular change is to handle case number needed error by showing the case number field to the user.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Solution description
Durian is enabled for any given product from Runtimehost and Applens separately. This can lead to situations where Runtimehost and Applens are not updated synchronously and while the Runtimehost needs a case number, Applens is not asking the user for one (as the frontend config is not yet updated). To handle this - **if the Runtimehost throws an error asking for a case number, the frontend should assume Durian is enabled for the product and should show the field for the user to provide the case number**. This solution achieves that.

## How Can This Be Tested? <span>&#128269;</span>
A CSS user is asked for case number while accessing AppLens for certain products. This change can be tested by enabling Durian for a product in backend (Runtimehost) but not in Frontend (AppLens). Initially when user comes to AppLens, they will not see case number field since frontend doesn't have Durian enabled for the product. However, once they enter information and try to move further, backend will throw an error asking for case number (since Durian is enabled for the product on the backend). The above solution should handle that error gracefully and show the user case number field to fill in the data.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
Initial Screen (Durian is not enabled on frontend for AKS resources, so the user is not asked for case number)
![image](https://user-images.githubusercontent.com/8492235/214516731-1365cd77-ace2-425c-9002-63a07d7e2972.png)

However when they try to enter Applens:
![image](https://user-images.githubusercontent.com/8492235/214517171-5e26f0fb-d966-4c14-805d-cc0946305060.png)

Here we can see user is seeing the error message about case number but no field to provide it. This is due to configuration mismatch between frontend (Applens) and backend (Runtimehost).

## Screenshots After Fix (if appropriate):
After this fix, user will get an option to provide case number when the error occurs
![image](https://user-images.githubusercontent.com/8492235/214522893-e886490f-9204-4ce3-b900-c42cf545abbb.png)

