### PR TITLE
Ask the backend about case enforcement enabled RPs

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.html
@@ -18,7 +18,7 @@
       </div>
       <div style="width: 50%;">
         <div class="section"
-        *ngIf="caseNumberNeededForProduct || (caseNumberNeededForUser && (selectedResourceType && selectedResourceType.userAuthorizationEnabled))">
+        *ngIf="caseNumberNeededForProduct || (caseNumberNeededForUser && caseNumberNeededForRP)">
           <fab-text-field [ariaLabel]="'Customer case number'" [defaultValue]="caseNumber" (onChange)="updateCaseNumber($event)"
             [placeholder]="caseNumberPlaceholder" [label]="'Case Number'" [required]="true"
             [styles]="fabTextFieldStyles">

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -43,6 +43,8 @@ export class MainComponent implements OnInit {
   loaderSize = SpinnerSize.large;
   caseNumberNeededForUser: boolean = false;
   caseNumberNeededForProduct: boolean = false;
+  caseNumberNeededForRP: boolean = false;
+  caseNumberEnabledRPs: string[] = [];
   caseNumber: string = '';
   caseNumberValidationError: string = null;
   accessErrorMessage: string = '';
@@ -128,6 +130,7 @@ export class MainComponent implements OnInit {
       if (this.selectedResourceType.resourceType == "ARMResourceId") {
         this.resourceName = this._activatedRoute.snapshot.queryParams['resourceId'];
       }
+      this.hasResourceCaseNumberEnforced();
     }
   }
 
@@ -150,6 +153,54 @@ export class MainComponent implements OnInit {
     }
   }
 
