### PR TITLE
MSRC Security issue: Prevent Bing API key leak

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/documents-search.service.ts
@@ -9,7 +9,6 @@ import { BackendCtrlService } from '../../shared/services/backend-ctrl.service';
   providedIn:"root"
 })
 export class DocumentSearchService {
-  private authKey: string = "";
   private url : string = "";
   private _config : DocumentSearchConfiguration;
   private featureEnabledForPesId  : boolean = false;
@@ -21,39 +20,12 @@ export class DocumentSearchService {
               ) {
 
       this._config = new DocumentSearchConfiguration();;
-
-      this._backendApi.get<string>(`api/appsettings/DeepSearch:Endpoint`).subscribe((value: string) =>{
-        this.url = value;
-      });
-
-      this._backendApi.get<string>(`api/appsettings/DeepSearch:AuthKey`).subscribe((value: string) =>{
-        this.authKey = value;
-        this.httpOptions = {
-          headers: new HttpHeaders({
-            "Content-Type" : "application/json",
-            "authKey" : this.authKey
-          })
-        };
-      });
-
   }
 
   public IsEnabled(pesId : string) : Observable<boolean> {
     // featureEnabledForProduct is disabled by default
+    return Observable.of(false);
 
-    var isPesIdValid = pesId && pesId.length >0 ;
-    if( isPesIdValid )
-    {
-      pesId = pesId.trim();
-      var listOfEnabledPesIds =  this._config.documentSearchEnabledSupportTopicIds[pesId] ;    
-      var isDeepSearchEnabledForThisPesId = listOfEnabledPesIds && (listOfEnabledPesIds.findIndex( x => x == pesId ) > -1)
-      this.featureEnabledForPesId = isDeepSearchEnabledForThisPesId ;
-    }
-   
-    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
-                            // Value in App Service Application Settings are returned as strings
-                            // converting this to boolean
-                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForPesId) );
 
 
   }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-content.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-content.service.ts
@@ -21,15 +21,8 @@ export class ApplensContentService {
         //   link: 'https://docs.microsoft.com/en-us/azure/app-service/web-sites-purchase-ssl-web-site'
         // }
       ];
-    
-    private ocpApimKeySubject: Subject<string> = new ReplaySubject<string>(1);
-    private ocpApimKey: string = '';
 
     constructor(private _http: HttpClient, private _backendApi: DiagnosticApiService, private _resourceService: ResourceService,) { 
-        this._backendApi.get<string>(`api/appsettings/ContentSearch:Ocp-Apim-Subscription-Key`).subscribe((value: string) =>{
-            this.ocpApimKey = value;
-            this.ocpApimKeySubject.next(value);
-        });
     }
 
     public getContent(searchString?: string): Observable<any[]> {
@@ -55,15 +48,6 @@ export class ApplensContentService {
         }
 
         const query = encodeURIComponent(`${questionString} AND ${searchSuffix}${preferredSitesSuffix}${excludedSitesSuffix}`);
-        const url = `https://api.cognitive.microsoft.com/bing/v7.0/search?q='${query}'&count=${resultsCount}`;
-
-        return this.ocpApimKeySubject.pipe(mergeMap((key: string) => {
-            return this._http.get(url, { 
-                headers: {
-                    "Content-Type": "application/json",
-                    "Ocp-Apim-Subscription-Key": this.ocpApimKey
-                }
-            });
-        }));
+        return this._backendApi.get<string>(`api/bing/search?q=${query}&count=${resultsCount}`);
     }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-documents-search.service.ts
