### PR TITLE
Fix for null reference and cancel previous observable when switching between detectors

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/tabs/tab-data/tab-data.component.ts
@@ -167,6 +167,7 @@ export class TabDataComponent implements OnInit {
       this.detector = this._route.snapshot.params['detector'];
     }
 
+
     this._diagnosticApiService.getDetectorMetaDataById(this.detector, this.isWorkflowDetector).subscribe(metaData => {
       if (metaData) {
         this._applensGlobal.updateHeader(metaData.name);
@@ -184,21 +185,16 @@ export class TabDataComponent implements OnInit {
     // Detecting whether Download Report button should be displayed or not
     this.displayDownloadReportButton = this.detector === "ResiliencyScore" && (this.checkIsWindowsApp() || this.checkIsLinuxApp());
 
-    // Detecting whether Download Report button should be displayed or not
-    this.displayDownloadReportButton = this.detector === "ResiliencyScore" && (this.checkIsWindowsApp() || this.checkIsLinuxApp());
-
     // Logging telemetry for Download Report button
     const dRBDEventProperties = {
-      'ResiliencyScoreButtonDisplayed': this.displayDownloadReportButton.toString(),
+      'ResiliencyScoreButtonDisplayed': `${this.displayDownloadReportButton}`,
       'Subscription': this._route.parent.snapshot.params['subscriptionid'],
-      'Platform': this.siteSku.is_linux != undefined ? !this.siteSku.is_linux ? "Windows" : "Linux" : "",
-      'AppType': this.siteSku.kind != undefined ? this.siteSku.kind.toLowerCase() === "app" ? "WebApp" : this.siteSku.kind.toString() : "",
-      'resourceSku': this.siteSku.sku != undefined ? this.siteSku.sku.toString() : "",
+      'Platform': this.siteSku?.is_linux != undefined ? !this.siteSku.is_linux ? "Windows" : "Linux" : "",
+      'AppType': this.siteSku?.kind != undefined ? `${this.siteSku.kind}`.toLowerCase() === "app" ? "WebApp" : `${this.siteSku.kind}` : "",
+      'resourceSku': this.siteSku?.sku != undefined ? `${this.siteSku.sku}` : "",
       'ReportType': 'ResiliencyScore',
     };
     this._telemetryService.logEvent(TelemetryEventNames.DownloadReportButtonDisplayed, dRBDEventProperties);
-    const loggingError = new Error();
-
   }
 
   refreshPage() {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -3,7 +3,7 @@ import { DiagnosticService } from '../../services/diagnostic.service';
 import { DetectorControlService } from '../../services/detector-control.service';
 import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { DetectorResponse, RenderingType, DownTime } from '../../models/detector';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { VersionService } from '../../services/version.service';
 import { Moment } from 'moment';
 import * as momentNs from 'moment';
@@ -11,6 +11,7 @@ import { XAxisSelection, zoomBehaviors } from '../../models/time-series';
 import { DIAGNOSTIC_DATA_CONFIG, DiagnosticDataConfig } from '../../config/diagnostic-data-config';
 import { Inject } from '@angular/core';
 import { FeatureNavigationService } from '../../services/feature-navigation.service';
+import { takeUntil, tap } from 'rxjs/operators';
 const moment = momentNs;
 
 const hideTimePickerDetectors: string[] = [
@@ -45,11 +46,21 @@ export class DetectorContainerComponent implements OnInit {
   refreshInstanceIdSubscription: any;
   isPublic: boolean = true;
   workflowLastRefreshed: string = '';
+  detectorResponseObservable:Observable<DetectorResponse>;
+  stopDetectorResponseSubject: Subject<boolean> = new Subject();
 
-  @Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+  //@Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
   @Input() set detector(detector: string) {
-    this.detectorSubject.next(detector);
+    //this.detectorSubject.next(detector);
+    if (detector && detector !== "searchResultsAnalysis") {
+      this.detectorName = detector;
+      this.refresh(false);
+    }
+    //For now hard code detectors which are not show time picker, next step is to read it from detector definition
+    if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
+      this.hideDetectorControl = true;
+    }
   }
 
   @Input() analysisMode: boolean = false;
@@ -116,18 +127,7 @@ export class DetectorContainerComponent implements OnInit {
       }
     });
 
-    this.detectorSubject.subscribe(detector => {
-      if (detector && detector !== "searchResultsAnalysis") {
-        this.detectorName = detector;
-        this.refresh(false);
-      }
 
-
-      //For now hard code detectors which are not show time picker, next step is to read it from detector definition
-      if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
-        this.hideDetectorControl = true;
-      }
-    });
 
     const component: any = this._route.component;
 
@@ -155,6 +155,19 @@ export class DetectorContainerComponent implements OnInit {
       }
       this.featureNavigationService.lastIsAnalysisView = !!param["analysisId"];
     });
