### PR TITLE
Add monitoring script for checking blank screen

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
+++ b/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
@@ -80,6 +80,7 @@ class LoggingUtilities {
 function monitoring() {
     const shellSrc = LoggingUtilities.getQueryStringParameter("trustedAuthority");
     const logger = new Logging(shellSrc);
+    logger.postMessage("initializationcomplete",null);
     logger.logEvent(LoggingUtilities.startMonitoringIFrame,{});
     let timer = setTimeout(() => {
         const eles = document.getElementsByTagName("sc-app");

--- a/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
+++ b/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
@@ -1,0 +1,96 @@
+class Logging {
+    shellSrc = "";
+    constructor(shellSrc) {
+        this.shellSrc = shellSrc;
+    }
+
+    postMessage(verb, data) {
+        if (LoggingUtilities.inIFrame()) {
+            let dataString = data;
+            try {
+                var dataJsonObject = data === null ? {} : JSON.parse(data);
+                const dataObjectWithEventType = {
+                    signature: LoggingUtilities.iFrameSignature,
+                    eventType: verb,
+                    ...dataJsonObject,
+                }
+
+                dataString = JSON.stringify(dataObjectWithEventType);
+            }
+            catch (error) {
+            }
+
+            window.parent.postMessage({
+                signature: LoggingUtilities.portalSignature,
+                kind: verb,
+                data: dataString
+            }, this.shellSrc);
+        }
+    }
+
+    logAction(subcomponent, action, data) {
+        const actionStr = JSON.stringify({
+            subcomponent: subcomponent,
+            action: action,
+            data: data
+        });
+        this.postMessage(LoggingUtilities.logAction, actionStr);
+    }
+
+    logEvent(eventMessage, properties) {
+        const eventProp = {
+            ...properties,
+            'url': window.location.href
+        };
+        this.logAction('diagnostic-data', eventMessage, eventProp);
+    }
+}
+
+class LoggingUtilities {
+    static portalSignature = "FxFrameBlade";
+    static iFrameSignature = 'AppServiceDiagnosticsIFrame'
+    static logAction = "log-action";
+
+    static monitoringTimeout = 30;
+    static portalBlankPageEvent = "PortalBlankPage";
+
+    static inIFrame() {
+        return window.parent !== window;
+    }
+
+    static getQueryMap() {
+        const query = window.location.search.substring(1);
+        const parameterList = query.split('&');
+        const map = {};
+        for (let i = 0; i < parameterList.length; i++) {
+            const pair = parameterList[i].split('=');
+            map[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+        }
+
+        return map;
+    }
+
+    static getQueryStringParameter(name) {
+        return this.getQueryMap()[name] || '';
+    }
+}
+
+
+function monitoring() {
+    const shellSrc = LoggingUtilities.getQueryStringParameter("trustedAuthority");
+    const logger = new Logging(shellSrc);
+    setTimeout(() => {
+        const eles = document.getElementsByTagName("sc-app");
+        for (const ele of eles) {
+            if (ele.innerText.length === 0) {
+                logger.logEvent(LoggingUtilities.portalBlankPageEvent, {});
+            }
+        }
+    }, LoggingUtilities.monitoringTimeout * 1000);
+}
+
+monitoring();
+
+
+
+

--- a/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
+++ b/AngularApp/projects/app-service-diagnostics/src/assets/scripts/monitoring.js
@@ -53,6 +53,7 @@ class LoggingUtilities {
 
     static monitoringTimeout = 30;
     static portalBlankPageEvent = "PortalBlankPage";
+    static startMonitoringIFrame = "StartMonitoringIFrame";
 
     static inIFrame() {
         return window.parent !== window;
@@ -79,13 +80,15 @@ class LoggingUtilities {
 function monitoring() {
     const shellSrc = LoggingUtilities.getQueryStringParameter("trustedAuthority");
     const logger = new Logging(shellSrc);
-    setTimeout(() => {
+    logger.logEvent(LoggingUtilities.startMonitoringIFrame,{});
+    let timer = setTimeout(() => {
         const eles = document.getElementsByTagName("sc-app");
         for (const ele of eles) {
             if (ele.innerText.length === 0) {
                 logger.logEvent(LoggingUtilities.portalBlankPageEvent, {});
             }
         }
+        clearTimeout(timer);
     }, LoggingUtilities.monitoringTimeout * 1000);
 }
 

--- a/AngularApp/projects/app-service-diagnostics/src/index.html
+++ b/AngularApp/projects/app-service-diagnostics/src/index.html
@@ -11,6 +11,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css" />
 
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css" />
+
+    <script src="./assets/scripts/monitoring.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Overview
This PR is for adding monitoring.js script to monitoring blank screen issue for our Angular project 
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

## Related Work Item
<!--- Please provide the work item number as well as its link: -->
[WI 2953 Set up more alerts on the SCIFrame blade to catch scenarios when no detector is found, or no expected parameters are present](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2953)
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## Solution description
<!--- Describe your code changes in details for reviewers. -->

Added monitoring.js scrpit, it will be running once scripted ready. For checking <sc-app> which it a tag created by Angular to make sure our page is not blank. 

If it is a blank screen we will log "PortalBlankPage" event into Kusto table so to get alert based on this event



