### PR TITLE
Adding Platform, AppType and ResourceSKU to Events

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/detector-command-bar/detector-command-bar.component.ts
@@ -207,11 +207,15 @@ export class DetectorCommandBarComponent implements AfterViewInit {
         // log telemetry for interaction
         const eventProperties = {
           'Subscription': this.subscriptionId,
+          'Platform': this.resourcePlatform != undefined ? this.resourcePlatform.toString() : "",
+          'AppType': this.resourceAppType != undefined ? this.resourceAppType.toString(): "",
+          'ResourceSku': this.resourceSku != undefined ? this.resourceSku.toString(): "",
           'CustomerName': JSON.parse(httpResponse.dataset[0].table.rows[0][0]).CustomerName,
           'NameSite1': JSON.parse(httpResponse.dataset[0].table.rows[1][0])[0].Name,
           'ScoreSite1': JSON.parse(httpResponse.dataset[0].table.rows[1][0])[0].OverallScore,
           'DetectorTimeTaken': detectorTimeTaken.toString(),
-          'TotalTimeTaken': totalTimeTaken.toString()
+          'TotalTimeTaken': totalTimeTaken.toString(),
+
         };
         this.telemetryService.logEvent(TelemetryEventNames.ResiliencyScoreReportDownloaded, eventProperties);
         this.gRPDFButtonText = "Get Resiliency Score report";

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.ts
@@ -161,6 +161,9 @@ export class DownloadReportComponent implements OnInit {
           // log telemetry for interaction
           let eventProperties = {
             'Subscription': this.subscriptionId,
+            'Platform': this.resourcePlatform != undefined ? this.resourcePlatform.toString() : "",
+            'AppType': this.resourceAppType != undefined ? this.resourceAppType.toString(): "",
+            'ResourceSku': this.resourceSku != undefined ? this.resourceSku.toString(): "",
             'DetectorName': this.detectorName,
             'ResourceName': this.resourceName,
             'DetectorTimeTaken': detectorTimeTaken.toString(),


### PR DESCRIPTION
## Overview
Adding Platform, AppType and ResourceSKU to the ResiliencyScoreReportDownloaded and DownloadReportDirectLinkDownloaded logging events as productName is not as reliable to use to differentiate the Platform and AppType.

## Related Work Item
N/A

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## Solution description
To differentiate the product being use, productName is not enough as in certain scenarios will simply log microsoft.web/sites instead "AZURE WEB APP" or "Azure Web App Linux". Adding Platform, AppType and SKU to both ResiliencyScoreReportDownloaded and DownloadReportDirectLinkDownloaded logging events, will allow to filter by Platform and AppType.

### This PR:
DiagnoseAndSolvePortal Application Insights component in the customEvents table will have for ResiliencyScoreReportDownloaded or DownloadReportDirectLinkDownloaded  logging events, Plaform, AppType and  ResourceSku.

## How Can This Be Tested? <span>&#128269;</span>
Query in DiagnoseAndSolvePortal Application Insights component in the customEvents table for timestamp after this PR is deployed, for either ResiliencyScoreReportDownloaded or DownloadReportDirectLinkDownloaded  and verify that customDimensions["Platform"], customDimensions["AppType"] and customDimensions["ResourceSku"] are there.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
