### PR TITLE
URL Encode the values in bing query object

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -102,9 +102,9 @@ export class ContentService {
     }
 
     const query = JSON.stringify({
-      queryText: `${questionString}${useStack ? stackTypeSuffix : ''}`,
-      productName: searchSuffix,
-      siteFilters: `${preferredSitesSuffix} AND ${excludedSitesSuffix}`
+      queryText: encodeURIComponent(`${questionString}${useStack ? stackTypeSuffix : ''}`),
+      productName: encodeURIComponent(searchSuffix),
+      siteFilters: encodeURIComponent(`${preferredSitesSuffix} AND ${excludedSitesSuffix}`)
     });
     return query;
   }


### PR DESCRIPTION
## Overview
Fixes the issue where JSON deserialization fails due to double quote characters in input query for bing detector id.

## Related Work Item
We received a SEV 2 for this: https://portal.microsofticm.com/imp/v3/incidents/details/375755846/home

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.