### PR TITLE
Make Network Trace Analysis Tool Searchable

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/network-trace-analysis/network-trace-analysis.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/network-trace-analysis/network-trace-analysis.component.ts
@@ -1,5 +1,7 @@
+import { AdalService } from 'adal-angular4';
 import { Component, OnInit } from '@angular/core';
 import {DomSanitizer,SafeResourceUrl,} from '@angular/platform-browser';
+import { environment } from '../../../../environments/environment';
 import { DiagnosticApiService } from "../../../shared/services/diagnostic-api.service";
 
 @Component({
@@ -9,12 +11,18 @@ import { DiagnosticApiService } from "../../../shared/services/diagnostic-api.se
 })
 export class NetworkTraceAnalysisComponent implements OnInit {
   iframeUrl : SafeResourceUrl;
+  userId: string = "";
 
-  constructor(private _diagnosticApi: DiagnosticApiService, public sanitizer:DomSanitizer) { }
+  constructor(private _diagnosticApi: DiagnosticApiService, private _adalService: AdalService, public sanitizer:DomSanitizer) {
+    if (environment.adal.enabled) {
+      let alias: string = Object.keys(this._adalService.userInfo.profile).length > 0 ? this._adalService.userInfo.profile.upn : '';
+      this.userId = alias.replace('@microsoft.com', '');
+    }
+   }
 
   ngOnInit(): void {
     this._diagnosticApi.getAppSetting("NetworkTraceAnalysisTool:APIUrl").subscribe(url => {
-      this.iframeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(url);
+      this.iframeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(`${url}?userId=${this.userId}`);
     });
   }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.html
@@ -43,9 +43,9 @@
           <i class="fa fa-code fa-fw menu-icon menu-icon-create" aria-hidden="true"></i>
           <collapsible-menu-item *ngFor="let item of createNew" [menuItem]="item"></collapsible-menu-item>
         </section-divider>
-        <section-divider [label]="'Tools'" [selected]="isSectionHeaderSelected('networkTraceAnalysis')" [initiallyExpanded]="false">
+        <section-divider [label]="'Tools'" [selected]="isSectionHeaderSelected('networkTraceAnalysis')" [initiallyExpanded]="true">
           <i class="fa fa-wrench fa-fw menu-icon menu-icon-detectors" aria-hidden="true"></i>
-          <collapsible-menu-item *ngFor="let tool of tools" [menuItem]="tool"></collapsible-menu-item>
+          <collapsible-menu-item *ngFor="let tool of tools" [menuItem]="tool" [searchValue]="searchValue"></collapsible-menu-item>
         </section-divider>
         <section-divider *ngIf="gists.length > 0" [selected]="isSectionHeaderSelected('gists/', false)"
           [label]="'Gists'" [initiallyExpanded]="false">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/side-nav/side-nav.component.ts
@@ -54,6 +54,8 @@ export class SideNavComponent implements OnInit {
   searchValue: string = undefined;
   searchAriaLabel: string = "Filter by name or id";
 
+  toolsCopy: CollapsibleMenuItem[] = [];
+
   contentHeight: string;
 
   getDetectorsRouteNotFound: boolean = false;
@@ -71,8 +73,7 @@ export class SideNavComponent implements OnInit {
     private _openAIService: ApplensOpenAIChatService) {
     this.contentHeight = (window.innerHeight - 139) + 'px';
     if (environment.adal.enabled) {
-      let alias = this._adalService.userInfo.profile ? this._adalService.userInfo.profile.upn : '';
-      this.userId = alias.replace('@microsoft.com', '');
+      this.userId = this.getUserId();
     }
   }
 
@@ -200,7 +201,6 @@ export class SideNavComponent implements OnInit {
       icon: null
     }];
 
-
   ngOnInit() {
     this._openAIService.CheckEnabled().subscribe(enabled => {
       this.showChatGPT = this._openAIService.isEnabled;
@@ -236,6 +236,7 @@ export class SideNavComponent implements OnInit {
       );
     }
 
+    this.toolsCopy = this.deepCopyArray(this.tools);
   }
 
   navigateToOverview() {
@@ -251,13 +252,18 @@ export class SideNavComponent implements OnInit {
   }
 
   navigateToActivePRs() {
-    let alias = Object.keys(this._adalService.userInfo.profile).length > 0 ? this._adalService.userInfo.profile.upn : '';
-    const userId: string = alias.replace('@microsoft.com', '');
+    const userId: string = this.getUserId();
     this.navigateTo(`users/${userId}/activepullrequests`);
   }
 
   private getCurrentRoutePath() {
     this.currentRoutePath = this._activatedRoute.firstChild.snapshot.url.map(urlSegment => urlSegment.path);
+  }
+
+  private getUserId() {
+    let alias: string = Object.keys(this._adalService.userInfo.profile).length > 0 ? this._adalService.userInfo.profile.upn : '';
+    const userId: string = alias.replace('@microsoft.com', '');
+    return userId;
   }
 
   navigateTo(path: string) {
@@ -525,12 +531,15 @@ export class SideNavComponent implements OnInit {
     this.categories = this.updateMenuItems(this.categoriesCopy, searchTerm);
     this.gists = this.updateMenuItems(this.gistsCopy, searchTerm);
     this.favoriteDetectors = this.updateMenuItems(this.favoriteDetectorsCopy, searchTerm);
+    this.tools = this.updateMenuItems(this.toolsCopy, searchTerm);
 
     const subDetectorCount = this.contSubMenuItems(this.categories);
     const subGistCount = this.contSubMenuItems(this.gists);
+    const foundToolsCount = this.tools.length;
     const detectorAriaLabel = `${subDetectorCount > 0 ? subDetectorCount : 'No'} ${subDetectorCount > 1 ? 'Detectors' : 'Detector'}`;
     const gistAriaLabel = `${subGistCount > 0 ? subGistCount : 'No'} ${subGistCount > 1 ? 'Gists' : 'Gist'}`;
-    this.searchAriaLabel = `${detectorAriaLabel} And ${gistAriaLabel} Found for ${this.searchValue}`;
+    const toolsAriaLabel = `${foundToolsCount > 0 ? foundToolsCount : 'No'} ${foundToolsCount > 1 ? 'Tools' : 'Tool'}`;
+    this.searchAriaLabel = `${detectorAriaLabel}, ${gistAriaLabel} And ${toolsAriaLabel} Found for ${this.searchValue}`;
   }
 
   //Only support filtering for two layer menu-item


### PR DESCRIPTION
## Overview
After launching the Network Trace Analysis tool on Applens, we received a feedback from one of its users about how they couldn't search for the tool using the search box on Applens. This was the main initiative behind this fix

## Related Work Item
<img width="378" alt="image" src="https://user-images.githubusercontent.com/24648672/228966009-978517c4-c1d3-46bb-997d-581beb14a03c.png">

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
 - updates the search box functionality to search for tools in the Tools section
 - ensures that the `Tools ` section is initially expanded 
 - fetches the user id of users who get to use the network trace analysis tool and includes it as a query param in the iframe url This is needed for tracking the page view by aliases.

## How Can This Be Tested? <span>&#128269;</span>
- Go to http://localhost:4200/
- In the search box nav, type `network`. The Network Trace Analysis title should be bold

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
<img width="1883" alt="image" src="https://user-images.githubusercontent.com/24648672/228967977-10e88ec4-ddfd-409c-8d00-fbca4eb0aed7.png">

## Screenshots After Fix (if appropriate):
<img width="1909" alt="image" src="https://user-images.githubusercontent.com/24648672/228968291-7db837e0-9ec8-40e2-8523-702f9447f873.png">

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