+  fetchCaseNumberEnforcedRpList(){
+    this.displayLoader = true;
+    this._diagnosticApiService.FetchCaseEnabledResourceProviders().subscribe(res => {
+      this.displayLoader = false;
+      if (res && res.length>0) {
+        this.caseNumberEnabledRPs = res.split(",").map(x => x.toLowerCase());
+      }
+      this.hasResourceCaseNumberEnforced();
+    },
+    (err) => {
+      //This failure is critical, we will choose to show an error and request the user to try again
+      this.userAccessErrorMessage = "Failed to fetch case number enforcement information. Please try again. If the error persists, contact AppLens team.";
+      this.displayUserAccessError = true;
+      this.displayLoader = false;
+    });
+  }
+
+  //Checks if RP has case number enforcement e.g. microsoft.web/sites
+  hasRPCaseNumberEnforced(rpName) {
+    rpName = rpName.toLowerCase();
+    return this.caseNumberEnabledRPs.indexOf(rpName)>= 0;
+  }
+
+  extractRPInfoFromARMUri(armUri) {
+    const resourceUriPattern = /subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/([a-zA-Z\.]+)\/([a-zA-Z\.]+)\//i;
+    if (armUri && armUri.length>0) {
+      const match = armUri.match(resourceUriPattern);
+      return `${match[3]}/${match[4]}`;
+    }
+    else {
+      return "";
+    }
+  }
+
+  hasResourceCaseNumberEnforced() {
+    if (this.selectedResourceType.resourceType != null) {
+      if (this.selectedResourceType.resourceType.toLowerCase() == "armresourceid") {
+        this.caseNumberNeededForRP = this.hasRPCaseNumberEnforced(this.extractRPInfoFromARMUri(this.resourceName));
+      }
+      else {
+        this.caseNumberNeededForRP = this.hasRPCaseNumberEnforced(this.selectedResourceType.resourceType);
+      }
+    }
+    else {
+      this.caseNumberNeededForRP = false;
+    }
+  }
+
   fetchUserDetails() {
     this.displayLoader = true;
     this.userAccessErrorMessage = '';
@@ -157,6 +208,7 @@ export class MainComponent implements OnInit {
     this._diagnosticApiService.checkUserAccess().subscribe(res => {
       if (res && res.Status == UserAccessStatus.CaseNumberNeeded) {
         this.caseNumberNeededForUser = true;
+        this.fetchCaseNumberEnforcedRpList();
         this._diagnosticApiService.setCaseNumberNeededForUser(this.caseNumberNeededForUser);
         this.displayLoader = false;
       }
@@ -190,6 +242,7 @@ export class MainComponent implements OnInit {
     this.resourceTypes = [...this.defaultResourceTypes];
     if (!this.selectedResourceType) {
       this.selectedResourceType = this.defaultResourceTypes[0];
+      this.hasResourceCaseNumberEnforced();
     }
 
     this.defaultResourceTypes.forEach(resource => {
@@ -208,6 +261,7 @@ export class MainComponent implements OnInit {
 
       if (!(this.accessErrorMessage && this.accessErrorMessage.length > 0 && this.selectedResourceType) && userInfo && userInfo.defaultServiceType && this.defaultResourceTypes.find(type => type.id.toLowerCase() === userInfo.defaultServiceType.toLowerCase())) {
         this.selectedResourceType = this.defaultResourceTypes.find(type => type.id.toLowerCase() === userInfo.defaultServiceType.toLowerCase());
+        this.hasResourceCaseNumberEnforced();
       }
     });
 
@@ -266,6 +320,7 @@ export class MainComponent implements OnInit {
   selectDropdownKey(e: { option: IDropdownOption, index: number }) {
     const resourceType = this.defaultResourceTypes.find(resource => resource.displayName === e.option.text);
     this.selectResourceType(resourceType);
+    this.hasResourceCaseNumberEnforced();
   }
 
   private normalizeArmUriForRoute(resourceURI: string, enabledResourceTypes: ResourceServiceInputs[]): string {
@@ -308,7 +363,7 @@ export class MainComponent implements OnInit {
 
   onSubmit() {
     this._userSettingService.updateDefaultServiceType(this.selectedResourceType.id);
-    if (!(this.caseNumber == "internal") && this.caseNumberNeededForUser && (this.selectedResourceType && this.selectedResourceType.userAuthorizationEnabled)) {
+    if (!(this.caseNumber == "internal") && this.caseNumberNeededForUser && (this.selectedResourceType && this.caseNumberNeededForRP)) {
       this.caseNumber = this.caseNumber.trim();
       if (!this.validateCaseNumber()) {
         return;
@@ -449,6 +504,7 @@ export class MainComponent implements OnInit {
 
   updateResourceName(e: { event: Event, newValue?: string }) {
     this.resourceName = e.newValue.toString();
+    this.hasResourceCaseNumberEnforced();
   }
 
   navigateToUnauthorized() {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -208,7 +208,13 @@ export class MainComponent implements OnInit {
     this._diagnosticApiService.checkUserAccess().subscribe(res => {
       if (res && res.Status == UserAccessStatus.CaseNumberNeeded) {
         this.caseNumberNeededForUser = true;
-        this.fetchCaseNumberEnforcedRpList();
+        if (res.EnforcedResourceProviders && res.EnforcedResourceProviders.length>0) {
+          this.caseNumberEnabledRPs = res.EnforcedResourceProviders.split(",").map(x => x.toLowerCase());
+          this.hasResourceCaseNumberEnforced();
+        }
+        else {
+          this.fetchCaseNumberEnforcedRpList();
+        }
         this._diagnosticApiService.setCaseNumberNeededForUser(this.caseNumberNeededForUser);
         this.displayLoader = false;
       }

--- a/AngularApp/projects/applens/src/app/shared/models/resources.ts
+++ b/AngularApp/projects/applens/src/app/shared/models/resources.ts
@@ -16,7 +16,6 @@ export interface ResourceTypeState {
     enabled: boolean;
     caseId: boolean;
     id: string;
-    userAuthorizationEnabled: boolean;
 }
 
 export interface ActivatedResource {
@@ -68,7 +67,6 @@ export interface ResourceServiceInputs {
     emergingIssuesICMLookupEnabled?: boolean;
     displayName?: string;
     overviewPageMetricsId?: string;
-    userAuthorizationEnabled: boolean;
     workflowsEnabled: boolean;
 }
 
@@ -86,6 +84,5 @@ export const DEFAULT_RESOURCE_SERVICE_INPUTS: ResourceServiceInputs = {
     sapProductId:'',
     staticSelfHelpContent: '',
     searchSuffix: 'AZURE',
-    userAuthorizationEnabled: false,
     workflowsEnabled: false
 };

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -53,6 +53,11 @@ export class DiagnosticApiService {
     return this.invoke<any>(path, HttpMethod.GET, null, true, false, true, false);
   }
 
+  public FetchCaseEnabledResourceProviders() {
+    let path = "internal/FetchCaseEnabledResourceProviders";
+    return this.invoke<any>(path, HttpMethod.GET, null, true, false, true, false);
+  }
+
   public unrelatedResourceConfirmation(resourceId: string) {
     let body = {
       caseNumber: this.CustomerCaseNumber,

--- a/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
+++ b/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
@@ -13,8 +13,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'App Service',
       enabled: true,
       caseId: false,
-      id: 'App Service',
-      userAuthorizationEnabled: true
+      id: 'App Service'
     },
     {
       resourceType: "Microsoft.Web/hostingEnvironments",
@@ -23,8 +22,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'App Service Environment',
       enabled: true,
       caseId: false,
-      id: 'App Service Environment',
-      userAuthorizationEnabled: false
+      id: 'App Service Environment'
     },
     {
       resourceType: "Microsoft.Web/containerApps",
@@ -33,8 +31,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'Container App',
       enabled: true,
       caseId: false,
-      id: 'Container App',
-      userAuthorizationEnabled: false
+      id: 'Container App'
     }, {
       resourceType: "Microsoft.Web/staticSites",
       resourceTypeLabel: 'Static App Name Or Default Host Name',
@@ -42,8 +39,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'Static Web App',
       enabled: true,
       caseId: false,
-      id: 'Static Web App',
-      userAuthorizationEnabled: false
+      id: 'Static Web App'
     },
     {
       resourceType: "Microsoft.Compute/virtualMachines",
@@ -52,8 +48,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'Virtual Machine',
       enabled: true,
       caseId: false,
-      id: 'Virtual Machine',
-      userAuthorizationEnabled: false
+      id: 'Virtual Machine'
     },
     {
       resourceType: "ARMResourceId",
@@ -62,8 +57,7 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'ARM Resource ID',
       enabled: true,
       caseId: false,
-      id: 'ARM Resource ID',
-      userAuthorizationEnabled: false
+      id: 'ARM Resource ID'
     },
     {
       resourceType: null,
@@ -72,7 +66,6 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       displayName: 'Internal Stamp',
       enabled: true,
       caseId: false,
-      id: 'Internal Stamp',
-      userAuthorizationEnabled: false
+      id: 'Internal Stamp'
     }
 ];

--- a/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
+++ b/AngularApp/projects/applens/src/assets/enabledResourceTypes.json
@@ -16,7 +16,6 @@
             "emergingIssuesICMLookupEnabled": false,
             "displayName": "App",
             "overviewPageMetricsId" : "applensoverviewmetrics_appservices",
-            "userAuthorizationEnabled": true,
             "workflowsEnabled": true
         },
         {


### PR DESCRIPTION
## Overview
Currently we rely on a config in frontend and a separate config in backend for Durian. Any sync issues between these configs can result in unwanted consequences. This PR aims to change this and make the frontend depend on backend (Runtimehost) config to check for which RPs, case number is enforced.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.