### PR TITLE
Bug 3048: [Screen Reader- App Services - Proactive auto-heal] Screen …

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/proactive-autohealing/proactive-autohealing.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/proactive-autohealing/proactive-autohealing.component.html
@@ -17,7 +17,7 @@
     <toggle-button ToggleText="Proactive Auto-Heal" [selected]="proactiveAutoHealEnabled"
       (selectedChange)="proactiveAutoHealEnabled = $event;checkForChanges()"></toggle-button>
 
-    <div *ngIf="!retrievingProactiveSettings  && !errorMessage && saveEnabled" class="alert alert-danger alert-section">
+    <div *ngIf="!retrievingProactiveSettings  && !errorMessage && saveEnabled" class="alert alert-danger alert-section" role="alert">
       <strong>CAUTION</strong>: Saving pro-active autoheal settings will restart the application domain
       for the web app and this can cause logged-in user information, sessions, and in-memory cache to be cleared.
       Hence, it is advised to make these changes during non-business hours.


### PR DESCRIPTION
[Bug 3048](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/3048): [Screen Reader- App Services - Proactive auto-heal] Screen reader doesn't announce 'caution' text message when the focus moves to 'Off' radio button.