### PR TITLE
Bug: Resource object is not extensible issue

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard-container/dashboard-container.component.ts
@@ -233,7 +233,10 @@ export class DashboardContainerComponent implements OnInit {
 
   updateAscLink() {
     if(this.ascResourceExplorerLink && this.resource!= null ) {
-          this.resource['ASCLink'] = `<a href="${this.ascResourceExplorerLink}" target="_blank">Resource Explorer<i class="hyper-link-icon ml-1" aria-hidden="true"></i></a>`;
+          this.resource = {
+              ...this.resource,
+              ASCLink: `<a href="${this.ascResourceExplorerLink}" target="_blank">Resource Explorer<i class="hyper-link-icon ml-1" aria-hidden="true"></i></a>`
+          };
           this.keys.push('ASCLink');
     }
   }


### PR DESCRIPTION
## Overview
The issue is basically Applens does not show any resource information if ASC link is embedded:
![image](https://user-images.githubusercontent.com/8492235/215917240-66b084a1-1c3d-4b01-b3fc-9343ca29efc1.png)

This will happen for every CSS user workflow as they provide a case number which activates the embedding of ASC Link.

The core issue was that the resource object is not extensible and thus anything like this.resource['ASCLink'] breaks the code path.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Solution description
This fix was to use object spread instead of object extension.

### This PR:
Fixes the issue.
![image](https://user-images.githubusercontent.com/8492235/215917591-ed7a55ce-f576-4c84-9546-d93ede01024d.png)


## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://user-images.githubusercontent.com/8492235/215917240-66b084a1-1c3d-4b01-b3fc-9343ca29efc1.png)

## Screenshots After Fix (if appropriate):
![image](https://user-images.githubusercontent.com/8492235/215917626-647756f3-846e-41b3-9f3b-8ca5be7fee11.png)


## Extra Notes
I had a lot of fun debugging this and a lot of time.
