### PR TITLE
Enable Workflows on 'detector' routes only

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
@@ -1,53 +1,56 @@
-<div class="form-group row" [hidden]="true">
-  <button class="btn btn-sm btn-primary ml-2" (click)="showFlowData()">View Json</button>
+<div style="display: flex; flex-direction: column;">
+  <div class="form-group row" [hidden]="true">
+    <button class="btn btn-sm btn-primary ml-2" (click)="showFlowData()">View Json</button>
+  </div>
+
+  <form>
+    <div class="form-row">
+      <div class="form-group col-md-3">
+        <label for="workflowId">Id</label>
+        <input name="workflowId" class="form-control input-sm" placeholder="Workflow Id" [(ngModel)]="publishBody.Id">
+      </div>
+      <div class="form-group col-md-3">
+        <label for="workflowName">Name</label>
+        <input class="form-control input-sm" name="workflowName" placeholder="Workflow Name"
+          [(ngModel)]="publishBody.WorkflowName">
+      </div>
+      <div class="form-group col-md-3">
+        <label for="description">Description</label>
+        <input class="form-control  input-sm" name="description" placeholder="Workflow description"
+          [(ngModel)]="publishBody.Description">
+      </div>
+
+      <div class="form-group col-md-3">
+        <label for="workflowAuthor">Author</label>
+        <input class="form-control input-sm" name="workflowAuthor" placeholder="Enter your alias"
+          [(ngModel)]="publishBody.Author">
+      </div>
+
+    </div>
+    <div class="form-row">
+      <ng-container *ngIf="service === 'SiteService'">
+        <div class="form-group col-md-3">
+          <label for="appType">App Type</label>
+          <ng-select #selectAppType [items]="appTypes" [multiple]="true" (change)="onAppTypeChange($event)"
+            placeholder="Select App type">
+          </ng-select>
+        </div>
+        <div class="form-group col-md-3">
+          <label for="platformType">Platform Type</label>
+          <ng-select #selectPlatformType [items]="platformTypes" [multiple]="true"
+            (change)="onPlatformTypeChange($event)" placeholder="Select Platform type">
+          </ng-select>
+        </div>
+        <div class="form-group col-md-3">
+          <label for="stackType">Stack Type</label>
+          <ng-select #selectStackType [items]="stackTypes" [multiple]="true" (change)="onStackTypeChange($event)"
+            placeholder="Select Stack type">
+          </ng-select>
+        </div>
+      </ng-container>
+    </div>
+  </form>
+
+  <div id="canvas" ngFlowchartCanvas [ngFlowchartOptions]="options" [disabled]="disabled"
+    [ngFlowchartCallbacks]="callbacks"></div>
 </div>
-
-<form>
-  <div class="form-row">
-    <div class="form-group col-md-3">
-      <label for="workflowId">Id</label>
-      <input name="workflowId" class="form-control input-sm" placeholder="Workflow Id" [(ngModel)]="publishBody.Id">
-    </div>
-    <div class="form-group col-md-3">
-      <label for="workflowName">Name</label>
-      <input class="form-control input-sm" name="workflowName" placeholder="Workflow Name"
-        [(ngModel)]="publishBody.WorkflowName">
-    </div>
-    <div class="form-group col-md-3">
-      <label for="description">Description</label>
-      <input class="form-control  input-sm" name="description" placeholder="Workflow description"
-        [(ngModel)]="publishBody.Description">
-    </div>
-
-    <div class="form-group col-md-3">
-      <label for="workflowAuthor">Author</label>
-      <input class="form-control input-sm" name="workflowAuthor" placeholder="Enter your alias" [(ngModel)]="publishBody.Author">
-    </div>
-
-  </div>
-  <div class="form-row">
-    <ng-container *ngIf="service === 'SiteService'">
-      <div class="form-group col-md-3">
-        <label for="appType">App Type</label>
-        <ng-select #selectAppType [items]="appTypes" [multiple]="true" (change)="onAppTypeChange($event)"
-          placeholder="Select App type">
-        </ng-select>
-      </div>
-      <div class="form-group col-md-3">
-        <label for="platformType">Platform Type</label>
-        <ng-select #selectPlatformType [items]="platformTypes" [multiple]="true" (change)="onPlatformTypeChange($event)"
-          placeholder="Select Platform type">
-        </ng-select>
-      </div>
-      <div class="form-group col-md-3">
-        <label for="stackType">Stack Type</label>
-        <ng-select #selectStackType [items]="stackTypes" [multiple]="true" (change)="onStackTypeChange($event)"
-          placeholder="Select Stack type">
-        </ng-select>
-      </div>
-    </ng-container>
-  </div>
-</form>
-
-<div id="canvas" ngFlowchartCanvas [ngFlowchartOptions]="options" [disabled]="disabled"
-  [ngFlowchartCallbacks]="callbacks"></div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-accept-userinput/workflow-accept-userinput.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-accept-userinput/workflow-accept-userinput.component.ts
@@ -44,18 +44,18 @@ export class WorkflowAcceptUserinputComponent implements OnInit {
     let keyName = Object.keys(this.data.inputNodeSettings.variables)[0];
     switch (this.data.inputNodeSettings.inputType) {
       case inputType.text:
-        userInputs[keyName] = this.inputFieldValue;
+        userInputs[keyName] = encodeURIComponent(this.inputFieldValue);
         break;
       case inputType.date:
-        userInputs[keyName] = this.getDateTime(this.dateFieldValue, this.dateTimeField);
+        userInputs[keyName] = encodeURIComponent(this.getDateTime(this.dateFieldValue, this.dateTimeField));
         break;
       case inputType.select:
-        userInputs[keyName] = this.selectFieldValue;
+        userInputs[keyName] = encodeURIComponent(this.selectFieldValue);
         break;
       case inputType.daterange:
         let keyNameEndDate = Object.keys(this.data.inputNodeSettings.variables)[1];
-        userInputs[keyName] = this.getDateTime(this.startDateFieldValue, this.startTimeField);
-        userInputs[keyNameEndDate] = this.getDateTime(this.endDateFieldValue, this.endTimeField);
+        userInputs[keyName] = encodeURIComponent(this.getDateTime(this.startDateFieldValue, this.startTimeField));
+        userInputs[keyNameEndDate] = encodeURIComponent(this.getDateTime(this.endDateFieldValue, this.endTimeField));
         break;
 
       default:
@@ -88,10 +88,10 @@ export class WorkflowAcceptUserinputComponent implements OnInit {
     }
   }
 
-  getDateTime(date: Date, time: string) {
+  getDateTime(date: Date, time: string): string {
     let timeValues = time.split(":");
     let dateTime = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), parseInt(timeValues[0]), parseInt(timeValues[1]), 0, 0));
-    return dateTime
+    return dateTime.toISOString();
   }
 
   getErrorMessageOnTextField(value: string): string {


### PR DESCRIPTION
## Overview
To avoid making a change to our GeoMaster, we are enabling list workflow and execute workflow node on existing /detectors/ route only.

For workflows an additional parameter diagnosticEntityType=workflows will be passed in query string and backend will return detectors vs workflows based on this query parameter and other query parameters passed for executing workflow node Id.

After this change, we will not need to update GeoMaster code to enable Workflows in Diagnose and Solve.
