### PR TITLE
Changing Request method to POST for databasetest route

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.ts
@@ -174,7 +174,6 @@ export class KustoQueryDialogComponent implements OnInit {
   getQueryText(): string {
     let code = this.code.substring(3);
     code = code.substring(0, code.length - 1);
-    console.log(code);
     return code;
   }
 


### PR DESCRIPTION
## Overview
The next version of DAAS is updating the /databasetest controller from GET to POST. This PR will check if the HTTP GET call fails, a fallback to POST will happen and once entire DAAS is updated, I will revert this code to just make a POST call.

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
