### PR TITLE
Allow configuring workflow users by storing them in cosmosDB

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard.module.ts
@@ -129,6 +129,7 @@ import { ApplensOpenAIService } from '../../shared/services/applens-openai.servi
 import { GenericOpenAIService } from '../../../../../diagnostic-data/src/public_api';
 import { OpenAIChatComponent } from './openai-chat/openai-chat.component';
 import {ChatGPTContextService} from 'diagnostic-data';
+import { WorkflowUserAccessComponent } from './workflow/workflow-user-access/workflow-user-access.component';
 
 @Injectable()
 export class InitResolver implements Resolve<Observable<ResourceInfo>>{
@@ -235,6 +236,10 @@ export const DashboardModuleRoutes: ModuleWithProviders<DashboardModule> = Route
                 path: 'createWorkflow',
                 component: WorkflowComponent,
                 canDeactivate: [DevelopNavigationGuardService]
+            },
+            {
+                path: 'addworkflowuser',
+                component: WorkflowUserAccessComponent
             },
             {
                 path: 'solutionOrchestrator',
@@ -587,6 +592,6 @@ export const DashboardModuleRoutes: ModuleWithProviders<DashboardModule> = Route
         L2SideNavComponent, UserActivePullrequestsComponent, FavoriteDetectorsComponent, ApplensDocsComponent, ApplensDocSectionComponent, CreateWorkflowComponent,
         IfElseConditionStepComponent, ConditionIftrueStepComponent, ConditionIffalseStepComponent, SwitchStepComponent, SwitchCaseStepComponent, SwitchCaseDefaultStepComponent,
         KustoQueryDialogComponent, DetectorNodeComponent, KustoNodeComponent, MarkdownNodeComponent, NodeActionsComponent, ConfigureVariablesComponent, CommonNodePropertiesComponent,
-        NodeTitleComponent, ErrorMessageComponent, MarkdownQueryDialogComponent, WorkflowComponent, WorkflowRunDialogComponent, UpdateDetectorReferencesComponent, WorkflowRootNodeComponent, OpenAIChatComponent]
+        NodeTitleComponent, ErrorMessageComponent, MarkdownQueryDialogComponent, WorkflowComponent, WorkflowRunDialogComponent, UpdateDetectorReferencesComponent, WorkflowRootNodeComponent, OpenAIChatComponent, WorkflowUserAccessComponent]
 })
 export class DashboardModule { }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-diagnostic.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/services/applens-diagnostic.service.ts
@@ -182,9 +182,9 @@ export class ApplensDiagnosticService {
     }));
   }
 
