### PR TITLE
Keep context of where user was going

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -181,6 +181,7 @@ export class DashboardComponent implements OnDestroy {
     this._alertService.getUnAuthorizedAlerts().subscribe((error: HttpErrorResponse) => {
       let errorObj = JSON.parse(error.error);
       if (errorObj && errorObj.DetailText) {
+        localStorage.setItem('targetedPathBeforeUnauthorized', this._router.url.toString());
         this.accessError = errorObj.DetailText;
         this.navigateBackToHomePage();
       }

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -367,6 +367,26 @@ export class MainComponent implements OnInit {
     }
   }
 
+  paramsToObject(entries) {
+    const result = {}
+    for(const [key, value] of entries) { // each 'entry' is a [key, value] tupple
+      result[key] = value;
+    }
+    return result;
+  }
+
+  extractQueryParams(url) {
+    try {
+      const anchor = document.createElement('a');  
+      anchor.href = url;  
+      const queryParams = new URLSearchParams(anchor.search);
+      return { url: anchor.pathname, queryParams: this.paramsToObject(queryParams)};
+    }
+    catch (err) {
+      return { url: url, queryParams: {}};
+    }
+  }
+
   onSubmit() {
     this._userSettingService.updateDefaultServiceType(this.selectedResourceType.id);
     if (!(this.caseNumber == "internal") && this.caseNumberNeededForUser && (this.selectedResourceType && this.caseNumberNeededForRP)) {
@@ -392,7 +412,6 @@ export class MainComponent implements OnInit {
       window.location.href = `https://azuresupportcenter.msftcloudes.com/caseoverview?srId=${this.resourceName}`;
     }
 
-
     this._detectorControlService.setCustomStartEnd(this._detectorControlService.startTime, this._detectorControlService.endTime);
 
     let timeParams = {
@@ -404,7 +423,20 @@ export class MainComponent implements OnInit {
       queryParams: {
         ...timeParams,
         ...!(this.caseNumber == "internal") && this.caseNumber ? { caseNumber: this.caseNumber } : {}
-      },
+      }
+    }
+
+    let targetedPathBeforeUnauthorized = localStorage.getItem('targetedPathBeforeUnauthorized');
+    if (targetedPathBeforeUnauthorized && targetedPathBeforeUnauthorized.length>0) {
+      localStorage.removeItem('targetedPathBeforeUnauthorized');
+      var extraction = this.extractQueryParams(targetedPathBeforeUnauthorized);
+      route = extraction.url;
+      //Case number should not be passed to the targeted path
+      if (extraction.queryParams.hasOwnProperty('caseNumber')) {
+        delete extraction.queryParams['caseNumber'];
+      }
+      
+      navigationExtras.queryParams = {...navigationExtras.queryParams, ...extraction.queryParams};
     }
 
     if (this.errorMessage === '') {


### PR DESCRIPTION
## Overview
Current Durian implementation forgets the context of where user was going before they ended up with authorization failure. For example if a CSS user clicked a link for a detector (that did not contain casenumber), they are taken back to the main page to enter case number. But when they enter the case number they are taken to the default overview page in applens and not the detector whose link they came from.

This PR improves this experience by storing the user's destination path in localStorage/browser, and when they enter the correct case number, takes them to their original intended destination. It also preserves query parameters like startTime, endTime, form params etc.

Where user is asked to enter the case number
![image](https://user-images.githubusercontent.com/8492235/230525518-0001fdd8-d2e8-49b0-8bfb-527dcee0d8e0.png)

After entering the case number, user is taken directly to the intended destination:
![image](https://user-images.githubusercontent.com/8492235/230525947-9be9f531-7902-4472-9920-b48e6064cedf.png)
