### PR TITLE
Adding timeout for loading experience and logging for empty search term

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/download-report/download-report.component.html
@@ -5,6 +5,6 @@
 </div>
 
 <ng-template #loaderView>
-  <loader-detector-view style="margin-top:300px" [LoadingMessage4]="'Generating Downloadable Report'"></loader-detector-view>    
+  <loader-detector-view style="margin-top:300px" [LoadingMessage4]="'Generating Downloadable Report'" [Source]="'DownloadReport'"></loader-detector-view>    
 </ng-template>
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild, Input, Output, EventEmitter, Inject } fro
 import { GenericDetectorComponent } from '../generic-detector/generic-detector.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ResourceService } from '../../../shared-v2/services/resource.service';
-import { FeatureNavigationService, TelemetryService, DiagnosticService, DownTime, DiagnosticDataConfig, DIAGNOSTIC_DATA_CONFIG } from 'diagnostic-data';
+import { FeatureNavigationService, TelemetryService, DiagnosticService, DownTime, DiagnosticDataConfig, DIAGNOSTIC_DATA_CONFIG, TelemetryEventNames } from 'diagnostic-data';
 import { AuthService } from '../../../startup/services/auth.service';
 import { DetectorListAnalysisComponent } from 'diagnostic-data';
 import { SearchAnalysisMode } from 'projects/diagnostic-data/src/lib/models/search-mode';
