### PR TITLE
Change DaaS service to retry POST on GET failure

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/arm.service.ts
@@ -144,7 +144,7 @@ export class ArmService {
             subscriptionLocation = response.body['subscriptionPolicies'] ? response.body['subscriptionPolicies']['locationPlacementId'] : '';
         });
 
-        if (!!additionalHeaders == false){
+        if (!!additionalHeaders == false) {
             additionalHeaders = new Map<string, string>();
         }
 
@@ -335,7 +335,7 @@ export class ArmService {
         return this._cache.get(cacheKey, request, invalidateCache);
     }
 
-    requestResource<T, S>(method:string, resourceUri: string, body?: S, apiVersion?: string): Observable<{} | T> {
+    requestResource<T, S>(method: string, resourceUri: string, body?: S, apiVersion?: string): Observable<{} | T> {
         if (!resourceUri.startsWith('/')) {
             resourceUri = '/' + resourceUri;
         }
@@ -345,12 +345,12 @@ export class ArmService {
             bodyString = JSON.stringify(body);
         }
 
-        const request = this._http.request<S>(method, url, { headers: this.getHeaders(), body: bodyString, observe:"response" });
+        const request = this._http.request<S>(method, url, { headers: this.getHeaders(), body: bodyString, observe: "response" });
 
         return request;
     }
 
-    requestResourceWithCache<T, S>(method:string, resourceUri: string, body?: S, apiVersion?: string, invalidateCache = false): Observable<{} | T> {
+    requestResourceWithCache<T, S>(method: string, resourceUri: string, body?: S, apiVersion?: string, invalidateCache = false): Observable<{} | T> {
         if (!resourceUri.startsWith('/')) {
             resourceUri = '/' + resourceUri;
         }
@@ -360,7 +360,7 @@ export class ArmService {
             bodyString = JSON.stringify(body);
         }
 
-        const request = this._http.request<S>(method, url, { headers: this.getHeaders(), body: bodyString, observe:"response" });
+        const request = this._http.request<S>(method, url, { headers: this.getHeaders(), body: bodyString, observe: "response" });
 
         return this._cache.get(url, request, invalidateCache);
     }
@@ -507,6 +507,26 @@ export class ArmService {
         return this._cache.get(resourceUri, request, invalidateCache);
     }
 
+    retryWithPostOnGetFailure<T, S>(resourceUri: string, body?: S, apiVersion?: string, invalidateCache: boolean = false, upatedResourceUri: string = ''): Observable<boolean | {} | T> {
+        const url = this.createUrl(resourceUri, apiVersion);
+        return this._http.get<T>(url, { headers: this.getHeaders() }).pipe(
+            map(resp => {
+                return resp;
+            }),
+            catchError(err => {
+                if (err.status && err.status === 405) {
+                    let actualResourceUri = upatedResourceUri ? upatedResourceUri : resourceUri;
+                    return this.postResourceWithoutEnvelope<T, S>(actualResourceUri, body, apiVersion, invalidateCache);
+                } else {
+                    let actualError: string = JSON.stringify(err);
+                    if (err.error && err.error.Message) {
+                        actualError = err.error.Message;
+                    }
+                    return throwError(actualError)
+                }
+            }));
+    }
+
     static prettifyError(error: any): string {
         let errorReturn = '';
 
@@ -558,7 +578,7 @@ export class ArmService {
             }
             loggingProps['url'] = `${error.url}`;
             loggingProps['status'] = `${error.status}`;
-            loggingProps['statusText'] = `${error.statusText}`; 
+            loggingProps['statusText'] = `${error.statusText}`;
         }
 
         if (!loggingError.message) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -44,18 +44,19 @@ export class DaasService {
         let resourceUri: string = this._uriElementsService.getActiveSessionUrl(site);
         if (!isWindowsApp) {
             resourceUri = this._uriElementsService.getActiveSessionLinuxUrl(site, useDiagnosticServerForLinux);
+            return <Observable<Session>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri, null, true);
         }
-        return <Observable<Session>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri, null, true);
+        return <Observable<Session>>this._armClient.retryWithPostOnGetFailure<Session, any>(resourceUri, null, null, true);
     }
 
     getSessions(site: SiteDaasInfo, useDiagnosticServerForLinux: boolean): Observable<Session[]> {
-        const resourceUri: string = this._uriElementsService.getSessionsUrl(site, useDiagnosticServerForLinux);
-        return <Observable<Session[]>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri, null, true);
+        const resourceUri: string = this._uriElementsService.getListSessionsUrl(site, useDiagnosticServerForLinux);
+        return <Observable<Session[]>>this._armClient.postResourceWithoutEnvelope<Session, any>(resourceUri, null, null, true);
     }
 
     getSession(site: SiteDaasInfo, sessionId: string, useDiagServerForLinux: boolean): Observable<Session> {
         const resourceUri: string = this._uriElementsService.getSessionUrl(site, sessionId, useDiagServerForLinux);
-        return <Observable<Session>>this._armClient.getResourceWithoutEnvelope<Session>(resourceUri, null, true);
+        return <Observable<Session>>this._armClient.retryWithPostOnGetFailure<Session, any>(resourceUri, null, null, true);
     }
 
     getInstances(site: SiteDaasInfo, isWindowsApp: boolean = true): Observable<Instance[]> {
@@ -132,12 +133,13 @@ export class DaasService {
 
     getAllMonitoringSessions(site: SiteDaasInfo): Observable<MonitoringSession[]> {
         const resourceUri: string = this._uriElementsService.getMonitoringSessionsUrl(site);
-        return <Observable<MonitoringSession[]>>(this._armClient.getResourceWithoutEnvelope<MonitoringSession[]>(resourceUri, null, true));
+        const resourceUriListSessions: string = this._uriElementsService.getMonitoringSessionsListUrl(site);
+        return <Observable<MonitoringSession[]>>(this._armClient.retryWithPostOnGetFailure<MonitoringSession[], any>(resourceUri, null, null, true, resourceUriListSessions));
     }
 
     getMonitoringSession(site: SiteDaasInfo, sessionId: string): Observable<MonitoringSession> {
         const resourceUri: string = this._uriElementsService.getMonitoringSessionUrl(site, sessionId);
-        return <Observable<MonitoringSession>>(this._armClient.getResourceWithoutEnvelope<MonitoringSession>(resourceUri, null, true));
+        return <Observable<MonitoringSession>>(this._armClient.retryWithPostOnGetFailure<MonitoringSession, any>(resourceUri, null, null, true));
     }
 
     analyzeMonitoringSession(site: SiteDaasInfo, sessionId: string): Observable<any> {
@@ -147,12 +149,12 @@ export class DaasService {
 
     getActiveMonitoringSession(site: SiteDaasInfo): Observable<MonitoringSession> {
         const resourceUri: string = this._uriElementsService.getActiveMonitoringSessionUrl(site);
-        return <Observable<MonitoringSession>>(this._armClient.getResourceWithoutEnvelope<MonitoringSession>(resourceUri, null, true));
+        return <Observable<MonitoringSession>>(this._armClient.retryWithPostOnGetFailure<MonitoringSession, any>(resourceUri, null, null, true));
     }
 
     getActiveMonitoringSessionDetails(site: SiteDaasInfo): Observable<ActiveMonitoringSession> {
         const resourceUri: string = this._uriElementsService.getActiveMonitoringSessionDetailsUrl(site);
-        return <Observable<ActiveMonitoringSession>>(this._armClient.getResourceWithoutEnvelope<ActiveMonitoringSession>(resourceUri, null, true));
+        return <Observable<ActiveMonitoringSession>>(this._armClient.retryWithPostOnGetFailure<ActiveMonitoringSession, any>(resourceUri, null, null, true));
     }
 
     stopMonitoringSession(site: SiteDaasInfo): Observable<string> {
@@ -324,16 +326,6 @@ export class DaasService {
 
     get isNationalCloud() {
         return this._armClient.isNationalCloud;
-    }
-
-    private _getHeaders(): HttpHeaders {
-
-        const headers = new HttpHeaders();
-        headers.append('Content-Type', 'application/json');
-        headers.append('Accept', 'application/json');
-        headers.append('Authorization', `Bearer ${this._authService.getAuthToken()}`);
-
-        return headers;
     }
 
     get defaultContainerName(): string {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
@@ -49,6 +49,7 @@ export class UriElementsService {
     private _daasDatabaseTestPath = this._daasApiPath + 'databasetest';
     private _daasAppInfoPath = this._daasApiPath + 'appinfo';
     private _daasCpuMonitoringPath = this._daasApiPath + "CpuMonitoring";
+    private _daasCpuMonitoringListSessionsPath = this._daasCpuMonitoringPath + "/list";
     private _daasStdoutSettingPath = this._daasApiPath + 'settings/stdout';
     private _daasCpuMonitoringSessionActivePath = this._daasCpuMonitoringPath + "/active"
     private _daasCpuMonitoringSessionActivePathDetails = this._daasCpuMonitoringPath + "/activesessiondetails"
@@ -63,6 +64,7 @@ export class UriElementsService {
 
     private _daasPath = '/extensions/daas';
     private _daasSessionsPath = this._daasPath + '/sessions';
+    private _daasListSessionsPath = this._daasSessionsPath + '/list';
     private _daasDiagnosersPath = this._daasPath + '/diagnosers';
     private _daasActiveSessionPath = this._daasSessionsPath + '/active';
     private _daasSingleSessionPath = this._daasSessionsPath + '/{sessionId}';
@@ -70,6 +72,7 @@ export class UriElementsService {
     // Linux DiagServer paths
     private _daasDiagServerPath = this._daasPath + "/v2";
     private _daasDiagServerSessionsPath = this._daasDiagServerPath + '/sessions';
+    private _daasDiagServerListSessionsPath = this._daasDiagServerSessionsPath + '/list';
     private _daasDiagServerSessionsPathForInstance = this._daasDiagServerSessionsPath + '?instance={instanceId}';
     private _daasDiagServerActiveSessionPath = this._daasDiagServerSessionsPath + '/active';
     private _daasDiagServerSingleSessionPath = this._daasDiagServerSessionsPath + '/{sessionId}';
@@ -83,6 +86,13 @@ export class UriElementsService {
             return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasDiagServerSessionsPath;
         }
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasSessionsPath;
+    }
+
+    getListSessionsUrl(site: SiteDaasInfo, useDiagnosticServerForLinux: boolean) {
+        if (useDiagnosticServerForLinux) {
+            return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasDiagServerListSessionsPath;
+        }
+        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasListSessionsPath;
     }
 
     getSessionUrl(site: SiteDaasInfo, sessionId: string, useDiagServerForLinux: boolean) {
@@ -142,6 +152,10 @@ export class UriElementsService {
 
     getMonitoringSessionsUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasCpuMonitoringPath;
+    }
+    
+    getMonitoringSessionsListUrl(site: SiteDaasInfo) {
+        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasCpuMonitoringListSessionsPath;
     }
 
     getActiveMonitoringSessionUrl(site: SiteDaasInfo) {


### PR DESCRIPTION
## Overview
The DAAS Site extension was updated to ensure all controllers that may return secrets should be marked as POST only. This change will retry the request with POST once the GET call fails with 403.

Once the Site Extension is updated everywhere, will remove this logic and just code for POST requests only. This is just an interim solution till the site extension gets updated everywhere.

## Related Work Item
https://github.com/Azure/DaaS/pull/101

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.