### PR TITLE
Switch to using DaaS Storage connection string instead of SAS URI

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
@@ -168,12 +168,7 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
   updateDaasAction(emitEvent: boolean) {
     if (this.validationResult.Validated) {
       this.updatedCustomAction.exe = daasConsolePath;
-      if (this.validationResult.ConfiguredAsAppSetting) {
-        this.updatedCustomAction.parameters = `-${this.diagnoserOption.option} "${this.diagnoser.Name}"`;
-      } else {
-        this.updatedCustomAction.parameters = this.validationResult.BlobSasUri.length > 0 ? `-${this.diagnoserOption.option} "${this.diagnoser.Name}" -BlobSasUri:"${this.validationResult.BlobSasUri}"` : `-${this.diagnoserOption.option} "${this.diagnoser.Name}"`;
-      }
-
+      this.updatedCustomAction.parameters = `-${this.diagnoserOption.option} "${this.diagnoser.Name}"`;
     } else {
       this.updatedCustomAction.exe = '';
       this.updatedCustomAction.parameters = '';

--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/create-storage-account-panel/create-storage-account-panel.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/create-storage-account-panel/create-storage-account-panel.component.ts
@@ -183,12 +183,7 @@ export class CreateStorageAccountPanelComponent implements OnInit {
               return;
             }
             let storageKey = resp.keys[0].value;
-            if (this.isWindowsApp) {
-              this.generateSasKey(storageAccountId, storageAccountName, storageKey);
-            } else {
-              this.generateStorageConnectionString(storageAccountId, storageAccountName, storageKey);
-            }
-
+            this.generateStorageConnectionString(storageAccountId, storageAccountName, storageKey);
           }
         },
           error => {
@@ -208,30 +203,6 @@ export class CreateStorageAccountPanelComponent implements OnInit {
         this.error = error;
       });
 
-  }
-
-  generateSasKey(storageAccountId: string, storageAccountName: string, storageKey: string) {
-    this._storageService.generateSasKey(storageAccountId, storageKey).subscribe(generatedSasUri => {
-      if (generatedSasUri) {
-        let storageAccountProperties: StorageAccountProperties = new StorageAccountProperties();
-        storageAccountProperties.name = storageAccountName;
-        storageAccountProperties.sasUri = `https://${storageAccountName}.blob.${this._armService.storageUrl}/${this._daasService.defaultContainerName}?${generatedSasUri}`;
-        this._daasService.setStorageConfiguration(this.siteToBeDiagnosed, storageAccountProperties, false).subscribe(resp => {
-          this.generatingSasUri = false;
-          this._sharedStorageAccountService.emitChange(storageAccountProperties);
-          this.globals.openCreateStorageAccountPanel = false;
-        }, error => {
-          this.errorMessage = "Failed while updating SAS Key app setting";
-          this.generatingSasUri = false;
-          this.error = error;
-        });
-
-      }
-    }, error => {
-      this.errorMessage = "Failed while generating SAS Key";
-      this.generatingSasUri = false;
-      this.error = error;
-    });
   }
 
   generateStorageConnectionString(storageAccountId: string, storageAccountName: string, storageKey: string) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/shared-storage-account.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/shared-storage-account.service.ts