@@ -68,6 +68,11 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
                 if (this.analysisId === "searchResultsAnalysis" && ((this.searchTerm && this.searchTerm.length > 0) || this.searchMode !== SearchAnalysisMode.Genie)) {
                     //Show search bar in case submission or if not passing searchTerm
                     this.showSearchBar = this.searchMode === SearchAnalysisMode.CaseSubmission || !this.searchTerm ? true : this.showSearchBar;
+
+                    if(this.searchMode === SearchAnalysisMode.CaseSubmission && !this.searchTerm) {
+                        this._telemetryService.logEvent(TelemetryEventNames.EmptySearchTerm);
+                    }
+
                     this.displayDetectorContainer = false;
                 }
                 else {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/generic-analysis/generic-analysis.component.ts
@@ -69,8 +69,10 @@ export class GenericAnalysisComponent extends GenericDetectorComponent implement
                     //Show search bar in case submission or if not passing searchTerm
                     this.showSearchBar = this.searchMode === SearchAnalysisMode.CaseSubmission || !this.searchTerm ? true : this.showSearchBar;
 
-                    if(this.searchMode === SearchAnalysisMode.CaseSubmission && !this.searchTerm) {
-                        this._telemetryService.logEvent(TelemetryEventNames.EmptySearchTerm);
+                    if(!this.searchTerm) {
+                        this._telemetryService.logEvent(TelemetryEventNames.EmptySearchTerm, {
+                            searchMode: SearchAnalysisMode[this.searchMode]
+                        });
                     }
 
                     this.displayDetectorContainer = false;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-panel/risk-alerts-panel.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/risk-alerts-panel/risk-alerts-panel.component.html
@@ -12,7 +12,7 @@
       </div>
     </ng-container>
     <ng-template #loaderView>
-      <loader-detector-view style="margin-top:300px"></loader-detector-view>
+      <loader-detector-view style="margin-top:300px" [Source]="'RiskAlertPanel'"></loader-detector-view>
     </ng-template>
   </div>
 </fab-panel>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -52,7 +52,7 @@
 
 <div *ngIf="timePickerErrorStr !==''" class="error-time-picker-message">{{timePickerErrorStr}}</div>
 
-<div *ngIf="false">
+<div *ngIf="detectorDataLocalCopy">
   <div *ngFor="let data of detectorDataLocalCopy.dataset  | renderfilter:isAnalysisView"
     [ngClass]="{'dynamic-data-container': !isRiskAlertDetector}">
     <dynamic-data [isRiskAlertDetector]="isRiskAlertDetector" [isAnalysisView]="isAnalysisView" [diagnosticData]="data"
@@ -69,7 +69,7 @@
 
 <cxp-chat-launcher *ngIf="showChatButton()" [trackingId]="cxpChatTrackingId" [chatUrl]="cxpChatUrl"
   [supportTopicId]="supportTopicId"></cxp-chat-launcher>
-<loader-detector-view style="margin-top:300px" *ngIf="true"></loader-detector-view>
+<loader-detector-view style="margin-top:300px" *ngIf="!detectorDataLocalCopy && !errorState" [Source]="'DetectorView'"></loader-detector-view>
 
 <ng-container *ngIf="!detectorDataLocalCopy && errorState">
   <div class="mt-3">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -52,7 +52,7 @@
 
 <div *ngIf="timePickerErrorStr !==''" class="error-time-picker-message">{{timePickerErrorStr}}</div>
 
-<div *ngIf="detectorDataLocalCopy">
+<div *ngIf="false">
   <div *ngFor="let data of detectorDataLocalCopy.dataset  | renderfilter:isAnalysisView"
     [ngClass]="{'dynamic-data-container': !isRiskAlertDetector}">
     <dynamic-data [isRiskAlertDetector]="isRiskAlertDetector" [isAnalysisView]="isAnalysisView" [diagnosticData]="data"
@@ -69,7 +69,7 @@
 
 <cxp-chat-launcher *ngIf="showChatButton()" [trackingId]="cxpChatTrackingId" [chatUrl]="cxpChatUrl"
   [supportTopicId]="supportTopicId"></cxp-chat-launcher>
-<loader-detector-view style="margin-top:300px" *ngIf="!detectorDataLocalCopy && !errorState"></loader-detector-view>
+<loader-detector-view style="margin-top:300px" *ngIf="true"></loader-detector-view>
 
 <ng-container *ngIf="!detectorDataLocalCopy && errorState">
   <div class="mt-3">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.html
@@ -1,4 +1,4 @@
-<div class="loader-container">
+<div *ngIf="!isTimeout;else loaderTimeout" class="loader-container">
   <div class="fxs-progress">
     <div class="fxs-progress-image">
       <img [src]=imgSrc />
@@ -6,3 +6,7 @@
     <fab-spinner [label]="loadingString"></fab-spinner>
   </div>
 </div>
+
+<ng-template #loaderTimeout>
+  <div class="critical-color">Sorry, an error occurred. Please refresh the page and try again.</div>
+</ng-template>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { DiagnosticDataConfig, DIAGNOSTIC_DATA_CONFIG } from '../../config/diagnostic-data-config';
 import { TelemetryEventNames } from '../../services/telemetry/telemetry.common';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { Guid } from '../../utilities/guid';
@@ -18,6 +19,7 @@ export class LoaderDetectorViewComponent implements OnInit {
     @Input() LoadingMessage2: string;
     @Input() LoadingMessage3: string;
     @Input() LoadingMessage4: string;
+    @Input() Source: string;
     message: string = "loading detector view";
     imgSrc: string = "assets/img/loading-detector-view/fetching_logs.svg";
     loadingString: string = "Fetching properties and logs ...";
@@ -28,6 +30,7 @@ export class LoaderDetectorViewComponent implements OnInit {
     endLoadingTimeInMilliSeconds: any;
     duration: any;
     trackingEventId: any;
+    isPublic: boolean = false;
 
     isTimeout: boolean = false;
     timeoutTimer: any = null;
@@ -56,7 +59,8 @@ export class LoaderDetectorViewComponent implements OnInit {
         }
     ];
 
-    constructor(private telemetryService: TelemetryService) {
+    constructor(private telemetryService: TelemetryService, @Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
+        this.isPublic = config?.isPublic;
     }
 
 
@@ -117,7 +121,8 @@ export class LoaderDetectorViewComponent implements OnInit {
         this.timeoutTimer = setTimeout(() => {
             this.isTimeout = true;
             this.telemetryService.logEvent(TelemetryEventNames.LoadingTimeOut, {
-                Source: ""
+                source: this.Source,
+                isPublic: `${this.isPublic}`
             });
         }, this.timeoutInMS * 1000);
     }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/loader-detector-view/loader-detector-view.component.ts
@@ -29,6 +29,10 @@ export class LoaderDetectorViewComponent implements OnInit {
     duration: any;
     trackingEventId: any;
 
+    isTimeout: boolean = false;
+    timeoutTimer: any = null;
+    readonly timeoutInMS: number = 120 * 1000;
+
     loadingStages: LoadingStage[] = [
         {
             duration: 2000,
@@ -55,13 +59,14 @@ export class LoaderDetectorViewComponent implements OnInit {
     constructor(private telemetryService: TelemetryService) {
     }
 
-    
+
     ngOnInit() {
         this.trackingEventId = Guid.newGuid();
-        if (this.LoadingMessage1 || this.LoadingMessage2 || this.LoadingMessage3 || this.LoadingMessage4){
+        if (this.LoadingMessage1 || this.LoadingMessage2 || this.LoadingMessage3 || this.LoadingMessage4) {
             this.customLoadingMessages();
         }
         this.loading();
+        this.checkLoadingTimeout();
     }
 
     // This is the loading function for each stage. We set a random time out for each stage.
@@ -91,6 +96,8 @@ export class LoaderDetectorViewComponent implements OnInit {
         let endLoadingTimeISOString = new Date().toISOString();
         this.duration = this.endLoadingTimeInMilliSeconds - this.startLoadingTimeInMilliSeconds;
         this.telemetryService.logEvent(TelemetryEventNames.LoadingDetectorViewEnded, { "TrackingEventId": this.trackingEventId, "EndLoadingTime": endLoadingTimeISOString, "Duration": this.duration });
+
+        window.clearTimeout(this.timeoutTimer);
     }
 
     ngAfterViewInit() {
@@ -103,6 +110,16 @@ export class LoaderDetectorViewComponent implements OnInit {
         this.loadingStages[1].loadingString = this.LoadingMessage2 != undefined ? this.LoadingMessage2 : this.loadingStages[1].loadingString;
         this.loadingStages[2].loadingString = this.LoadingMessage3 != undefined ? this.LoadingMessage3 : this.loadingStages[2].loadingString;
         this.loadingStages[3].loadingString = this.LoadingMessage4 != undefined ? this.LoadingMessage4 : this.loadingStages[3].loadingString;
+    }
+
+    checkLoadingTimeout() {
+        this.isTimeout = false;
+        this.timeoutTimer = setTimeout(() => {
+            this.isTimeout = true;
+            this.telemetryService.logEvent(TelemetryEventNames.LoadingTimeOut, {
+                Source: ""
+            });
+        }, this.timeoutInMS * 1000);
     }
 }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/solution-orchestrator/solution-orchestrator.component.html
@@ -68,7 +68,7 @@
         </div>
       </div>
       <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="(fetchingDetectors || getPendingDetectorCount() > 0) && !showSolutionsTimedout">
-        <loader-detector-view></loader-detector-view>
+        <loader-detector-view [Source]="'SolutionOrchestrator'"></loader-detector-view>
       </div>
       <div style="width: 60%;margin: 15px 20%;min-width: 300px;background-color: white;" *ngIf="!fetchingDetectors && (((getPendingDetectorCount() === 0) && (!topLevelSolutions || topLevelSolutions.length==0)) || showSolutionsTimedout)">
         <!--<div class="support-doc-section">

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -122,7 +122,8 @@ export const TelemetryEventNames = {
     ChatGPTRequestError: 'ChatGPTRequestError',
     ChatGPTUserQuotaExceeded: 'ChatGPTUserQuotaExceeded',
     ChatGPTTooManyRequestsError: 'ChatGPTTooManyRequestsError',
-    LoadingTimeOut: 'LoadingTimeOut'
+    LoadingTimeOut: 'LoadingTimeOut',
+    EmptySearchTerm: 'EmptySearchTerm'
 };
 
 export const TelemetrySource = {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -121,7 +121,8 @@ export const TelemetryEventNames = {
     ChatGPTCheckMessageCount: 'ChatGPTCheckMessageCount',
     ChatGPTRequestError: 'ChatGPTRequestError',
     ChatGPTUserQuotaExceeded: 'ChatGPTUserQuotaExceeded',
-    ChatGPTTooManyRequestsError: 'ChatGPTTooManyRequestsError'
+    ChatGPTTooManyRequestsError: 'ChatGPTTooManyRequestsError',
+    LoadingTimeOut: 'LoadingTimeOut'
 };
 
 export const TelemetrySource = {


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

- Adding message for loader timeout(120s) and logging "LoadingTimeOut" event for alert
- Adding logging "EmptySearchTerm" when searching term is empty


## Related Work Item
<!--- Please provide the work item number as well as its link: -->
[Failover mechanism: Display Shield search bar requesting a customer input  ](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2954)
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Screenshots After Fix (if appropriate):
After 120s timeout, will show an exception message rather than keep showing loader

![image](https://user-images.githubusercontent.com/23129934/225112530-3360c3ae-cc66-4688-a6e5-da754ecf5629.png)


