### PR TITLE
Fix Start time getting shifted by a day - Part 2

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.html
@@ -57,7 +57,7 @@
                   showMonthPickerAsOverlay="true" (onSelectDate)="onSelectStartDateHandler($event)"
                   [formatDate]="formatDate" [value]="startDate">
                 </fab-date-picker>
-                <span *ngIf="monitoringEnabled">{{ formatDateToString(startDate) }}</span>
+                <span *ngIf="monitoringEnabled">{{ startDateString }}</span>
                 <div class="mt-1 mb-4">
                   <span *ngIf="monitoringEnabled">{{ startClock }}</span>
                   <fab-masked-text-field *ngIf="!monitoringEnabled" maxLength="6" [(value)]="startClock"
@@ -86,7 +86,7 @@
                   showMonthPickerAsOverlay="true" (onSelectDate)="onSelectEndDateHandler($event)"
                   [formatDate]="formatDate" [value]="endDate" [disabled]="monitoringEnabled">
                 </fab-date-picker>
-                <span *ngIf="monitoringEnabled">{{ formatDateToString(endDate) }}</span>
+                <span *ngIf="monitoringEnabled">{{ endDateString }}</span>
                 <div class="mt-1 mb-4">
                   <fab-masked-text-field *ngIf="!monitoringEnabled" maxLength="6" [(value)]="endClock"
                     [iconProps]="{iconName: 'Clock'}" [mask]="'99:99'" [maskChar]="'-'" [validateOnFocusOut]="true"

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/tools/crash-monitoring/crash-monitoring.component.ts
@@ -42,6 +42,8 @@ export class CrashMonitoringComponent implements OnInit {
   maxDate: Date = this.convertUTCToLocalDate(addMonths(this.today, 3));
   minDate: Date = this.convertUTCToLocalDate(this.today);
   startDate: Date = this.minDate;
+  startDateString = '';
+  endDateString = '';
   endDate: Date = addDays(this.startDate, 15);
   startClock: string;
   endClock: string;
@@ -148,6 +150,9 @@ export class CrashMonitoringComponent implements OnInit {
 
     this.startDate = monitoringDates.start;
     this.endDate = monitoringDates.end;
+
+    this.startDateString = this.formatDateToString(monitoringDates.start);
+    this.endDateString = this.formatDateToString(monitoringDates.end);
 
     this.startClock = momentNs.utc(this.startDate).format('HH:mm');
     this.endClock = momentNs.utc(this.endDate).format('HH:mm');
@@ -264,6 +269,9 @@ export class CrashMonitoringComponent implements OnInit {
         this.status = toolStatus.SettingsSaved;
         this.monitoringEnabled = true;
         this.collapsed = true;
+        let monitoringDates = this._siteService.getCrashMonitoringDates(this.crashMonitoringSettings);
+        this.startDateString = this.formatDateToString(monitoringDates.start);
+        this.endDateString = this.formatDateToString(monitoringDates.end);
       },
         error => {
           this.status = toolStatus.Error;
@@ -297,7 +305,6 @@ export class CrashMonitoringComponent implements OnInit {
   }
 
   getMonitoringSummary(): string {
-
     if (this.crashMonitoringSettings != null) {
       let monitoringDates = this._siteService.getCrashMonitoringDates(this.crashMonitoringSettings);
       return `${this.siteToBeDiagnosed.siteName} | ${this.formatDateToString(monitoringDates.start, true)} to ${this.formatDateToString(monitoringDates.end, true)} | ${this.crashMonitoringSettings.MaxDumpCount} memory dumps`;
@@ -305,7 +312,6 @@ export class CrashMonitoringComponent implements OnInit {
   }
 
   formatDateToString(date: Date, appendTime: boolean = false) {
-
     return appendTime ? momentNs.utc(date).format("YYYY-MM-DD HH:mm") : momentNs.utc(date).format("YYYY-MM-DD");
   }
 


### PR DESCRIPTION
## Overview
Start time and Stop time get shifted by 1 day on Crash Monitoring. This change fixes the issue

## Related Work Item
<html>
<body>
<!--StartFragment-->

ID | Title | Iteration Path | State | Tags | Comments | Changed Date
-- | -- | -- | -- | -- | -- | --
2992 | Start time and Stop time get shifted by 1 day on Crash Monitoring | app-service-diagnostics-portal\2203-2 | Active | Service Health | 0 | 2/22/2023, 12:14:58 PM

<!--EndFragment-->
</body>
</html>

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)