### PR TITLE
Kusto node related workflow changes and enabling Workflow view experience for everyone

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
@@ -68,8 +68,7 @@ export class SideNavComponent implements OnInit {
     private _diagnosticApiService: ApplensDiagnosticService, public resourceService: ResourceService, private _telemetryService: TelemetryService,
     private _userSettingService: UserSettingService, private breadcrumbService: BreadcrumbService, private _diagnosticApi: DiagnosticApiService,
     private _documentationService: ApplensDocumentationService,
-    private _openAIService: ApplensOpenAIChatService)
-  {
+    private _openAIService: ApplensOpenAIChatService) {
     this.contentHeight = (window.innerHeight - 139) + 'px';
     if (environment.adal.enabled) {
       let alias = this._adalService.userInfo.profile ? this._adalService.userInfo.profile.upn : '';
@@ -101,7 +100,7 @@ export class SideNavComponent implements OnInit {
       isSelected: null,
       icon: null
     }];
-  
+
   chatgpt: CollapsibleMenuItem[] = [
     {
       label: 'ChatGPT',
@@ -164,7 +163,7 @@ export class SideNavComponent implements OnInit {
       expanded: false,
       subItems: null,
       isSelected: () => {
-        return this.currentRoutePath && (this.currentRoutePath.join('/').toLowerCase().indexOf('deployments') > 0 );
+        return this.currentRoutePath && (this.currentRoutePath.join('/').toLowerCase().indexOf('deployments') > 0);
       },
       icon: null
     }
@@ -203,29 +202,25 @@ export class SideNavComponent implements OnInit {
     });
     this.initializeFavoriteDetectors();
 
-    this._diagnosticApiService.isUserAllowedForWorkflow(this.userId).subscribe(resp => {
-      if (resp) {
-        this.workflowsEnabled = this.resourceService.workflowsEnabled;
-        if (this.workflowsEnabled) {
-          this.initializeWorkflows();
-          this.createNew.push(
-            {
-              label: 'New Workflow',
-              id: "",
-              onClick: () => {
-                this.navigateTo('createWorkflow');
-              },
-              expanded: false,
-              subItems: null,
-              isSelected: () => {
-                return this.currentRoutePath && this.currentRoutePath.join('/').toLowerCase() === `createWorkflow`.toLowerCase();
-              },
-              icon: null
-            }
-          );
+    this.workflowsEnabled = this.resourceService.workflowsEnabled;
+    if (this.workflowsEnabled) {
+      this.initializeWorkflows();
+      this.createNew.push(
+        {
+          label: 'New Workflow',
+          id: "",
+          onClick: () => {
+            this.navigateTo('createWorkflow');
+          },
+          expanded: false,
+          subItems: null,
+          isSelected: () => {
+            return this.currentRoutePath && this.currentRoutePath.join('/').toLowerCase() === `createWorkflow`.toLowerCase();
+          },
+          icon: null
         }
-      }
-    });
+      );
+    }
 
   }
 
@@ -233,7 +228,7 @@ export class SideNavComponent implements OnInit {
     this.navigateTo("overview");
   }
 
-  navigateToChatGPT(){
+  navigateToChatGPT() {
     this.navigateTo("chatgpt");
   }
 

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
@@ -6,7 +6,7 @@ import { NgFlowchart, NgFlowchartCanvasDirective, NgFlowchartStepRegistry } from
 import { DetectorNodeComponent } from '../detector-node/detector-node.component';
 import { KustoNodeComponent } from '../kusto-node/kusto-node.component';
 import { MarkdownNodeComponent } from '../markdown-node/markdown-node.component';
-import { nodeType, workflow, workflowNode, workflowNodeData, workflowPublishBody } from 'projects/diagnostic-data/src/lib/models/workflow';
+import { kustoNode, nodeType, workflow, workflowNode, workflowNodeData, workflowPublishBody } from 'projects/diagnostic-data/src/lib/models/workflow';
 import { IfElseConditionStepComponent } from '../ifelse-condition-step/ifelse-condition-step.component';
 import { ConditionIffalseStepComponent } from '../condition-iffalse-step/condition-iffalse-step.component';
 import { ConditionIftrueStepComponent } from '../condition-iftrue-step/condition-iftrue-step.component';
@@ -189,8 +189,37 @@ export class CreateWorkflowComponent implements OnInit, AfterViewInit {
       return null;
     }
 
-    this.publishBody.WorkflowJson = this.canvas.getFlow().toJSON(4);
+    let workflowJson = this.canvas.getFlow().toJSON(4);
+    this.publishBody.WorkflowJson = this.updateJsonToLatestSchema(workflowJson)
     return this.publishBody;
+  }
+
+  //
+  // This is added to ensure that queryText property moves to 
+  // data.kustoNode instead of data.queryText. Will remove this change
+  // after updating all the published workflows.
+  //
+
+  updateJsonToLatestSchema(json: string): string {
+    let workflowObject: workflow = JSON.parse(json);
+    this.updateNode(workflowObject.root);
+    return JSON.stringify(workflowObject, null, 4);
+  }
+
+  updateNode(node: workflowNode) {
+    if (node.type === 'kustoQuery') {
+      if (node.data.kustoNode == null) {
+        node.data.kustoNode = new kustoNode();
+      }
+      if (!node.data.kustoNode.queryText) {
+        node.data.kustoNode.queryText = node.data.queryText;
+        delete node.data['queryText'];
+      }
+    }
+
+    if (node.children && node.children.length > 0) {
+      node.children.forEach(child => this.updateNode(child));
+    }
   }
 
   validateWorkflow(): boolean {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.html
@@ -47,6 +47,10 @@
           <option>ine</option>
           <option>contains</option>
           <option>icontains</option>
+          <option>startswith</option>
+          <option>istartswith</option>
+          <option>endswith</option>
+          <option>iendswith</option>
         </select>
 
         <select class="ml-2 form-select" *ngIf="dataType === 'sbyte' || dataType === 'boolean'">
@@ -55,8 +59,8 @@
 
         <form *ngIf="dataType !=='sbyte' && dataType !=='boolean'" class="example-form">
           <mat-form-field class="example-full-width" appearance="fill">
-            <mat-label class="matlabel">Variable</mat-label>
-            <input type="text" placeholder="Choose a variable" aria-label="Number" id="rightControl" matInput
+            <mat-label class="matlabel">Value</mat-label>
+            <input type="text" placeholder="Choose a variable or type a static value" aria-label="Number" id="rightControl" matInput
               [formControl]="rightControl" [matAutocomplete]="autoRight"
               (input)="updateVariable($event.target.value, 'ifconditionRightValue')">
             <mat-autocomplete autoActiveFirstOption #autoRight="matAutocomplete"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.scss
@@ -4,7 +4,7 @@
 
 select {
     height: 45px;
-    width: 70px;
+    width: 90px;
 }
 
 .example-form {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { promptType, stepVariable, workflowNodeData } from 'projects/diagnostic-data/src/lib/models/workflow';
-import {  NgFlowchartStepComponent } from 'projects/ng-flowchart/dist';
+import { kustoNode, promptType, stepVariable, workflowNodeData } from 'projects/diagnostic-data/src/lib/models/workflow';
+import { NgFlowchartStepComponent } from 'projects/ng-flowchart/dist';
 import { ConfigureVariablesComponent } from '../configure-variables/configure-variables.component';
 import { KustoQueryDialogComponent } from '../kusto-query-dialog/kusto-query-dialog.component';
 import { kustoQueryDialogParams } from '../models/kusto';
@@ -37,19 +37,23 @@ export class KustoNodeComponent extends WorkflowNodeBaseClass implements OnInit 
   configureKustoQuery() {
     const dialogConfig = this.getNewMatDialogConfig();
     let dialogParams: kustoQueryDialogParams = new kustoQueryDialogParams();
-    dialogParams.queryText = this.data.queryText !== '' ? this._workflowServicePrivate.decodeBase64String(this.data.queryText) : this.defaultQueryText;
+    let queryText = this._workflowServicePrivate.getQueryText(this.data);
+    dialogParams.queryText = queryText !== '' ? this._workflowServicePrivate.decodeBase64String(queryText) : this.defaultQueryText;
     dialogParams.queryLabel = this.data.name;
     dialogParams.variables = this.data.variables;
     dialogParams.kustoQueryColumns = this.data.kustoQueryColumns;
     dialogParams.completionOptions = this._workflowServicePrivate.getVariableCompletionOptions(this, false);
     dialogParams.currentNode = this.getCurrentNode();
+    dialogParams.addQueryOutputToMarkdown = this.data.kustoNode.addQueryOutputToMarkdown;
 
     dialogConfig.data = dialogParams;
     this.matDialog.open(KustoQueryDialogComponent, dialogConfig).afterClosed().subscribe(modelData => {
       if (modelData != null) {
         this.variables = modelData.variables;
         this.data.name = modelData.queryLabel;
-        this.data.queryText = modelData.queryText;
+        this.data.kustoNode = new kustoNode();
+        this.data.kustoNode.queryText = modelData.queryText;
+        this.data.kustoNode.addQueryOutputToMarkdown = modelData.addQueryOutputToMarkdown
         this.data.variables = this.variables;
         this.data.kustoQueryColumns = modelData.kustoQueryColumns;
         this._workflowServicePrivate.emitVariablesChange(true);

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
@@ -44,7 +44,9 @@ export class KustoNodeComponent extends WorkflowNodeBaseClass implements OnInit 
     dialogParams.kustoQueryColumns = this.data.kustoQueryColumns;
     dialogParams.completionOptions = this._workflowServicePrivate.getVariableCompletionOptions(this, false);
     dialogParams.currentNode = this.getCurrentNode();
-    dialogParams.addQueryOutputToMarkdown = this.data.kustoNode.addQueryOutputToMarkdown;
+    if (this.data.kustoNode && this.data.kustoNode.addQueryOutputToMarkdown){
+      dialogParams.addQueryOutputToMarkdown = true;
+    }
 
     dialogConfig.data = dialogParams;
     this.matDialog.open(KustoQueryDialogComponent, dialogConfig).afterClosed().subscribe(modelData => {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.html
@@ -87,6 +87,19 @@
         </div>
       </div>
     </div>
+    <div class="row mb-2 mt-2">
+      <div class="col-sm-2">
+        <label class="form-label">Add query output to markdown</label>
+      </div>
+      <div class="col-sm-10">
+        <div>
+          <label class="checkbox-inline">
+            <input [(ngModel)]="inputKustoQueryDialogParams.addQueryOutputToMarkdown" id="addQueryOutputToMarkdown"
+              name="chkaddQueryOutputToMarkdown" type="checkbox" /> (Check this checkbox if you want to append the query
+            output as an HTML table to the markdown) </label>
+        </div>
+      </div>
+    </div>
     <div class="row mb-2 mt-5">
       <div class="col-sm-2">
         <label class="form-label">Configure Variables</label>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-query-dialog/kusto-query-dialog.component.ts
@@ -76,7 +76,8 @@ export class KustoQueryDialogComponent implements OnInit {
       queryLabel: this.kustoQueryLabel,
       kustoQueryColumns: this.kustoQueryColumns,
       completionOptions: this.inputKustoQueryDialogParams.completionOptions,
-      currentNode: null
+      currentNode: null,
+      addQueryOutputToMarkdown: this.inputKustoQueryDialogParams.addQueryOutputToMarkdown,
     };
 
     this.dialogRef.close(dialogResult);

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/models/kusto.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/models/kusto.ts
@@ -8,6 +8,7 @@ export class kustoQueryDialogParams {
   kustoQueryColumns: DataTableResponseColumn[];
   completionOptions: stepVariable[] = [];
   currentNode: NgFlowchartStepComponent<workflowNodeData>;
+  addQueryOutputToMarkdown: boolean;
 }
 
 export interface dynamicExpressionBody {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/models/kusto.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/models/kusto.ts
@@ -8,7 +8,7 @@ export class kustoQueryDialogParams {
   kustoQueryColumns: DataTableResponseColumn[];
   completionOptions: stepVariable[] = [];
   currentNode: NgFlowchartStepComponent<workflowNodeData>;
-  addQueryOutputToMarkdown: boolean;
+  addQueryOutputToMarkdown: boolean = false;
 }
 
 export interface dynamicExpressionBody {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-styles.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-styles.scss
@@ -27,3 +27,7 @@ select {
     background-color: var(--bodyBackground);
     color: var(--inputText);
 }
+
+::ng-deep .mat-form-field-appearance-fill ::ng-deep .mat-form-field-flex {
+    background-color: var(--bodyBackground);
+}

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
@@ -501,6 +501,16 @@ export class WorkflowService {
     swalWithBootstrapButtons.fire(title, message, 'error');
   }
 
+  showMessageBoxWithFooter(title: string, message: string, footer: string, width?: string) {
+    swalWithBootstrapButtons.fire({
+      icon: 'error',
+      title: title,
+      html: message,
+      footer: footer,
+      width: width
+    });
+  }
+
   isValidVariableName(variableName: string): boolean {
     const regexVarName = new RegExp('^[a-zA-Z_][a-zA-Z_0-9]*$');
     return regexVarName.test(variableName);

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
@@ -449,6 +449,18 @@ export class WorkflowService {
     return false;
   }
 
+  getQueryText(data: workflowNodeData): string {
+    if (data.queryText) {
+      return data.queryText;
+    }
+
+    if (data.kustoNode && data.kustoNode.queryText) {
+      return data.kustoNode.queryText
+    }
+
+    return '';
+  }
+
   isNodeUsingVariable(stepVariableName: string, node: NgFlowchartStepComponent<workflowNodeData>): boolean {
     if (node.data.markdownText.toLowerCase().indexOf(stepVariableName.toLocaleLowerCase()) > -1) {
       return true;
@@ -457,8 +469,8 @@ export class WorkflowService {
       return true;
     }
 
-    if (node.type === 'kustoQuery' && node.data.queryText) {
-      let queryPlainText = this.decodeBase64String(node.data.queryText);
+    if (node.type === 'kustoQuery' && this.getQueryText(node.data)) {
+      let queryPlainText = this.decodeBase64String(this.getQueryText(node.data));
       if (queryPlainText.indexOf(stepVariableName.toLocaleLowerCase()) > -1) {
         return true;
       }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.html
@@ -6,7 +6,7 @@
       </node-title>
     </div>
     <div class="panel-body">
-      <form>
+      <form class="example-form">
         <div class="form-group row">
           <div class="col-sm-12">
             <input class="form-control" type="text" name="switch-{{uniqueId}}" id="switch-{{uniqueId}}"

--- a/AngularApp/projects/applens/src/styles.scss
+++ b/AngularApp/projects/applens/src/styles.scss
@@ -312,3 +312,11 @@ markdown, .markdown {
   color: var(--bodyText);
   border: 1px solid;
 }
+
+//
+// For all message boxes launched for workflows
+//
+
+.swal2-html-container, .swal2-footer {
+  font-size: large !important;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
@@ -1,6 +1,7 @@
 .panel {
-  width: 400px;
   min-height: 100px;
+  min-width: 300px;
+  max-width: 550px;
   border-radius: 0px;
   border: 0px;
   border-radius: 0px;
@@ -36,9 +37,9 @@
 }
 
 .markdown-text {
-  inline-size: 380px;
   overflow-wrap: break-word;
   padding: 5px;
+  padding-right: 15px;
 }
 
 .run-button {

--- a/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
@@ -62,7 +62,7 @@ export class workflowNodeData {
   detectorId: string = '';
   isEditing: boolean = false;
   isEditingTitle: boolean = false;
-  queryText: string = '';
+  queryText?: string = '';
   kustoQueryColumns: DataTableResponseColumn[] = [];
   variables: stepVariable[] = [];
   markdownText: string = '';
@@ -77,6 +77,23 @@ export class workflowNodeData {
   switchCaseValue: string;
   foreachVariable: string;
   inputNode: inputNode = new inputNode();
+  kustoNode: kustoNode = new kustoNode();
+}
+
+export class kustoNode {
+  queryText: string = '';
+  kustoClusterName: string = '';
+  kustoClusterDataBase: string = '';
+  addQueryOutputToMarkdown: boolean = false;
+  slotMapConfiguration: slotMapConfiguration = new slotMapConfiguration()
+}
+
+export class slotMapConfiguration {
+  timeStampColumnName: string;
+  siteRuntimeNameColumnName: string;
+  finalColumnName: string;
+  aggregateColumnName: string;
+  runSlotMapOnQueryOutput: boolean = false;
 }
 
 export class inputNode {


### PR DESCRIPTION
## Overview

- With this PR, we are now enabling the Workflows View experience to all users and only restricting the workflow publishing.
- The other change is a checkbox that allows you to add DataTable output of Kusto Query to markdown.
- Increasing the size of the text in all alerts displayed by Workflow components.
- Apart from that, just changing the schema of workflowNodeData and moving all the Kusto related configuration in its own object. I have added model classes for SlotMapConfiguration but they are not used anywhere yet and will be working on those in the coming days.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots After Fix (if appropriate):

![image](https://user-images.githubusercontent.com/5299838/225863716-5ac65f0a-161b-479c-a80a-7760fc762853.png)

Then during actual run phase

![image](https://user-images.githubusercontent.com/5299838/225863888-99c1ed86-27d9-4beb-a621-0fa919291104.png)
