### PR TITLE
Add Kusto caching to Comms query

### DIFF
--- a/ApplensBackend/Services/OutageCommunicationService/OutageCommunicationService.cs
+++ b/ApplensBackend/Services/OutageCommunicationService/OutageCommunicationService.cs
@@ -18,13 +18,14 @@ namespace AppLensV3.Services
         private TimeSpan _commExpandedWindow = TimeSpan.FromDays(1);
 
         private string commsQuery = @"
+        set query_results_cache_max_age = time(1d);
         let startDate = datetime({START_TIME});
         let endDate = datetime({END_TIME});
         cluster('Icmcluster').database('ACM.Backend'). 
         GetCommunicationsBySubIdAndDateRange(@'{SUBSCRIPTION}', startDate, endDate) 
         | where CommunicationType == 'Outage'
-        | order by PublishedTime asc
         | project CommunicationId, PublishedTime, Title, RichTextMessage, Status, Severity, IncidentId, CommunicationType, ImpactedServices, ExternalIncidentId
+        | order by PublishedTime asc
         ";
 
         private string emergingIssuesQuery = @"


### PR DESCRIPTION
## Overview
Comms query in ICM consuming high memory and are being throttled by ICM cluster

## Related Work Item
NA

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
### This PR:
Add kusto caching to comms query so that the data is cached for one day.

## How Can This Be Tested? <span>&#128269;</span>
Wait for a day and see if the memory usage on ICM cluster has gone down, or execute the raw query with your ID against the ICM cluster and observe the memory usage.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
