### PR TITLE
Fix for not showing keyword and hide description in case submission

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -281,7 +281,7 @@ export class SupportTopicService {
                                 let keystoneSolutionApplied: boolean = false;
                                 keywordsList = JSON.parse(keystoneInsight["Title"]);
 
-                                if (keywordsList && keywordsList.findIndex((keyword) => searchTerm.toLowerCase().indexOf(keyword) !== -1) !== -1) {
+                                if (keywordsList && keywordsList.findIndex((keyword) => searchTerm.toLowerCase().indexOf(keyword.toLowerCase()) !== -1) !== -1) {
                                     queryParamsDic["keystoneDetectorId"] = keystoneDetectorId;
                                     keystoneSolutionApplied = true;
                                 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -47,7 +47,7 @@
 </div>
 
 <div *ngIf="timePickerErrorStr !==''" class="error-time-picker-message">{{timePickerErrorStr}}</div>
-<div *ngIf="detectorDataLocalCopy && detectorDataLocalCopy.metadata">
+<div *ngIf="detectorDataLocalCopy && detectorDataLocalCopy.metadata  && !isInCaseSubmission()">
   <p>{{detectorDataLocalCopy.metadata.description}}</p>
 </div>
 


### PR DESCRIPTION
## Overview
This PR is for
1. Fixing in case submission, it is not redirecting to keystone detector
2. Hide detector description in case submission

## Related Work Item
[BUG 2973 Logic App Keystone Issue](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2973/?triage=true)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Solution description
Add tolowercase() when comparing with keyword list and input keyword


## How Can This Be Tested? <span>&#128269;</span>
1. Open case submission for any consumption logic app
2. In Problem Description, Type "TrustFailure" in summary, select problem type is "Connectors" and sub problem type is "HTTP", click "Next"

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://user-images.githubusercontent.com/23129934/218365915-eecf2561-41b2-426d-aab8-ac7fd0a72d2b.png)

## Screenshots After Fix (if appropriate):
![image](https://user-images.githubusercontent.com/23129934/218365784-9f4787f8-438c-4bf4-a583-17ee54943a90.png)

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