@@ -8,7 +8,6 @@ import { DiagnosticApiService } from '../../../shared/services/diagnostic-api.se
   providedIn:"root"
 })
 export class ApplensDocumentsSearchService {
-  private authKey: string = "";
   private url : string = "";
   private _config : DocumentSearchConfiguration;
   private featureEnabledForProduct : boolean = false; 
@@ -19,35 +18,12 @@ export class ApplensDocumentsSearchService {
                 private _backendApi : DiagnosticApiService                 
               ) { 
     
-    this._config = new DocumentSearchConfiguration();
-    this._backendApi.get<string>(`api/appsettings/DeepSearch:Endpoint`).subscribe((value: string) =>{
-      this.url = value;
-    });
-
-    this._backendApi.get<string>(`api/appsettings/DeepSearch:AuthKey`).subscribe((value: string) =>{
-      this.authKey = value;
-      this.httpOptions = {
-        headers: new HttpHeaders({
-          "Content-Type" : "application/json",
-          "authKey" : this.authKey
-        })
-      };
-    });
-    
+    this._config = new DocumentSearchConfiguration();    
   }
 
   public IsEnabled(pesId : string) : Observable<boolean> {
     // featureEnabledForProduct is disabled by default
-    if ( pesId.length >0 && this._config.documentSearchEnabledPesIdsInternal.findIndex(x => x==pesId)>=0){
-          this.featureEnabledForProduct = true;
-    }
-
-    return this._backendApi.get<string>(`api/appsettings/DeepSearch:isEnabled`)
-                            // Value in App Service Application Settings are returned as strings 
-                            // converting this to boolean
-                            .map(status =>  ( status.toLowerCase() == "true" && this.featureEnabledForProduct) );    
-    
-    
+    return Observable.of(false);    
   }
 
   private constructUrl(query: Query) : string{

--- a/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/web-search/web-search.component.ts
@@ -45,7 +45,7 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
     showSearchTermPractices: boolean = false;
     showPreLoader: boolean = false;
     showPreLoadingError: boolean = false;
-    preLoadingErrorMessage: string = "Some error occurred while fetching web results."
+    preLoadingErrorMessage: string = "An error occurred while fetching web results from the web. We will be fixing this soon. Please try again later."
     subscription: ISubscription;
     deepSearchConfig: DocumentSearchConfiguration;
     
@@ -233,6 +233,7 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
             searchTaskComplete = true;
             postFinish();
         }, (err)=> {
+            this.showPreLoadingError = true;
             searchTaskResult = null;
             searchTaskComplete = true;
             postFinish();
@@ -243,6 +244,7 @@ export class WebSearchComponent extends DataRenderBaseComponent implements OnIni
                 searchTaskPrefsComplete = true;
                 postFinish();
             }, (err)=> {
+                this.showPreLoadingError = true;
                 searchTaskPrefsResult = null;
                 searchTaskPrefsComplete = true;
                 postFinish();

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -110,6 +110,15 @@ namespace AppLensV3
             services.AddMemoryCache();
             services.AddMvc().AddNewtonsoftJson();
 
+            if (!string.IsNullOrWhiteSpace(Configuration.GetValue("ContentSearch:Ocp-Apim-Subscription-Key", string.Empty)))
+            {
+                services.AddSingleton<IBingSearchService, BingSearchService>();
+            }
+            else
+            {
+                services.AddSingleton<IBingSearchService, BingSearchServiceDisabled>();
+            }
+
             if (Configuration.GetValue("Graph:Enabled", false))
             {
                 GraphTokenService.Instance.Initialize(Configuration);

--- a/ApplensBackend/Configuration/StartupNationalCloud.cs
+++ b/ApplensBackend/Configuration/StartupNationalCloud.cs
@@ -2,6 +2,7 @@
 using AppLensV3.Authorization;
 using AppLensV3.Helpers;
 using AppLensV3.Middleware;
+using AppLensV3.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -34,6 +35,7 @@ namespace AppLensV3
             });
 
             services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerNationalCloud>();
+            services.AddSingleton<IBingSearchService, BingSearchServiceDisabled>();
 
             if (environment.IsProduction())
             {

--- a/ApplensBackend/Controllers/BingAPIController.cs
+++ b/ApplensBackend/Controllers/BingAPIController.cs
@@ -1,0 +1,69 @@
+﻿using AppLensV3.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Xml;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Controllers
+{
+    [Route("api/bing")]
+    [Produces("application/json")]
+    [Authorize(Policy = "ApplensAccess")]
+    public class BingAPIController : Controller
+    {
+        private IBingSearchService _bingSearchService;
+        private ILogger<BingAPIController> _logger;
+        public BingAPIController(IBingSearchService bingSearchService, ILogger<BingAPIController> logger)
+        {
+            _bingSearchService = bingSearchService;
+            _logger = logger;
+        }
+
+        public HttpResponseMessage SendBadRequest(string message)
+        {
+            return new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(message)
+            };
+        }
+
+        [HttpGet("search")]
+        public async Task<IActionResult> BingSearch(string q, int count)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(q)) {
+                    return BadRequest("Query parameter 'q' should not be empty");
+                }
+                else if (!(count > 0 && count < 20))
+                {
+                    return BadRequest("Result count parameter should be within 1-20 range");
+                }
+                var result = await _bingSearchService.RunBingSearch(q, count);
+                if (result.IsSuccessStatusCode)
+                {
+                    var response = await result.Content.ReadAsStringAsync();
+                    return Ok(JsonConvert.DeserializeObject(response));
+                }
+                else
+                {
+                    var errorMessage = await result.Content.ReadAsStringAsync();
+                    _logger.LogError($"BingAPICallError: {result.StatusCode} -- {errorMessage}");
+                    return NotFound(errorMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"BingAPICallException: {ex.ToString()}");
+                return StatusCode(500);
+            }
+
+        }
+    }
+}

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -45,7 +45,7 @@ namespace AppLensV3.Controllers
         private readonly bool detectorDevelopmentEnabled;
         private readonly IList<string> apiEndpointsForDetectorDevelopment;
         private readonly string[] allowedUsers;
