### PR TITLE
Revert change for detecotr-container

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-container/detector-container.component.ts
@@ -46,19 +46,12 @@ export class DetectorContainerComponent implements OnInit {
   refreshInstanceIdSubscription: any;
   isPublic: boolean = true;
   workflowLastRefreshed: string = '';
+  detectorSubject = new BehaviorSubject<string>(null);
   detectorResponseObservable:Observable<DetectorResponse>;
   stopDetectorResponseSubject: Subject<boolean> = new Subject();
 
   @Input() set detector(detector: string) {
-    //this.detectorSubject.next(detector);
-    if (detector && detector !== "searchResultsAnalysis") {
-      this.detectorName = detector;
-      this.refresh(false);
-    }
-    //For now hard code detectors which are not show time picker, next step is to read it from detector definition
-    if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
-      this.hideDetectorControl = true;
-    }
+    this.detectorSubject.next(detector);
   }
 
   @Input() analysisMode: boolean = false;
@@ -125,6 +118,18 @@ export class DetectorContainerComponent implements OnInit {
       }
     });
 
+    this.detectorSubject.subscribe(detector => {
+      if (detector && detector !== "searchResultsAnalysis") {
+        this.detectorName = detector;
+        this.refresh(false);
+      }
+
+
+      //For now hard code detectors which are not show time picker, next step is to read it from detector definition
+      if (detector && hideTimePickerDetectors.find(d => d.toLowerCase() === detector.toLowerCase())) {
+        this.hideDetectorControl = true;
+      }
+    });
 
 
     const component: any = this._route.component;


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
This PR is for reverting changes made in [PR 1967 Fix for null reference and cancel previous observable when switching between detectors](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/pull/1967) which will make refresh and time-picker not working