### PR TITLE
Curibe/rsr4 linux to100percent subscriptions

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
@@ -61,7 +61,7 @@ export class DetectorCommandBarComponent implements AfterViewInit {
     // allowlisting beta subscriptions for testing purposes
     _isBetaSubscription = DemoSubscriptions.betaSubscriptions.indexOf(this.subscriptionId) >= 0;
     // allowing 0% of subscriptions to use new feature
-    _isSubIdInPercentageToRelease = this._percentageOfSubscriptions(this.subscriptionId, 0.5);
+    _isSubIdInPercentageToRelease = this._percentageOfSubscriptions(this.subscriptionId, 1);
 
     // Releasing to only Beta Subscriptions for Web App (Linux) in standard or higher and all Web App (Windows) in standard or higher
     this.displayRPDFButton = ((this._checkIsWebAppProdSku(OperatingSystem.linux) && (_isSubIdInPercentageToRelease || _isBetaSubscription)) || this._checkIsWebAppProdSku(OperatingSystem.windows));

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.ts
@@ -200,7 +200,7 @@ export class DownloadReportComponent implements OnInit {
     // allowlisting beta subscriptions for testing purposes
     _isBetaSubscription = DemoSubscriptions.betaSubscriptions.indexOf(this.subscriptionId) >= 0;
     // allowing 0% of subscriptions to use new feature
-    _isSubIdInPercentageToRelease = this._percentageOfSubscriptions(this.subscriptionId, 0.5);
+    _isSubIdInPercentageToRelease = this._percentageOfSubscriptions(this.subscriptionId, 1);
 
     // Releasing to only Beta Subscriptions for Web App (Linux) in standard or higher and all Web App (Windows) in standard or higher
     if (this._checkIsWebAppProdSku(OperatingSystem.linux) && (_isSubIdInPercentageToRelease || _isBetaSubscription) || this._checkIsWebAppProdSku(OperatingSystem.windows)) {


### PR DESCRIPTION
## Overview
Displaying Resiliency Score Report for Web App (Linux) to 100% of the subscriptions

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Solution description
Displaying Resiliency Score Report for Web App (Linux) to 100% of the subscriptions in both the button and the direct download link
### This PR:
<!--- An example of a solution description -->
<!--- - creates a new rendering type -->
<!--- - refactors the code -->
<!--- - adds a new function/enum to render a bar chart -->

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