-        private readonly string[] AllowedSections = new string[] { "ContentSearch", "DeepSearch", "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch" };
+        private readonly string[] AllowedSections = new string[] { "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch" };
 
         private class InvokeHeaders
         {

--- a/ApplensBackend/Services/BingSearchService/BingSearchService.cs
+++ b/ApplensBackend/Services/BingSearchService/BingSearchService.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Services
+{
+    public interface IBingSearchService : IDisposable
+    {
+        Task<HttpResponseMessage> RunBingSearch(string query, int resultCount);
+    }
+
+    public class BingSearchServiceDisabled: IBingSearchService
+    {
+        public async Task<HttpResponseMessage> RunBingSearch(string query, int resultCount) { return new HttpResponseMessage() { StatusCode = HttpStatusCode.NotFound, Content = new StringContent("Bing search is disabled") }; }
+        public void Dispose() { return; }
+    }
+
+    public class BingSearchService : IBingSearchService
+    {
+        private string BingSearchUrl = "https://api.cognitive.microsoft.com/bing/v7.0/search";
+        private string BingApiKey;
+        private ILogger<BingSearchService> _logger;
+        private static HttpClient _httpClient;
+        IConfiguration _configuration;
+        
+        public BingSearchService(IConfiguration Configuration, ILogger<BingSearchService> logger)
+        {
+            _logger = logger;
+            _configuration = Configuration;
+            BingApiKey = _configuration["ContentSearch:Ocp-Apim-Subscription-Key"];
+            if (BingApiKey != null)
+            {
+                BingApiKey = BingApiKey.ToString();
+            }
+            if (string.IsNullOrWhiteSpace(BingApiKey))
+            {
+                _logger.LogError("Invalid configuration for parameter - ContentSearch:Ocp-Apim-Subscription-Key");
+            }
+            else
+            {
+                InitializeHttpClient();
+            }
+        }
+
+
+        public async Task<HttpResponseMessage> RunBingSearch(string query, int resultCount)
+        {
+            if (string.IsNullOrWhiteSpace(BingApiKey))
+            {
+                return new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.NotFound,
+                    Content = new StringContent("Bing Search feature is not enabled")
+                };
+            }
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, $"{BingSearchUrl}?q='{query}'&count={resultCount}");
+            return await _httpClient.SendAsync(request);
+        }
+
+        private void InitializeHttpClient()
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", BingApiKey);
+            _httpClient.MaxResponseContentBufferSize = Int32.MaxValue;
+        }
+
+        public void Dispose()
+        {
+            if (_httpClient != null)
+            {
+                _httpClient.Dispose();
+            }
+        }
+    }
+}

--- a/Backend/Controllers/AppSettingsController.cs
+++ b/Backend/Controllers/AppSettingsController.cs
@@ -17,7 +17,7 @@ namespace Backend.Controllers
         private IConfiguration config;
         private IWebHostEnvironment env;
 
-        private string[] AllowedSections = new string[] { "Arm", "ContentSearch", "DeepSearch", "ApplicationInsights", "ASD_ENVIRONMENT", "ASD_HOST", "AcceptOriginSuffix:Origins", "AppInsights:UseCertificates" };
+        private string[] AllowedSections = new string[] { "Arm", "ApplicationInsights", "ASD_ENVIRONMENT", "ASD_HOST", "AcceptOriginSuffix:Origins", "AppInsights:UseCertificates" };
 
         public AppSettingsController(IConfiguration configuration, IWebHostEnvironment env)
         {

--- a/Backend/Controllers/BingAPIController.cs
+++ b/Backend/Controllers/BingAPIController.cs
@@ -1,0 +1,67 @@
+﻿using Backend.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Net;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Backend.Controllers
+{
+    [Route("api/bing")]
+    [Produces("application/json")]
+    public class BingAPIController : Controller
+    {
+        private IBingSearchService _bingSearchService;
+        private ILogger<BingAPIController> _logger;
+        public BingAPIController(IBingSearchService bingSearchService, ILogger<BingAPIController> logger)
+        {
+            _bingSearchService = bingSearchService;
+            _logger = logger;
+        }
+
+        public HttpResponseMessage SendBadRequest(string message)
+        {
+            return new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(message)
+            };
+        }
+
+        [HttpGet("search")]
+        public async Task<IActionResult> BingSearch(string q, int count)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(q))
+                {
+                    return BadRequest("Query parameter 'q' should not be empty");
+                }
+                else if (!(count > 0 && count < 20))
+                {
+                    return BadRequest("Result count parameter should be within 1-20 range");
+                }
+                var result = await _bingSearchService.RunBingSearch(q, count);
+                if (result.IsSuccessStatusCode)
+                {
+                    var response = await result.Content.ReadAsStringAsync();
+                    return Ok(JsonConvert.DeserializeObject(response));
+                }
+                else
+                {
+                    var errorMessage = await result.Content.ReadAsStringAsync();
+                    _logger.LogError($"BingAPICallError: {result.StatusCode} -- {errorMessage}");
+                    return NotFound(errorMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"BingAPICallException: {ex.ToString()}");
+                return StatusCode(500);
+            }
+
+        }
+    }
+}

