### PR TITLE
ChatGPT: Feedback, scrolls, decouple user prefs

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -38,6 +38,7 @@ import { CreateWorkflowComponent } from '../workflow/create-workflow/create-work
 import { workflowNodeResult, workflowPublishBody } from 'projects/diagnostic-data/src/lib/models/workflow';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { WorkflowRunDialogComponent } from '../workflow/workflow-run-dialog/workflow-run-dialog.component';
+import { UserSettingService } from '../services/user-setting.service';
 
 const codePrefix = `// *****PLEASE DO NOT MODIFY THIS PART*****
 using Diagnostics.DataProviders;
@@ -373,7 +374,7 @@ export class OnboardingFlowComponent implements OnInit, IDeactivateComponent {
     private _detectorControlService: DetectorControlService, private _adalService: AdalService,
     public ngxSmartModalService: NgxSmartModalService, private _telemetryService: TelemetryService, private _activatedRoute: ActivatedRoute,
     private _applensCommandBarService: ApplensCommandBarService, private _router: Router, private _themeService: GenericThemeService, private _applensGlobal: ApplensGlobal,
-    private matDialog: MatDialog) {
+    private matDialog: MatDialog, private _userSettingService: UserSettingService) {
     this.lightOptions = {
       theme: 'vs',
       language: 'csharp',
@@ -826,31 +827,42 @@ export class OnboardingFlowComponent implements OnInit, IDeactivateComponent {
     this._monacoEditor = editor;
     let getEnabled = this._diagnosticApi.get('api/appsettings/CodeCompletion:Enabled');
     let getServerUrl = this._diagnosticApi.get('api/appsettings/CodeCompletion:LangServerUrl');
-    forkJoin([getEnabled, getServerUrl]).subscribe(resList => {
-      this.codeCompletionEnabled = resList[0] == true || resList[0].toString().toLowerCase() == "true";
-      this.languageServerUrl = resList[1];
-      if (this.codeCompletionEnabled && this.languageServerUrl && this.languageServerUrl.length > 0) {
-        if (this.code.indexOf(codePrefix) < 0) {
-          this.code = this.addCodePrefix(this.code);
-          this.lastSavedVersion = this.code
-        }
-        let fileName = uuid();
-        let editorModel = monaco.editor.createModel(this.code, 'csharp', monaco.Uri.parse(`file:///workspace/${fileName}.cs`));
-        editor.setModel(editorModel);
-        MonacoServices.install(editor, { rootUri: "file:///workspace" });
-        const webSocket = this.createWebSocket(this.languageServerUrl);
+    try {
+      forkJoin([getEnabled, getServerUrl]).subscribe(resList => {
+        this._userSettingService.getUserSetting().subscribe(res => {
+          let userCodeCompletionEnabled = res && res.codeCompletion == "off"? false: true;
+          this.codeCompletionEnabled = (resList[0] == true || resList[0].toString().toLowerCase() == "true") && userCodeCompletionEnabled;
+          this.languageServerUrl = resList[1];
+          if (this.codeCompletionEnabled && this.languageServerUrl && this.languageServerUrl.length > 0) {
+            if (this.code.indexOf(codePrefix) < 0) {
+              this.code = this.addCodePrefix(this.code);
+              this.lastSavedVersion = this.code
+            }
+            let fileName = uuid();
+            let editorModel = monaco.editor.createModel(this.code, 'csharp', monaco.Uri.parse(`file:///workspace/${fileName}.cs`));
+            editor.setModel(editorModel);
+            MonacoServices.install(editor, { rootUri: "file:///workspace" });
+            const webSocket = this.createWebSocket(this.languageServerUrl);
 
-        listen({
-          webSocket,
-          onConnection: connection => {
-            // create and start the language client
-            const languageClient = this.createLanguageClient(connection);
-            const disposable = languageClient.start();
-            connection.onClose(() => disposable.dispose());
+            listen({
+              webSocket,
+              onConnection: connection => {
+                // create and start the language client
+                const languageClient = this.createLanguageClient(connection);
+                const disposable = languageClient.start();
+                connection.onClose(() => disposable.dispose());
+              }
+            });
           }
         });
-      }
-    });
+      },
+      (err) => {
+        this.codeCompletionEnabled = false;
+      });
+    }
+    catch (err) {
+      this.codeCompletionEnabled = false;
+    }
   }
 
   loadExamples() {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/openai-chat/openai-chat.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/openai-chat/openai-chat.component.html
@@ -14,7 +14,7 @@
           </ng-container>
         </div>
     </div>
-    <div class="chatgpt-box-row-container chatgpt-chat-messages-container" *ngIf="_chatContextService.messages && _chatContextService.messages.length>0">
+    <div id="chatgpt-all-messages-container-id" class="chatgpt-box-row-container chatgpt-chat-messages-container" *ngIf="_chatContextService.messages && _chatContextService.messages.length>0">
       <div class="chatgpt-request-error-container" *ngIf="showChatGPTRequestError" [ngClass]="{'fade-in': showChatGPTRequestError, 'fade-out': !showChatGPTRequestError}">
         {{chatGPTRequestError}}
       </div>
@@ -43,6 +43,12 @@
                 <p [ngClass]="{'blinking-cursor': message.status==2}" [innerText]="message.message">
                 </p>
               </div>
+              <ng-container *ngIf="message.messageSource=='system'">
+                <div class="chatgpt-feedback-icons">
+                  <i class="fa fa-thumbs-up chatgpt-feedback-icon" [ngClass]="{'chatgpt-feedback-icon-selected': message.userFeedback=='like'}" (click)="logUserFeedback(message.id, 'like')"></i>
+                  <i class="fa fa-thumbs-down chatgpt-feedback-icon" [ngClass]="{'chatgpt-feedback-icon-selected': message.userFeedback=='dislike'}" (click)="logUserFeedback(message.id, 'dislike')"></i>
+                </div>
+              </ng-container>
             </div>
           </ng-container>
         </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/openai-chat/openai-chat.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/openai-chat/openai-chat.component.scss
@@ -176,6 +176,28 @@
     display: flex;
     align-items: top;
   }