@@ -20,6 +20,5 @@ export class SharedStorageAccountService {
 
 export class StorageAccountProperties {
   name: string;
-  sasUri: string;
   connectionString: string;
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -24,11 +24,10 @@ export class ConfigureStorageAccountComponent implements OnInit {
         this.validateStorageConfigurationResponse = null;
       }
 
-      if (newStorageAccount.sasUri || newStorageAccount.connectionString) {
-        this.validationResult.BlobSasUri = newStorageAccount.sasUri ? newStorageAccount.sasUri : '';
+      if (newStorageAccount.connectionString) {
+        this.validationResult.BlobSasUri = '';
         this.validationResult.ConnectionString = newStorageAccount.connectionString ? newStorageAccount.connectionString : '';
         this.validationResult.Validated = true;
-        this.validationResult.ConfiguredAsAppSetting = true;
         this.StorageAccountValidated.emit(this.validationResult);
       }
 
@@ -53,39 +52,37 @@ export class ConfigureStorageAccountComponent implements OnInit {
     this.telemetryService.logPageView("CreateStorageAccountPanelView");
   }
 
-  getStorageAccountNameFromSasUri(blobSasUri: string): string {
-    let blobUrl = new URL(blobSasUri);
-    return blobUrl.host.split('.')[0];
-  }
-
   ngOnInit() {
 
     this.checkingBlobSasUriConfigured = true;
 
     this._daasService.getStorageConfiguration(this.siteToBeDiagnosed, this.useDiagServerForLinux).subscribe(daasStorageConfiguration => {
-      if (!this.useDiagServerForLinux && daasStorageConfiguration.SasUri && daasStorageConfiguration.IsAppSetting) {
+      if (!this.useDiagServerForLinux) {
         this._daasService.validateSasUri(this.siteToBeDiagnosed).subscribe(resp => {
           this.checkingBlobSasUriConfigured = false;
           if (resp.IsValid) {
             this.validateStorageConfigurationResponse = null;
-            this.chosenStorageAccount = this.getStorageAccountNameFromSasUri(daasStorageConfiguration.SasUri);
+            if (daasStorageConfiguration.SasUri){
+              this.chosenStorageAccount = this._daasService.getStorageAccountNameFromSasUri(daasStorageConfiguration.SasUri);
+            } else if (daasStorageConfiguration.ConnectionString){
+              this.chosenStorageAccount = this._daasService.getStorageAccountNameFromConnectionString(daasStorageConfiguration.ConnectionString);
+            }
+
+            this.validationResult.ConnectionString = daasStorageConfiguration.ConnectionString;
             this.validationResult.BlobSasUri = daasStorageConfiguration.SasUri;
-            this.validationResult.ConfiguredAsAppSetting = daasStorageConfiguration.IsAppSetting;
             this.validationResult.Validated = true;
             this.StorageAccountValidated.emit(this.validationResult);
           } else {
             this.validateStorageConfigurationResponse = resp;
           }
         });
-      } else if (this.useDiagServerForLinux && daasStorageConfiguration.ConnectionString && daasStorageConfiguration.IsAppSetting) {
-
+      } else if (this.useDiagServerForLinux && daasStorageConfiguration.ConnectionString) {
         this._daasService.validateStorageAccount(this.siteToBeDiagnosed).subscribe(resp => {
           this.checkingBlobSasUriConfigured = false;
           if (resp.IsValid) {
             this.validateStorageConfigurationResponse = null;
             this.chosenStorageAccount = resp.StorageAccount;
             this.validationResult.ConnectionString = daasStorageConfiguration.ConnectionString;
-            this.validationResult.ConfiguredAsAppSetting = daasStorageConfiguration.IsAppSetting;
             this.validationResult.Validated = true;
             this.StorageAccountValidated.emit(this.validationResult);
           } else {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -57,14 +57,14 @@ export class ConfigureStorageAccountComponent implements OnInit {
     this.checkingBlobSasUriConfigured = true;
 
     this._daasService.getStorageConfiguration(this.siteToBeDiagnosed, this.useDiagServerForLinux).subscribe(daasStorageConfiguration => {
-      if (!this.useDiagServerForLinux) {
+      if (!this.useDiagServerForLinux && (daasStorageConfiguration.ConnectionString || daasStorageConfiguration.SasUri)) {
         this._daasService.validateSasUri(this.siteToBeDiagnosed).subscribe(resp => {
           this.checkingBlobSasUriConfigured = false;
           if (resp.IsValid) {
             this.validateStorageConfigurationResponse = null;
-            if (daasStorageConfiguration.SasUri){
+            if (daasStorageConfiguration.SasUri) {
               this.chosenStorageAccount = this._daasService.getStorageAccountNameFromSasUri(daasStorageConfiguration.SasUri);
-            } else if (daasStorageConfiguration.ConnectionString){
+            } else if (daasStorageConfiguration.ConnectionString) {
               this.chosenStorageAccount = this._daasService.getStorageAccountNameFromConnectionString(daasStorageConfiguration.ConnectionString);
             }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.ts
@@ -265,10 +265,6 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
   }
 
   getLinkToDumpFile(dumpFileName: string): string {
-    if (this.daasBlobSasUri === '') {
-      return "";
-    }
-
     if (this.daasStorageConfiguration !== null) {
       let blobUrl: URL;
       if (this.daasStorageConfiguration.SasUri) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.ts
@@ -25,7 +25,6 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
   @Output() settingsChanged: EventEmitter<CrashMonitoringSettings> = new EventEmitter<CrashMonitoringSettings>();
 
   loading: boolean = true;
-  blobSasUri: string = "";
   insights: CrashInsight[];
   monitoringEnabled: boolean = false;
   error: any;
@@ -39,7 +38,9 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
   savingSettings: boolean = false;
   crashMonitoringHistory: CrashMonitoringData[] = [];
   refreshingHistory: boolean = true;
-  blobSasUriObservable: Observable<DaasStorageConfiguration>;
+  storageAccountConfigurationObservable: Observable<DaasStorageConfiguration>;
+  daasStorageConfiguration: DaasStorageConfiguration = null;
+  daasBlobSasUri: string = '';
 
   // For tooltip display
   directionalHint = DirectionalHint.rightTopEdge;
@@ -68,12 +69,11 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
 
     this._siteService.getSiteDaasInfoFromSiteMetadata().subscribe(site => {
       this.siteToBeDiagnosed = site;
-      this.blobSasUriObservable = this._daasService.getStorageConfiguration(site, false);
+      this.storageAccountConfigurationObservable = this._daasService.getStorageConfiguration(site, false);
 
-      if (!this.blobSasUri) {
-
-        this.blobSasUriObservable.subscribe(daasSasUri => {
-          this.blobSasUri = daasSasUri.SasUri;
+      if (this.daasStorageConfiguration == null) {
+        this.storageAccountConfigurationObservable.subscribe(daasStorageConfiguration => {
+          this.daasStorageConfiguration = daasStorageConfiguration;
         });
       }
     });
@@ -108,18 +108,29 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
 
       this._diagnosticService.getDetector(crashMonitoringDetectorName, _startTime.format(this.stringFormat), _endTime.format(this.stringFormat), true, false, null, null).subscribe(detectorResponse => {
         let rawTable = detectorResponse.dataset.find(x => x.renderingProperties.type === RenderingType.Table) // && x.table.tableName === "CrashMonitoring");
-        if (this.blobSasUri) {
-          this.loadDetectorData(rawTable);
+        if (this.daasStorageConfiguration) {
+          this.updateSasUriAndLoadDetectorData(rawTable);
         } else {
 
-          if (!this.blobSasUri) {
-            this.blobSasUriObservable.subscribe(daasSasUri => {
-                this.blobSasUri = daasSasUri.SasUri;
-                this.loadDetectorData(rawTable);
+          if (!this.daasStorageConfiguration) {
+            this.storageAccountConfigurationObservable.subscribe(daasStorageConfiguration => {
+              this.daasStorageConfiguration = daasStorageConfiguration;
+              this.updateSasUriAndLoadDetectorData(rawTable);
             });
           }
         }
       });
+    }
+  }
+
+  updateSasUriAndLoadDetectorData(rawTable: DiagnosticData) {
+    if (this.daasStorageConfiguration.ConnectionString) {
+      this._daasService.getBlobSasUri(this.siteToBeDiagnosed).subscribe(blobSasUri => {
+        this.daasBlobSasUri = blobSasUri;
+        this.loadDetectorData(rawTable);
+      });
+    } else {
+      this.loadDetectorData(rawTable);
     }
   }
 
@@ -254,10 +265,22 @@ export class CrashMonitoringAnalysisComponent implements OnInit, OnChanges, OnDe
   }
 
   getLinkToDumpFile(dumpFileName: string): string {
-    if (this.blobSasUri !== "") {
-      let blobUrl = new URL(this.blobSasUri);
+    if (this.daasBlobSasUri === '') {
+      return "";
+    }
+
+    if (this.daasStorageConfiguration !== null) {
+      let blobUrl: URL;
+      if (this.daasStorageConfiguration.SasUri) {
+        blobUrl = new URL(this.daasStorageConfiguration.SasUri);
+      }
+      else if (this.daasStorageConfiguration.ConnectionString) {
+        blobUrl = new URL(this.daasBlobSasUri);
+      }
+
       let relativePath = "CrashDumps/" + dumpFileName;
       return `https://${blobUrl.host}${blobUrl.pathname}/${relativePath}?${blobUrl.searchParams}`;
+
     } else {
       return "";
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
@@ -33,12 +33,12 @@
 
               </div>
               <div class="col-md-2">
-                <span> {{ monitoringEnabled || storageConfiguredAsAppSetting ? chosenStorageAccount : ""}}
+                <span> {{ chosenStorageAccount }}
                 </span>
                 <div class="mt-1 mb-4" (click)="toggleStorageAccountPanel()"
                   (keyup.enter)="toggleStorageAccountPanel()">
                   <a tabindex="0" role="button" name="Change storage account" aria-label="Change storage account">
-                    {{ chosenStorageAccount && (monitoringEnabled || storageConfiguredAsAppSetting) ? 'Change' : 'Select' }}</a>
+                    {{ chosenStorageAccount != null && chosenStorageAccount.length > 0  ? 'Change' : 'Select' }}</a>
                 </div>
               </div>
             </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -208,14 +208,12 @@ export class DaasSettings {
 export class DaasStorageConfiguration {
     SasUri: string = '';
     ConnectionString: string = '';
-    IsAppSetting: boolean = false;
 }
 
 export class DaasValidationResult {
     Validated: boolean = false;
     BlobSasUri: string = "";
     ConnectionString: string = "";
-    ConfiguredAsAppSetting: boolean = false;
     UseDiagServerForLinux: boolean = false;
 }
 
@@ -289,4 +287,9 @@ export interface LinuxCommandOutput {
     Output: string;
     Error: string;
     ExitCode: number;
+}
+
+export interface DaasSettingsResponse {
+    BlobSasUri: string;
+    StorageConnectionString: string;
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -7,7 +7,7 @@ import { SiteDaasInfo } from '../models/solution-metadata';
 import { ArmService } from './arm.service';
 import { AuthService } from '../../startup/services/auth.service';
 import { UriElementsService } from './urielements.service';
-import { DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, ValidateSasUriResponse, Session, LinuxDaasSettings, ValidateStorageAccountResponse, DaasStorageConfiguration, Instance, LinuxCommandOutput, LinuxCommand } from '../models/daas';
+import { DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, ValidateSasUriResponse, Session, LinuxDaasSettings, ValidateStorageAccountResponse, DaasStorageConfiguration, Instance, LinuxCommandOutput, LinuxCommand, DaasSettingsResponse } from '../models/daas';
 import { SiteInfoMetaData } from '../models/site';
 import { SiteService } from './site.service';
 import { StorageAccountProperties } from '../../shared-v2/services/shared-storage-account.service';
@@ -20,6 +20,7 @@ export class DaasService {
 
     linuxDiagServerEnabled: boolean = false;
     linuxDiagServerEnabledChecked: boolean = false;
+    cachedBlobSasUri: string = '';
 
     linuxDiagServerStorageConfigured: boolean = false
     linuxDiagServerStorageConfiguredChecked: boolean = false
@@ -169,35 +170,25 @@ export class DaasService {
         return <Observable<string>>(this._armClient.deleteResource(resourceUri, null, true));
     }
 
-    setBlobSasUri(site: SiteDaasInfo, blobAccount: string, blobKey: string): Observable<boolean> {
-        const resourceUri: string = this._uriElementsService.getBlobSasUriUrl(site);
-        const settings = new DaasSettings();
-        settings.BlobSasUri = "";
-        settings.BlobContainer = BlobContainerName.toLowerCase();
-        settings.BlobKey = blobKey;
-        settings.BlobAccount = blobAccount;
-        settings.EndpointSuffix = "";
-        if (this._armClient.isNationalCloud) {
-            settings.EndpointSuffix = this._armClient.storageUrl;
-        }
-
-        return <Observable<boolean>>(this._armClient.postResource(resourceUri, settings, null, true));
-    }
-
     setStorageConfiguration(site: SiteDaasInfo, storageAccountProperties: StorageAccountProperties, useDiagServerForLinux: boolean): Observable<any> {
         let settingValue: string = '';
-        let settingName = "WEBSITE_DAAS_STORAGE_SASURI";
-        settingValue = storageAccountProperties.sasUri;
-        if (useDiagServerForLinux) {
-            settingName = "WEBSITE_DAAS_STORAGE_CONNECTIONSTRING";
-            settingValue = storageAccountProperties.connectionString;
-        }
+        let settingName = "WEBSITE_DAAS_STORAGE_CONNECTIONSTRING";
+        let settingSasUriName = "WEBSITE_DAAS_STORAGE_SASURI";
+        settingValue = storageAccountProperties.connectionString;
 
         return this._siteService.getSiteAppSettings(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot).pipe(
             map(settingsResponse => {
                 if (settingsResponse && settingsResponse.properties) {
                     if (settingValue) {
                         settingsResponse.properties[settingName] = settingValue;
+                        if (settingsResponse.properties[settingSasUriName] != null) {
+
+                            //
+                            // Explicitly set it to an empty space because deleting the app setting
+                            // will trigger a site restart
+                            //
+                            settingsResponse.properties[settingSasUriName] = " ";
+                        }
                     } else {
                         if (settingsResponse.properties[settingName]) {
                             delete settingsResponse.properties[settingName];
@@ -222,22 +213,21 @@ export class DaasService {
     }
 
     getStorageConfiguration(site: SiteDaasInfo, useDiagServerForLinux: boolean): Observable<DaasStorageConfiguration> {
-        let settingName = "WEBSITE_DAAS_STORAGE_SASURI";
-        if (useDiagServerForLinux) {
-            settingName = "WEBSITE_DAAS_STORAGE_CONNECTIONSTRING";
-        }
+        let settingName = "WEBSITE_DAAS_STORAGE_CONNECTIONSTRING";
+        let settingSasUriName = "WEBSITE_DAAS_STORAGE_SASURI";
 
         return this._siteService.getSiteAppSettings(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot).pipe(
             map(settingsResponse => {
-                if (settingsResponse && settingsResponse.properties && settingsResponse.properties[settingName] != null) {
-                    let daasStorageConfiguration: DaasStorageConfiguration = new DaasStorageConfiguration();
-                    daasStorageConfiguration.IsAppSetting = true;
-                    if (useDiagServerForLinux) {
+                if (settingsResponse && settingsResponse.properties) {
+                    if (settingsResponse.properties[settingName] != null) {
+                        let daasStorageConfiguration: DaasStorageConfiguration = new DaasStorageConfiguration();
                         daasStorageConfiguration.ConnectionString = settingsResponse.properties[settingName];
-                    } else {
-                        daasStorageConfiguration.SasUri = settingsResponse.properties[settingName];
+                        return daasStorageConfiguration;
+                    } else if (settingsResponse.properties[settingSasUriName] != null && !useDiagServerForLinux) {
+                        let daasStorageConfiguration: DaasStorageConfiguration = new DaasStorageConfiguration();
+                        daasStorageConfiguration.SasUri = settingsResponse.properties[settingSasUriName];
+                        return daasStorageConfiguration;
                     }
-                    return daasStorageConfiguration;
                 }
             }),
             mergeMap((daasStorageConfiguration: DaasStorageConfiguration) => {
@@ -348,5 +338,55 @@ export class DaasService {
 
     get defaultContainerName(): string {
         return BlobContainerName;
+    }
+
+    getStorageAccountNameFromSasUri(blobSasUri: string): string {
+        if (!blobSasUri) {
+            return blobSasUri;
+        }
+        let blobUrl = new URL(blobSasUri);
+        return blobUrl.host.split('.')[0];
+    }
+
+    getStorageAccountNameFromConnectionString(storageConnectionString: string): string {
+        const startIndex = storageConnectionString.toLowerCase().indexOf("AccountName=".toLowerCase()) + "AccountName=".length;
+        const endIndex = storageConnectionString.indexOf(";", startIndex);
+        return storageConnectionString.substring(startIndex, endIndex);
+    }
+
+    getBlobSasUri(site: SiteDaasInfo): Observable<string> {
+        if (this.cachedBlobSasUri) {
+            return of(this.cachedBlobSasUri);
+        }
+
+        let resourceUri = this._uriElementsService.getDaasSettingsUrl(site);
+        return <Observable<string>>this._armClient.requestResource<HttpResponse<DaasSettingsResponse>, any>("GET", resourceUri, null, null).pipe(
+            map((response: HttpResponse<DaasSettingsResponse>) => {
+                this.cachedBlobSasUri = response.body.BlobSasUri;
+                return response.body.BlobSasUri;
+            }),
+            catchError(err => {
+
+                //
+                // DaaS site extension is changing the method for /settings to POST instead of GET
+                // Handle any error that we get while making the get call and if we get any failure, then
+                // try making a POST call till the site extension is updated globally
+                //
+
+                if (err.status && err.status === 405) {
+                    return <Observable<string>>this._armClient.postResourceWithoutEnvelope<DaasSettingsResponse, any>(resourceUri, null, null, true).pipe(
+                        map((response: DaasSettingsResponse) => {
+                            this.cachedBlobSasUri = response.BlobSasUri;
+                            return this.cachedBlobSasUri;
+                        }));
+                } else {
+                    let actualError: string = JSON.stringify(err);
+                    if (err.error && err.error.Message) {
+                        actualError = err.error.Message;
+                    }
+                    throwError(actualError)
+                }
+            })
+        )
     }
 }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/site.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/site.service.ts
@@ -220,7 +220,7 @@ export class SiteService {
         return { start: returnStartDate, end: returnEndDate };
     }
 
-    saveCrashMonitoringSettings(site: SiteDaasInfo, crashMonitoringSettings: CrashMonitoringSettings, blobSasUri: string = ''): Observable<any> {
+    saveCrashMonitoringSettings(site: SiteDaasInfo, crashMonitoringSettings: CrashMonitoringSettings, storageConnectionString: string = ''): Observable<any> {
         return this.getSiteAppSettings(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot).pipe(
             map(settingsResponse => {
                 if (settingsResponse && settingsResponse.properties) {
@@ -252,8 +252,8 @@ export class SiteService {
                         }
                         settingsResponse.properties['WEBSITE_CRASHMONITORING_ENABLED'] = true;
                         settingsResponse.properties['WEBSITE_CRASHMONITORING_SETTINGS'] = JSON.stringify(crashMonitoringSettings);
-                        if (blobSasUri) {
-                            settingsResponse.properties['WEBSITE_DAAS_STORAGE_SASURI'] = blobSasUri;
+                        if (storageConnectionString) {
+                            settingsResponse.properties['WEBSITE_DAAS_STORAGE_CONNECTIONSTRING'] = storageConnectionString;
                         }
                         settingsResponse.properties['WEBSITE_CRASHMONITORING_USE_DEBUGDIAG'] = true;
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/storage.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/storage.service.ts
@@ -86,7 +86,7 @@ export class StorageService {
     postBody.signedServices = "bqt";
     postBody.signedResourceTypes = "co";
     postBody.signedPermission = "acdlpruw";
-    postBody.signedProtocol = "http,https";
+    postBody.signedProtocol = "https";
     postBody.signedExpiry = moment.utc().add(10, 'years').toISOString();
     postBody.signedStart = moment.utc().toISOString();
     let url = this._uriElementsService.createSasUri(storageAccountResourceUri);

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
@@ -165,7 +165,7 @@ export class UriElementsService {
             .replace('{sessionId}', sessionId);
     }
 
-    getBlobSasUriUrl(site: SiteDaasInfo) {
+    getDaasSettingsUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasSettingsPath;
     }
 


### PR DESCRIPTION
## Overview
This PR was long pending. We had introduced new app setting `WEBSITE_DAAS_STORAGE_CONNECTIONSTRING ` which can contain the connection string for the storage account. All the DAAS backend tools are updated to honor this app setting. This was done primarily for two reasons:
1) It becomes easier for customers to automate any DAAS tool as now they can easily create a new APP setting WEBSITE_DAAS_STORAGE_CONNECTIONSTRING which points to the connection string directly vs. manually generating the SAS URI and then updating it in their config.
2) We were not following best practices for generating SAS URI as we were creating really long lived SAS URI and this is not recommended.
3) We wanted to have parity with Linux apps as they already use WEBSITE_DAAS_STORAGE_CONNECTIONSTRING.

## Type of change

- With this change, any new storage account configurations will use the WEBSITE_DAAS_STORAGE_CONNECTIONSTRING setting. Also if the customer reconfigures the storage account, it will use WEBSITE_DAAS_STORAGE_CONNECTIONSTRING instead of WEBSITE_DAAS_STORAGE_SASURI.
- All the existing configurations where customers are using WEBSITE_DAAS_STORAGE_SASURI will continue to work. 

Once we are sure that this change is not breaking anything, I will raise another PR that will update the storage setting to WEBSITE_DAAS_STORAGE_CONNECTIONSTRING from WEBSITE_DAAS_STORAGE_SASURI whenever someone hits diagnose and solve blade.

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

Also removing some dead code and functions that are not used anywhere.