--- a/Backend/Services/BingSearchService/BingSearchService.cs
+++ b/Backend/Services/BingSearchService/BingSearchService.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Backend.Services
+{
+    public interface IBingSearchService : IDisposable
+    {
+        Task<HttpResponseMessage> RunBingSearch(string query, int resultCount);
+    }
+
+    public class BingSearchServiceDisabled : IBingSearchService
+    {
+        public async Task<HttpResponseMessage> RunBingSearch(string query, int resultCount) { return new HttpResponseMessage() { StatusCode = HttpStatusCode.NotFound, Content = new StringContent("Bing search is disabled") }; }
+        public void Dispose() { return; }
+    }
+
+    public class BingSearchService : IBingSearchService
+    {
+        private string BingSearchUrl = "https://api.cognitive.microsoft.com/bing/v7.0/search";
+        private string BingApiKey;
+        private ILogger<BingSearchService> _logger;
+        private static HttpClient _httpClient;
+        IConfiguration _configuration;
+
+        public BingSearchService(IConfiguration Configuration, ILogger<BingSearchService> logger)
+        {
+            _logger = logger;
+            _configuration = Configuration;
+            BingApiKey = _configuration["ContentSearch:Ocp-Apim-Subscription-Key"];
+            if (BingApiKey != null)
+            {
+                BingApiKey = BingApiKey.ToString();
+            }
+            if (string.IsNullOrWhiteSpace(BingApiKey))
+            {
+                _logger.LogError("Invalid configuration for parameter - ContentSearch:Ocp-Apim-Subscription-Key");
+            }
+            else
+            {
+                InitializeHttpClient();
+            }
+        }
+
+
+        public async Task<HttpResponseMessage> RunBingSearch(string query, int resultCount)
+        {
+            if (string.IsNullOrWhiteSpace(BingApiKey))
+            {
+                return new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.NotFound,
+                    Content = new StringContent("Bing Search feature is not enabled")
+                };
+            }
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, $"{BingSearchUrl}?q='{query}'&count={resultCount}");
+            return await _httpClient.SendAsync(request);
+        }
+
+        private void InitializeHttpClient()
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", BingApiKey);
+            _httpClient.MaxResponseContentBufferSize = Int32.MaxValue;
+        }
+
+        public void Dispose()
+        {
+            if (_httpClient != null)
+            {
+                _httpClient.Dispose();
+            }
+        }
+    }
+}

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -67,6 +67,14 @@ namespace Backend
             services.AddSingleton<IEncryptionService, EncryptionService>();
             services.AddSingleton<IAppInsightsService, AppInsightsService>();
             services.AddSingleton<IHealthCheckService, HealthCheckService>();
+            if (!string.IsNullOrWhiteSpace(Configuration.GetValue("ContentSearch:Ocp-Apim-Subscription-Key", string.Empty)))
+            {
+                services.AddSingleton<IBingSearchService, BingSearchService>();
+            }
+            else
+            {
+                services.AddSingleton<IBingSearchService, BingSearchServiceDisabled>();
+            }
 
             // https://stackoverflow.com/questions/52036998/how-do-i-get-a-reference-to-an-ihostedservice-via-dependency-injection-in-asp-ne
             services.AddSingleton<CertificateService>();


### PR DESCRIPTION
## Overview
Changes to how we call the Bing API to show web results.

## Related Work Item
ICM Incident from MSRC

## Type of change
Security issue fix for leaking API keys for bing and deep search API.

- [x] Bug fix (non-breaking change which fixes an issue)

## Solution description
Moving the calling of Bing API from client to backend

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

Screenshots after testing:
Web apps genie
![image](https://user-images.githubusercontent.com/8492235/218615513-49f50e5c-129b-446b-a3e8-fb2566c38916.png)

Web apps case submission (where no detector is mapped)
![image](https://user-images.githubusercontent.com/8492235/218615552-805ef9f8-c62c-4f5c-8a54-28fcea626913.png)

AKS genie
![image](https://user-images.githubusercontent.com/8492235/218615645-fe8a8a25-160d-4223-b005-681cb4680bd1.png)

AKS Case submission (where no detector and no apollo document is matched)
![image](https://user-images.githubusercontent.com/8492235/218615744-6e7599ad-d5fa-4d6b-a4b3-2f1d0cc683c0.png)