+
+  .chatgpt-feedback-icons {
+    float: right;
+  }
+
+  .chatgpt-feedback-icon {
+    font-size: 16px;
+    margin: 2px 5px;
+    color: transparent;
+    cursor: pointer;
+    -webkit-text-stroke-width: 1px;
+    -webkit-text-stroke-color: gray;
+  }
+
+  .chatgpt-feedback-icon-selected {
+    font-size: 16px;
+    margin: 2px 5px;
+    color: gray!important;
+    cursor: pointer;
+    -webkit-text-stroke-width: 1px;
+    -webkit-text-stroke-color: gray!important;
+  }
   
   .chatgpt-message-icon :hover {
     cursor: pointer;

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/user-setting.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/user-setting.service.ts
@@ -39,17 +39,27 @@ export class UserSettingService {
     constructor(private _diagnosticApiService: DiagnosticApiService, private _adalService: AdalService) {
     }
 
-    getUserSetting(invalidateCache = false): Observable<UserSetting> {
+    getUserSetting(invalidateCache = false, chatGPT = false): Observable<UserSetting> {
         if (!!this._userSetting && !invalidateCache) {
             return this._userSettingSubject;
         }
 
-        return this._diagnosticApiService.getUserSetting(this._userId, invalidateCache).pipe(
-            map(userSetting => {
-                this._userSetting = userSetting;
-                return userSetting;
-            })
-        );
+        if (!chatGPT) {
+            return this._diagnosticApiService.getUserSetting(this._userId, invalidateCache).pipe(
+                map(userSetting => {
+                    this._userSetting = userSetting;
+                    return userSetting;
+                })
+            );
+        }
+        else {
+            return this._diagnosticApiService.getUserSettingChatGPT(this._userId, invalidateCache).pipe(
+                map(userSetting => {
+                    this._userSetting = userSetting;
+                    return userSetting;
+                })
+            );
+        }
     }
 
     getExpandAnalysisCheckCard() {

--- a/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.html
+++ b/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.html
@@ -29,6 +29,7 @@
   <div class="user-setting-section" style="height: 80%;">
     <!-- <fab-toggle [onnText]="'Expand'" [offText]="'Collapse'" [label]="'Expand Analysis Card'" [checked]="expandCheckCard" (onChange)="toggleExpandCheckCard($event)"></fab-toggle> -->
     <fab-toggle [onnText]="'Dark'" [offText]="'Light'" [label]="'Dark Theme'" [checked]="darkThemeChecked" (onChange)="toggleTheme($event)"></fab-toggle>
+    <fab-toggle [onnText]="'On'" [offText]="'Off'" [label]="'Code Completion'" [checked]="codeCompletionChecked" (onChange)="toggleCodeCompletion($event)"></fab-toggle>
     <br />
     <fab-choice-group [label]="'Detector View Mode'" [options]="choiceGroupOptions"  [selectedKey]="selectedKey">
     </fab-choice-group>

--- a/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.ts
+++ b/AngularApp/projects/applens/src/app/shared/components/applens-header/applens-header.component.ts
@@ -35,6 +35,7 @@ export class ApplensHeaderComponent implements OnInit {
   };
   expandCheckCard: boolean = false;
   darkThemeChecked: boolean = false;
+  codeCompletionChecked: boolean = false;
   smartViewChecked: boolean = false;
   //Only If user changed setting, then send request to backend
   userSettingChanged: boolean = false;
@@ -83,6 +84,7 @@ export class ApplensHeaderComponent implements OnInit {
     this._userSettingService.getUserSetting().subscribe(userSettings => {
       this.expandCheckCard = userSettings ? userSettings.expandAnalysisCheckCard : false;
       this.darkThemeChecked = userSettings && userSettings.theme.toLowerCase() == "dark" ? true : false;
+      this.codeCompletionChecked = userSettings && userSettings.codeCompletion && userSettings.codeCompletion.toLowerCase() == "off" ? false : true;
       this.smartViewChecked = userSettings && userSettings.viewMode.toLowerCase() == "smarter" ? true : false;
       this.selectedKey = userSettings && userSettings.viewMode.toLowerCase() == "smarter" ? "smarter" : "waterfall";
     });
@@ -117,6 +119,10 @@ export class ApplensHeaderComponent implements OnInit {
     this.darkThemeChecked = event.checked;
   }
 
+  toggleCodeCompletion(event: { checked: boolean }) {
+    this.codeCompletionChecked = event.checked;
+  }
+
   toggleViewMode(event: { checked: boolean }) {
     this.viewModeChanged = !this.viewModeChanged;
     this.userSettingChanged = this.expandAnalysisChanged || this.themeChanged || this.viewModeChanged;
@@ -127,14 +133,15 @@ export class ApplensHeaderComponent implements OnInit {
   private updateUserSettingsFromPanel() {
     const themeStr = this.darkThemeChecked ? "dark" : "light";
     const updatedSettings: UserPanelSetting = {
+      codeCompletion: this.codeCompletionChecked ? "on": "off",
       expandAnalysisCheckCard: this.expandCheckCard,
       theme: themeStr,
       viewMode: this.smartViewChecked ? "smarter" : "waterfall"
     };
     this._themeService.setActiveTheme(themeStr);
     this._userSettingService.isWaterfallViewSub.next(!this.smartViewChecked);
-    this._userSettingService.updateUserPanelSetting(updatedSettings).subscribe();
-    window.location.reload();
+    this._userSettingService.updateUserPanelSetting(updatedSettings).subscribe(res => {}, err => {});
+    setTimeout(() => {window.location.reload();}, 1000);
   }
 
   openCallout() {

--- a/AngularApp/projects/applens/src/app/shared/models/user-setting.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/user-setting.ts
@@ -16,6 +16,7 @@ export interface UserPanelSetting {
     theme: string;
     viewMode: string;
     expandAnalysisCheckCard: boolean;
+    codeCompletion: string;
 }
 
 export interface RecentResource {

--- a/AngularApp/projects/applens/src/app/shared/services/applens-openai.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-openai.service.ts
@@ -26,7 +26,7 @@ export class ApplensOpenAIService {
   }
 
   public generateTextCompletion(queryModel: TextCompletionModel, caching: boolean = true): Observable<OpenAIAPIResponse> {
-    queryModel.prompt = `Please answer questions about ${this.productName}\n${queryModel.prompt}:`;
+    queryModel.prompt = `You are helping support eningeers to debug issues related to ${this.productName}. Do not be repetitive when providing steps in your answer. Please answer the below question\n${queryModel.prompt}:`;
     return this._backendApi.post(this.completionApiPath, {payload: queryModel}, new HttpHeaders({"x-ms-openai-cache": caching.toString()})).pipe(map((response: OpenAIAPIResponse) => {
       return response;
     }));

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -522,6 +522,10 @@ export class DiagnosticApiService {
     });
   }
 
+  public getUserSettingChatGPT(userId: string, invalidateCache: boolean): Observable<UserSetting> {
+    return this.get<UserSetting>(`api/usersetting/${userId}/userChatGPTSetting`, invalidateCache);
+  }
+
   updateUserChatGPTSetting(chatGPTSetting: any, userId: string): Observable<UserSetting> {
     const url: string = `${this.diagnosticApi}api/usersetting/${userId}/userChatGPTSetting`;
     return this._httpClient.post<UserSetting>(url, chatGPTSetting, {

--- a/AngularApp/projects/diagnostic-data/src/lib/models/chatbot-models.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/chatbot-models.ts
@@ -1,11 +1,11 @@
 export interface ChatMessage{
     id: string;
     message: string;
-    //displayedMessage: string;
     messageSource: MessageSource;
     timestamp: number;
     messageDisplayDate: string;
     renderingType: MessageRenderingType;
+    userFeedback: UserFeedbackType;
     status: MessageStatus;
 }
 
@@ -20,6 +20,12 @@ export enum MessageStatus{
     Waiting = 1,
     InProgress = 2,
     Finished = 3,
+}
+
+export enum UserFeedbackType {
+    Like = "like",
+    Dislike = "dislike",
+    None = "none"
 }
 
 export enum MessageSource {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -116,6 +116,8 @@ export const TelemetryEventNames = {
     ChatGPTLoaded: 'ChatGPTLoaded',
     ChatGPTUserSettingLoaded: 'ChatGPTUserSettingLoaded',
     ChatGPTSampleClicked: 'ChatGPTSampleClicked',
+    ChatGPTUserFeedbackLike: 'ChatGPTUserFeedbackLike',
+    ChatGPTUserFeedbackDislike: 'ChatGPTUserFeedbackDislike',
     ChatGPTCheckMessageCount: 'ChatGPTCheckMessageCount',
     ChatGPTRequestError: 'ChatGPTRequestError',
     ChatGPTUserQuotaExceeded: 'ChatGPTUserQuotaExceeded',

--- a/ApplensBackend/Controllers/UserSettingsController.cs
+++ b/ApplensBackend/Controllers/UserSettingsController.cs
@@ -79,6 +79,18 @@ namespace AppLensV3.Controllers
             return Ok(userSetting);
         }
 
+        [HttpGet("{userId}/userChatGPTSetting")]
+        public async Task<IActionResult> GetUserChatGPTInfo(string userId)
+        {
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return BadRequest("userId cannot be empty");
+            }
+            UserSetting user = await _cosmosDBHandler.GetUserSetting(userId, true, true);
+            if (user == null) return NotFound("");
+            return Ok(user);
+        }
+
         [HttpPost("{userId}/userChatGPTSetting")]
         public async Task<IActionResult> PathchUserChatGPTSettings(string userId, [FromBody] JToken body)
         {

--- a/ApplensBackend/Controllers/UserSettingsController.cs
+++ b/ApplensBackend/Controllers/UserSettingsController.cs
@@ -74,8 +74,9 @@ namespace AppLensV3.Controllers
             var theme = body?["theme"]?.ToString();
             var viewMode = body?["viewMode"]?.ToString();
             var expandAnalysisCheckCard = body?["expandAnalysisCheckCard"]?.ToString();
+            var codeCompletion = body?["codeCompletion"]?.ToString() ?? "on";
 
-            var userSetting = await _cosmosDBHandler.PatchUserPanelSetting(userId, theme, viewMode, expandAnalysisCheckCard);
+            var userSetting = await _cosmosDBHandler.PatchUserPanelSetting(userId, theme, viewMode, expandAnalysisCheckCard, codeCompletion);
             return Ok(userSetting);
         }
 

--- a/ApplensBackend/Models/RecentResource.cs
+++ b/ApplensBackend/Models/RecentResource.cs
@@ -18,6 +18,9 @@ namespace AppLensV3.Models
         [JsonProperty(PropertyName = "theme")]
         public string Theme { get; set; }
 
+        [JsonProperty(PropertyName = "codeCompletion")]
+        public string CodeCompletion { get; set; }
+
         [JsonProperty(PropertyName = "viewMode")]
         public string ViewMode { get; set; }
 
@@ -45,6 +48,7 @@ namespace AppLensV3.Models
             Resources = new List<RecentResource>();
             PartitionKey = UserSettingConstant.PartitionKey;
             Theme = defaultUserSetting?.Theme ?? UserSettingConstant.DefaultTheme;
+            CodeCompletion = defaultUserSetting?.CodeCompletion ?? "on";
             ViewMode = defaultUserSetting?.ViewMode ?? UserSettingConstant.DefaultViewMode;
             DefaultServiceType = defaultUserSetting?.DefaultServiceType ?? string.Empty;
             FavoriteDetectors = defaultUserSetting?.FavoriteDetectors ?? new Dictionary<string, FavoriteDetectorProp>();

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBUserSettingHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBUserSettingHandler.cs
@@ -78,13 +78,14 @@ namespace AppLensV3.Services
             return PathItemAsync(id, UserSettingConstant.PartitionKey, property, value);
         }
 
-        public async Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard)
+        public async Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard, string codeCompletion)
         {
             var patchOperations = new[]
             {
                 PatchOperation.Add("/theme",theme),
                 PatchOperation.Add("/viewMode",viewMode),
-                PatchOperation.Add("/expandAnalysisCheckCard",expandAnalysisCheckCard)
+                PatchOperation.Add("/expandAnalysisCheckCard",expandAnalysisCheckCard),
+                PatchOperation.Add("/codeCompletion", codeCompletion)
             };
             return await Container.PatchItemAsync<UserSetting>(id, new PartitionKey(UserSettingConstant.PartitionKey), patchOperations);
         }

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBUserSettingHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBUserSettingHandler.cs
@@ -101,7 +101,7 @@ namespace AppLensV3.Services
 
 
 
-        public async Task<UserSetting> GetUserSetting(string id, bool needCreate = true)
+        public async Task<UserSetting> GetUserSetting(string id, bool needCreate = true, bool chatGPT = false)
         {
             UserSetting userSetting = null;
             userSetting = await GetItemAsync(id, UserSettingConstant.PartitionKey);
@@ -118,6 +118,9 @@ namespace AppLensV3.Services
                     newUserSetting = new UserSetting(id);
                 }
                 userSetting = await CreateItemAsync(newUserSetting);
+            }
+            if (!chatGPT) {
+                userSetting.UserChatGPTSetting = "";
             }
             return userSetting;
         }

--- a/ApplensBackend/Services/CosmosDBHandler/ICosmosDBUserSettingHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/ICosmosDBUserSettingHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
+using System.Collections.Specialized;
 
 namespace AppLensV3.Services
 {
@@ -17,7 +18,7 @@ namespace AppLensV3.Services
 
         Task<UserSetting> AddFavoriteDetector(string id, string detectorId, FavoriteDetectorProp prop);
 
-        Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard);
+        Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard, string codeCompletion);
 
         Task<UserSetting> PatchLandingInfo(string id, List<RecentResource> resources, string defaultServiceType);
 

--- a/ApplensBackend/Services/CosmosDBHandler/ICosmosDBUserSettingHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/ICosmosDBUserSettingHandler.cs
@@ -9,7 +9,7 @@ namespace AppLensV3.Services
     {
         Task<UserSetting> UpdateUserSetting(UserSetting userSettings);
 
-        Task<UserSetting> GetUserSetting(string id, bool needCreate = true);
+        Task<UserSetting> GetUserSetting(string id, bool needCreate = true, bool chatGPT = false);
 
         Task<UserSetting> PathUserSettingProperty(string id, string property, object value);
 

--- a/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBUserSettingsHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBUserSettingsHandler.cs
@@ -34,7 +34,7 @@ namespace AppLensV3.Services
             return Task.FromResult(new List<UserSetting>() { nullableUserSetting });
         }
 
-        public Task<UserSetting> GetUserSetting(string id, bool needCreate = true)
+        public Task<UserSetting> GetUserSetting(string id, bool needCreate = true, bool chatGPT = false)
         {
             return Task.FromResult(nullableUserSetting);
         }

--- a/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBUserSettingsHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBUserSettingsHandler.cs
@@ -44,7 +44,7 @@ namespace AppLensV3.Services
             return Task.FromResult(nullableUserSetting);
         }
 
-        public Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard)
+        public Task<UserSetting> PatchUserPanelSetting(string id, string theme, string viewMode, string expandAnalysisCheckCard, string codeCompletion)
         {
             return Task.FromResult(nullableUserSetting);
         }


### PR DESCRIPTION
## Overview
Some enhancements and optimizations in AppLens ChatGPT.
Added a toggle feature for code completion.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Solution description
- Adds the feature for user to provide feedback through upvote/downvote button.
- Fixes a bug in scrolling, now it will scroll all the way to the end of the chat while chatting.
- Decouples user chat gpt info from the normal user preferences to avoid slowing down Applens loading (when chats get longer). **Chat info will only be fetched when user visits ChatGPT**.

- Adds a toggle feature in user preferences section for enabling/disabling code completion.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.
- [x] I have added logging for my feature.

## Screenshots
![image](https://user-images.githubusercontent.com/8492235/220234299-0fb3f2c4-5e15-442d-b919-98f1c7cc3f00.png)

Toggle feature for code completion
![image](https://user-images.githubusercontent.com/8492235/220249038-29ddc378-d41d-4188-a28b-b172fdcfe852.png)
