### PR TITLE
Fix Start time getting shifted by a day

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring-analysis/crash-monitoring-analysis.component.html
@@ -16,9 +16,9 @@
               <div>
                 <div *ngIf="monitoringEnabled" class="data-collection-loading">
                   <div class="dot-flashing"></div>
-                  <div *ngIf="insights.length === 0">Crash Monitoring session is in progress. Please return to this page
+                  <div class="ml-3" *ngIf="insights.length === 0">Crash Monitoring session is in progress. Please return to this page
                     to view data collected on future crashes.</div>
-                  <div *ngIf="insights.length > 0">Crash Monitoring session is in progress. See the insights below for
+                  <div class="ml-3" *ngIf="insights.length > 0">Crash Monitoring session is in progress. See the insights below for
                     previously collected data and do not delete data while the tool is running.</div>
                 </div>
                 <div *ngIf="!monitoringEnabled">

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
@@ -146,11 +146,11 @@ export class CrashMonitoringComponent implements OnInit {
 
     let monitoringDates = this._siteService.getCrashMonitoringDates(crashMonitoringSettings);
 
-    this.startDate = this.convertUTCToLocalDate(monitoringDates.start);
-    this.endDate = this.convertUTCToLocalDate(monitoringDates.end);
+    this.startDate = monitoringDates.start;
+    this.endDate = monitoringDates.end;
 
-    this.startClock = this.getHourAndMinute(this.startDate);
-    this.endClock = this.getHourAndMinute(this.endDate);
+    this.startClock = momentNs.utc(this.startDate).format('HH:mm');
+    this.endClock = momentNs.utc(this.endDate).format('HH:mm');
 
     // Reset the minDate to avoid the UI displaying an error
     this.minDate = this.startDate;


### PR DESCRIPTION
## Overview
Start time and Stop time get shifted by 1 day on Crash Monitoring. This change fixes the issue

## Related Work Item
<html>
<body>
<!--StartFragment-->

ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
2992 | Start time and Stop time get shifted by 1 day on Crash Monitoring | app-service-diagnostics-portal\2203-2 | Active | Service Health | 0 | 2/22/2023, 12:14:58 PM

<!--EndFragment-->
</body>
</html>

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)