### PR TITLE
Stop sending ARM token to public UI controller

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/backend-ctrl.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/backend-ctrl.service.ts
@@ -70,8 +70,7 @@ export class BackendCtrlService {
   private _getHeaders(startupInfo: StartupInfo, additionalHeaders: HttpHeaders): HttpHeaders {
     let headers = new HttpHeaders({
       'Content-Type': 'application/json',
-      'Accept': 'application/json',
-      'Authorization': `Bearer ${startupInfo.token}`
+      'Accept': 'application/json'
     });
 
     if (additionalHeaders) {


### PR DESCRIPTION
## Overview
We are sending the ARM token to our public UI controller. However, the controller doesn't need it. So we will stop sending it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.