### PR TITLE
Fix Switch case for UserInputs in Workflows

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.ts
@@ -49,7 +49,7 @@ export class SwitchCaseStepComponent extends WorkflowNodeBaseClass implements On
   save() {
     this.error = '';
     this.populateCurrentVariable();
-    if (this.currentVariable.type === 'String') {
+    if (this.currentVariable.type === 'String' || this.currentVariable.type === 'System.String') {
       this.data.switchCaseValue = this.switchCaseValue;
       this.editMode = false;
     } else if (this.integerDataTypes.indexOf(this.currentVariable.type) > -1) {


### PR DESCRIPTION
Fixing the Save Button not working when switch case is set on a User Input