-  getGistDetailsById(id: string) : Observable<DetectorMetaData[]>{
-    return this._diagnosticApi.getGistId(this._resourceService.versionPrefix, 
-      this._resourceService.getCurrentResourceId(true), id); 
+  getGistDetailsById(id: string): Observable<DetectorMetaData[]> {
+    return this._diagnosticApi.getGistId(this._resourceService.versionPrefix,
+      this._resourceService.getCurrentResourceId(true), id);
   }
 
 
@@ -341,7 +341,15 @@ export class ApplensDiagnosticService {
     return this._diagnosticApi.getDevopsCommitContent(filePath, commitid, resourceUri);
   }
 
-  isUserAllowedForWorkflow(userAlias:string){
+  isUserAllowedForWorkflow(userAlias: string) {
     return this._diagnosticApi.isUserAllowedForWorkflow(userAlias);
+  }
+
+  getWorkflowUsers(): Observable<string[]> {
+    return this._diagnosticApi.getWorkflowUsers();
+  }
+
+  addWorkflowUser(useralias: string): Observable<any> {
+    return this._diagnosticApi.addWorkflowUser(useralias);
   }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.html
@@ -1,0 +1,12 @@
+<span>Add User</span> <input class="ml-1" type="text" [(ngModel)]="userAlias">
+<button class="btn btn-primary ml-1" (click)="addUser()">Add</button>
+
+<i class="fa fa-spinner fa-spin fa-fw" *ngIf="isloading"></i>
+
+<div *ngIf="error">{{  JSON.stringify(error) }} </div>
+
+<ul>
+    <li *ngFor="let user of workflowUsers">
+        {{ user }}
+    </li>
+</ul>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.spec.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WorkflowUserAccessComponent } from './workflow-user-access.component';
+
+describe('WorkflowUserAccessComponent', () => {
+  let component: WorkflowUserAccessComponent;
+  let fixture: ComponentFixture<WorkflowUserAccessComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WorkflowUserAccessComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WorkflowUserAccessComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-user-access/workflow-user-access.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+import { ApplensDiagnosticService } from '../../services/applens-diagnostic.service';
+
+@Component({
+  selector: 'workflow-user-access',
+  templateUrl: './workflow-user-access.component.html',
+  styleUrls: ['./workflow-user-access.component.scss']
+})
+export class WorkflowUserAccessComponent implements OnInit {
+
+  constructor(private _applensDiagnosticService: ApplensDiagnosticService) { }
+
+  workflowUsers: string[] = [];
+  userAlias: string = '';
+  isloading: boolean = true;
+  error: any;
+
+  ngOnInit(): void {
+    this._applensDiagnosticService.getWorkflowUsers().subscribe(resp => {
+      this.workflowUsers = resp;
+      this.isloading = false;
+    }, error => {
+      this.error = error;
+      this.isloading = false;
+    });
+  }
+
+  addUser() {
+    this.isloading = true;
+    this.error = null;
+    if (this.userAlias) {
+      this._applensDiagnosticService.addWorkflowUser(this.userAlias).subscribe(resp => {
+        this._applensDiagnosticService.getWorkflowUsers().subscribe(usersResponse => {
+          this.workflowUsers = usersResponse;
+          this.isloading = false;
+        }, error => {
+          this.error = error;
+        });
+      }, error => {
+        this.error = error;
+        this.isloading = false;
+      });
+    }
+  }
+}

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -173,11 +173,11 @@ export class DiagnosticApiService {
     return this.invoke<DetectorResponse[]>(path, HttpMethod.POST, body).pipe(retry(1), map(response => response.map(gist => gist.metadata)));
   }
 
-  
-  public getGistId(version: string, resourceId: string, gistId: string, body?: any): Observable<any>{
-    
+
+  public getGistId(version: string, resourceId: string, gistId: string, body?: any): Observable<any> {
+
     let path = `${version}${resourceId}/gists/${gistId}`;
-    return this.invoke<any>(path, HttpMethod.POST, body, true); 
+    return this.invoke<any>(path, HttpMethod.POST, body, true);
   }
 
 
@@ -396,7 +396,7 @@ export class DiagnosticApiService {
     const url = `${this.diagnosticApi}${path}`;
     let bodyString: string = '';
     if (body) {
-        bodyString = JSON.stringify(body);
+      bodyString = JSON.stringify(body);
     }
 
     var requestHeaders = this._getHeaders();
@@ -675,9 +675,23 @@ export class DiagnosticApiService {
     }));
   }
 
-  public isUserAllowedForWorkflow(userAlias:string):Observable<boolean>{
+  public isUserAllowedForWorkflow(userAlias: string): Observable<boolean> {
     const path = `api/workflows/isuserallowed/${userAlias}`;
     return this.get(path).pipe(map((res: boolean) => {
+      return res;
+    }));
+  }
+
+  public getWorkflowUsers(): Observable<string[]> {
+    const path = `api/workflowusers`;
+    return this.get(path, true).pipe(map((res: string[]) => {
+      return res;
+    }));
+  }
+
+  public addWorkflowUser(useralias: string): Observable<any> {
+    const path = `api/workflowusers`;
+    return this.post(path, useralias).pipe(map(res => {
       return res;
     }));
   }

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -72,6 +72,7 @@ namespace AppLensV3
 
             services.AddSingleton<IObserverClientService, SupportObserverClientService>();
             services.AddSingleton<IDiagnosticClientService, DiagnosticClient>();
+            services.AddSingleton<IWorkflowUsersCacheService, WorkflowUsersCacheService>();
 
             services.AddSingletonWhenEnabled<IGithubClientService, GithubClientService>(Configuration, "Github");
 
@@ -102,6 +103,8 @@ namespace AppLensV3
             services.AddSingletonWhenEnabled<ISurveysService, SurveysService, NullableSurveysService>(Configuration, "Surveys");
 
             services.AddSingletonWhenEnabled<ICosmosDBUserSettingHandler, CosmosDBUserSettingHandler, NullableCosmosDBUserSettingsHandler>(Configuration, "UserSetting");
+
+            services.AddSingletonWhenEnabled<ICosmosDBWorkflowUsersHandler, CosmosDBWorkflowUsersHandler, NullableCosmosDBWorkflowUsersHandler>(Configuration, "UserSetting");
 
             services.AddSingletonWhenEnabled<IDetectorGistTemplateService, TemplateService>(Configuration, "DetectorGistTemplateService");
 

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -104,7 +104,7 @@ namespace AppLensV3
 
             services.AddSingletonWhenEnabled<ICosmosDBUserSettingHandler, CosmosDBUserSettingHandler, NullableCosmosDBUserSettingsHandler>(Configuration, "UserSetting");
 
-            services.AddSingletonWhenEnabled<ICosmosDBWorkflowUsersHandler, CosmosDBWorkflowUsersHandler, NullableCosmosDBWorkflowUsersHandler>(Configuration, "UserSetting");
+            services.AddSingletonWhenEnabled<ICosmosDBWorkflowUsersHandler, CosmosDBWorkflowUsersHandler, NullableCosmosDBWorkflowUsersHandler>(Configuration, "WorkflowUsers");
 
             services.AddSingletonWhenEnabled<IDetectorGistTemplateService, TemplateService>(Configuration, "DetectorGistTemplateService");
 

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -63,7 +63,7 @@ namespace AppLensV3.Controllers
         /// <param name="env">The environment.</param>
         /// <param name="diagnosticClient">Diagnostic client.</param>
         /// <param name="emailNotificationService">Email notification service.</param>
-        public DiagnosticController(IWebHostEnvironment env, IDiagnosticClientService diagnosticClient, IEmailNotificationService emailNotificationService, IConfiguration configuration, IResourceConfigService resConfigService, IAppSvcUxDiagnosticDataService appSvcUxDiagnosticDataService)
+        public DiagnosticController(IWebHostEnvironment env, IDiagnosticClientService diagnosticClient, IEmailNotificationService emailNotificationService, IConfiguration configuration, IResourceConfigService resConfigService, IAppSvcUxDiagnosticDataService appSvcUxDiagnosticDataService, IWorkflowUsersCacheService workflowUsersCacheService)
         {
             Env = env;
             DiagnosticClient = diagnosticClient;
@@ -88,6 +88,12 @@ namespace AppLensV3.Controllers
             apiEndpointsForDetectorDevelopment = new List<string>() { "/diagnostics/query?", "/diagnostics/publish" };
 
             allowedUsers = configuration.GetValue("Workflow:Users", string.Empty).Split(';').Select(x => x.ToLower()).ToArray();
+
+            var allowedUsersInDb = workflowUsersCacheService.GetWorkflowUsers();
+            if (allowedUsersInDb.Any())
+            {
+                allowedUsers = allowedUsers.Concat(allowedUsersInDb).ToArray();
+            }
         }
 
         private IDiagnosticClientService DiagnosticClient { get; }

--- a/ApplensBackend/Controllers/WorkflowUsersController.cs
+++ b/ApplensBackend/Controllers/WorkflowUsersController.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Threading.Tasks;
+using AppLensV3.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+namespace AppLensV3.Controllers
+{
+    /// <summary>
+    /// WorkflowUsersController.
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize(Policy = "ApplensAccess")]
+    public class WorkflowUsersController : ControllerBase
+    {
+        private readonly ICosmosDBWorkflowUsersHandler workflowUsersHandler;
+        private readonly string[] allowedUsers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowUsersController"/> class.
+        /// </summary>
+        /// <param name="cosmosDBWorkflowUsersHandler">Handler from DI.</param>
+        /// <param name="configuration">Asp.net configuration object.</param>
+        public WorkflowUsersController(ICosmosDBWorkflowUsersHandler cosmosDBWorkflowUsersHandler, IConfiguration configuration)
+        {
+            allowedUsers = configuration.GetValue("Workflow:Users", string.Empty).Split(';').Select(x => x.ToLower()).ToArray();
+            workflowUsersHandler = cosmosDBWorkflowUsersHandler;
+        }
+
+        /// <summary>
+        /// Get Workflow users.
+        /// </summary>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        [HttpGet]
+        public async Task<IActionResult> GetUsers()
+        {
+            if (!IsUserAllowed())
+            {
+                return Unauthorized("User not allowed to call this method");
+            }
+
+            var userAliases = new List<string>();
+            var users = await workflowUsersHandler.GetUsersAsync();
+            if (users.Any())
+            {
+                userAliases = users.Select(x => x.Alias.ToLower()).OrderBy(x => x).ToList();
+            }
+
+            return Ok(userAliases);
+        }
+
+        /// <summary>
+        /// Adds new users to the Workflow Users DB.
+        /// </summary>
+        /// <param name="userAlias">UserAlias of the user to add.</param>
+        /// <returns>nothing.</returns>
+        [HttpPost]
+        public async Task<IActionResult> AddUser([FromBody] string userAlias)
+        {
+            if (string.IsNullOrWhiteSpace(userAlias))
+            {
+                return BadRequest("userAlias cannot be empty");
+            }
+
+            if (!IsUserAllowed())
+            {
+                return Unauthorized("User not allowed to call this method");
+            }
+
+            await workflowUsersHandler.AddUser(new UserAlias(userAlias));
+            return Ok();
+        }
+
+        // For the time being, only allow users that are part of the app setting to add more users
+        private bool IsUserAllowed()
+        {
+            string currentUser = GetCurrentUser();
+            return allowedUsers.Contains(currentUser);
+        }
+
+        private string GetCurrentUser()
+        {
+            string authorization = HttpContext.Request.Headers["Authorization"].ToString();
+            if (string.IsNullOrWhiteSpace(authorization))
+            {
+                return string.Empty;
+            }
+
+            string accessToken = authorization.Split(" ")[1];
+            var token = new JwtSecurityToken(accessToken);
+            if (token.Payload.TryGetValue("upn", out object upn))
+            {
+                if (upn != null)
+                {
+                    return upn.ToString().Split('@')[0];
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/ApplensBackend/Services/CosmosDBHandler/CosmosDBWorkflowUsersHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/CosmosDBWorkflowUsersHandler.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace AppLensV3.Services
+{
+
+    /// <summary>
+    /// CosmosDBWorkflowUsersHandler class to get workflow users from CosmosDB.
+    /// </summary>
+    public class CosmosDBWorkflowUsersHandler : CosmosDBHandlerBase<UserAlias>, ICosmosDBWorkflowUsersHandler
+    {
+        private const string WorkflowUsersCollectionId = "WorkflowUsers";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDBWorkflowUsersHandler"/> class.
+        /// Constructor.
+        /// </summary>
+        /// <param name="configuration">Configuration object.</param>
+        public CosmosDBWorkflowUsersHandler(IConfiguration configuration)
+            : base(configuration)
+        {
+            CollectionId = WorkflowUsersCollectionId;
+            Inital(configuration).Wait();
+        }
+
+        /// <summary>
+        /// Adds user to database.
+        /// </summary>
+        /// <param name="userAlias">User alias to be added.</param>
+        /// <returns>A task to await upon.</returns>
+        public async Task AddUser(UserAlias userAlias)
+        {
+            await UpdateItemAsync(userAlias, UserAlias.WorkflowUsersPartitionKey);
+        }
+
+        /// <summary>
+        /// Gets all users from database synchronously.
+        /// </summary>
+        /// <returns>List of users.</returns>
+        public List<UserAlias> GetUsers()
+        {
+            return GetItemsAsync(UserAlias.WorkflowUsersPartitionKey).Result;
+        }
+
+        /// <summary>
+        /// Gets all users from database.
+        /// </summary>
+        /// <returns>List of users.</returns>
+        public async Task<List<UserAlias>> GetUsersAsync()
+        {
+            return await GetItemsAsync(UserAlias.WorkflowUsersPartitionKey);
+        }
+    }
+}

--- a/ApplensBackend/Services/CosmosDBHandler/ICosmosDBWorkflowUsersHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/ICosmosDBWorkflowUsersHandler.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Services
+{
+    public class UserAlias
+    {
+        public const string WorkflowUsersPartitionKey = "WorkflowUsers";
+
+        public UserAlias(string userAlias)
+        {
+            this.Alias = userAlias;
+            this.Id = userAlias;
+            this.PartitionKey = WorkflowUsersPartitionKey;
+        }
+
+        [JsonProperty(PropertyName = "alias")]
+        public string Alias { get; set; }
+
+        /// <summary>
+        /// User alias Id.
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        private readonly string PartitionKey;
+    }
+
+    /// <summary>
+    /// Interface for ASP.NET CORE dependency injection.
+    /// </summary>
+    public interface ICosmosDBWorkflowUsersHandler : ICosmosDBHandlerBase<UserAlias>
+    {
+        /// <summary>
+        /// Gets workflow users from CosmosDb.
+        /// </summary>
+        /// <returns>All users aliases allowed to publish workflows.</returns>
+        Task<List<UserAlias>> GetUsersAsync();
+
+        /// <summary>
+        /// Adds new user alias to workflow users in CosmosDb.
+        /// </summary>
+        /// <param name="userAlias">User Alias to add</param>
+        /// <returns>Task.</returns>
+        Task AddUser(UserAlias userAlias);
+
+        /// <summary>
+        /// Gets workflow users from CosmosDb.
+        /// </summary>
+        /// <returns>All users aliases allowed to publish workflows.</returns>
+        List<UserAlias> GetUsers();
+    }
+}

--- a/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBWorkflowUsersHandler.cs
+++ b/ApplensBackend/Services/CosmosDBHandler/NullableCosmosDBWorkflowUsersHandler.cs
@@ -1,0 +1,45 @@
+﻿using AppLensV3.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Services
+{
+    public class NullableCosmosDBWorkflowUsersHandler : ICosmosDBWorkflowUsersHandler
+    {
+        private UserAlias nullableUserAlias;
+        public Task AddUser(UserAlias userAlias)
+        {
+            return Task.FromResult(nullableUserAlias);
+        }
+
+        public Task<UserAlias> CreateItemAsync(UserAlias item)
+        {
+            return Task.FromResult(item);
+        }
+
+        public Task<UserAlias> GetItemAsync(string id, string partitionKey)
+        {
+            return Task.FromResult(nullableUserAlias);
+        }
+
+        public Task<List<UserAlias>> GetItemsAsync(string partitionKey)
+        {
+            return Task.FromResult(new List<UserAlias>() { nullableUserAlias });
+        }
+
+        public List<UserAlias> GetUsers()
+        {
+            return new List<UserAlias>() { nullableUserAlias };
+        }
+
+        public Task<List<UserAlias>> GetUsersAsync()
+        {
+            return Task.FromResult(new List<UserAlias>() { nullableUserAlias });
+        }
+
+        public Task<UserAlias> UpdateItemAsync(UserAlias item, string partitionKey)
+        {
+            return Task.FromResult(nullableUserAlias);
+        }
+    }
+}

--- a/ApplensBackend/Services/WorkflowUsersCacheService/IWorkflowUsersCacheService.cs
+++ b/ApplensBackend/Services/WorkflowUsersCacheService/IWorkflowUsersCacheService.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace AppLensV3.Services
+{
+    public interface IWorkflowUsersCacheService
+    {
+        List<string> GetWorkflowUsers();
+    }
+}

--- a/ApplensBackend/Services/WorkflowUsersCacheService/WorkflowUsersCacheService.cs
+++ b/ApplensBackend/Services/WorkflowUsersCacheService/WorkflowUsersCacheService.cs
@@ -30,9 +30,13 @@ namespace AppLensV3.Services
                 try
                 {
                     var workflowUsers = await workflowUsersHandler.GetUsersAsync();
-                    this.workflowUsersList = workflowUsers.Select(x => x.Alias.ToLower()).OrderBy(x => x).ToList();
+                    var usersInDb = workflowUsers.Select(x => x.Alias.ToLower()).OrderBy(x => x);
+                    if (usersInDb.Any())
+                    {
+                        this.workflowUsersList = usersInDb.ToList();
+                    }
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // TODO - log the exception
                 }

--- a/ApplensBackend/Services/WorkflowUsersCacheService/WorkflowUsersCacheService.cs
+++ b/ApplensBackend/Services/WorkflowUsersCacheService/WorkflowUsersCacheService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppLensV3.Helpers;
+
+namespace AppLensV3.Services
+{
+    public class WorkflowUsersCacheService : IWorkflowUsersCacheService
+    {
+        private const int RefreshIntervalInHours = 1;
+        private ICosmosDBWorkflowUsersHandler workflowUsersHandler;
+        private List<string> workflowUsersList = new ();
+
+        public WorkflowUsersCacheService(ICosmosDBWorkflowUsersHandler cosmosDBWorkflowUsersHandler)
+        {
+            workflowUsersHandler = cosmosDBWorkflowUsersHandler;
+            StartCacheRefresh();
+        }
+
+        public List<string> GetWorkflowUsers()
+        {
+            return this.workflowUsersList;
+        }
+
+        public async Task StartCacheRefresh()
+        {
+            while (true)
+            {
+                try
+                {
+                    var workflowUsers = await workflowUsersHandler.GetUsersAsync();
+                    this.workflowUsersList = workflowUsers.Select(x => x.Alias.ToLower()).OrderBy(x => x).ToList();
+                }
+                catch (Exception ex)
+                {
+                    // TODO - log the exception
+                }
+
+                await Task.Delay(TimeSpan.FromHours(RefreshIntervalInHours));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview
Instead of changing the `Workflow:Users` app setting on all the endpoints, storing the workflow users in CosmosDb and giving a small UI to configure them in AppLens.

Only those users that are part of the existing `Workflow:Users` app setting will be able to add new users to CosmosDB.