+
+    // this.detectorSubject.subscribe(detector => {
+    //   if (detector && detector !== "searchResultsAnalysis") {
+    //     this.detectorName = detector;
+    //     this.refresh(false);
+    //   }
+
+
+    //   //For now hard code detectors which are not show time picker, next step is to read it from detector definition
+    //   if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
+    //     this.hideDetectorControl = true;
+    //   }
+    // });
   }
 
   refresh(hardRefresh: boolean) {
@@ -255,13 +268,20 @@ export class DetectorContainerComponent implements OnInit {
 
       this.workflowLastRefreshed = Date.now().toString();
     } else {
-      this._diagnosticService.getDetector(this.detectorName, startTime, endTime,
-        invalidateCache, this.detectorControlService.isInternalView, additionalQueryString)
-        .subscribe((response: DetectorResponse) => {
+      if(this.detectorResponseObservable) {
+        //Stop previous subscribe
+        this.stopDetectorResponseSubject.next(true);
+      }
+
+      this.stopDetectorResponseSubject = new Subject<boolean>();
+      this.detectorResponseObservable = this._diagnosticService.getDetector(this.detectorName, startTime, endTime,invalidateCache, this.detectorControlService.isInternalView, additionalQueryString).pipe(takeUntil(this.stopDetectorResponseSubject));
+      this.detectorResponseObservable.subscribe((response: DetectorResponse) => {
           this.shouldHideTimePicker(response);
           this.detectorResponse = response;
         }, (error: any) => {
           this.error = error;
+        },() => {
+          // console.log(`Complete, ${this.detectorName}. Detector Response is ${this.detectorResponse === null && this.error === null ? "cancelled" : "have content"}`);
         });
     }
   }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -49,8 +49,6 @@ export class DetectorContainerComponent implements OnInit {
   detectorResponseObservable:Observable<DetectorResponse>;
   stopDetectorResponseSubject: Subject<boolean> = new Subject();
 
-  //@Input() detectorSubject: BehaviorSubject<string> = new BehaviorSubject<string>(null);
-
   @Input() set detector(detector: string) {
     //this.detectorSubject.next(detector);
     if (detector && detector !== "searchResultsAnalysis") {
@@ -155,19 +153,6 @@ export class DetectorContainerComponent implements OnInit {
       }
       this.featureNavigationService.lastIsAnalysisView = !!param["analysisId"];
     });
-
-    // this.detectorSubject.subscribe(detector => {
-    //   if (detector && detector !== "searchResultsAnalysis") {
-    //     this.detectorName = detector;
-    //     this.refresh(false);
-    //   }
-
-
-    //   //For now hard code detectors which are not show time picker, next step is to read it from detector definition
-    //   if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
-    //     this.hideDetectorControl = true;
-    //   }
-    // });
   }
 
   refresh(hardRefresh: boolean) {
@@ -269,7 +254,7 @@ export class DetectorContainerComponent implements OnInit {
       this.workflowLastRefreshed = Date.now().toString();
     } else {
       if(this.detectorResponseObservable) {
-        //Stop previous subscribe
+        //Stop previous subscribe by emitting any value
         this.stopDetectorResponseSubject.next(true);
       }
 
@@ -280,8 +265,6 @@ export class DetectorContainerComponent implements OnInit {
           this.detectorResponse = response;
         }, (error: any) => {
           this.error = error;
-        },() => {
-          // console.log(`Complete, ${this.detectorName}. Detector Response is ${this.detectorResponse === null && this.error === null ? "cancelled" : "have content"}`);
         });
     }
   }


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

This PR is mainly for fixing two issues for switching detectors in Applens side-nav
1. Switching between detectors is slow and stick with last detector in some cases.
2. Non-web app side nav is not working between switching detectors.


## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Solution description
For # 1 Switching between detectors is slow and stick with last detector in some cases,

I use [takeUntil](https://rxjs.dev/api/operators/takeUntil) operator to cancel previous observable by emitting a new value for  **stopDetectorResponseSubject** and switch to new Observable

For # 2 Non-web app side nav is not working between switching detectors,

Me and Nazeef look into and found in <tab-data> component there are null reference for logging, by fixing this side-nav back to work.


## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

Go to any non-web resource, like /subscriptions/34c84213-fd6e-466e-a62d-8374b761fcb9/resourceGroups/infra-central-rg/providers/Microsoft.ContainerService/managedClusters/infra-central-k8s

Click any detector in left side nav and switch between detectors in side-nav and see if left menu works

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
Huge thanks to Nazeef for help me debugging this issue !
