### PR TITLE
Fixing Accessibility BUG 17535630

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.html
@@ -3,7 +3,7 @@
     class="list-header" [attr.aria-label]="title">
     <span class="btn-inner">
       <div style="float:left" class="custom-caret" [class.custom-caret-down]="collapsed">
-        <fab-icon iconName="ChevronUp" ariaLabel="ChevronUp"></fab-icon>
+        <fab-icon iconName="ChevronUp" [ariaLabel]="ariaLabelChevronUp"></fab-icon>
       </div>
       <div style="float:left" *ngIf="iconProps">
         <fab-icon [iconName]="iconProps.iconName" ariaLabel="Section icon" [styles]="iconProps.styles"></fab-icon>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/collapsible-list/collapsible-list-fabric/collapsible-list-fabric.component.ts
@@ -17,10 +17,14 @@ export class CollapsibleListFabricComponent {
   @Output() collapsedChange = new EventEmitter<any>();
 
   @ContentChildren(CollapsibleListItemComponent) listItemComponents: QueryList<CollapsibleListItemComponent>;
+  ariaLabelChevronUp: string;
 
   constructor(private telemetryService:TelemetryService) {
   }
 
+  ngOnInit(): void {
+    this.ariaLabelChevronUp = `${this.title} chevron up ${this.collapsed ? 'collapsed' : 'expanded'}`;
+  }
   clickHandler() {
     this.telemetryService.logEvent("ClickCollapsibleList",{
       "CurrentState" : this.collapsed ? "Collapse" : "Expand",

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-list/detector-list.component.html
@@ -60,7 +60,7 @@
     [title]="'Observations and Solutions (' + issueDetectedViewModels.length + ')'">
     <collapsible-list-item body>
       <div *ngFor="let viewModel of issueDetectedViewModels" style="margin-bottom: 8px;">
-        <fab-card [expanded]="!isPublic" [isExpandable]="!!viewModel.insightDescription" [isAlign]="true">
+        <fab-card [expanded]="!isPublic" [isExpandable]="!!viewModel.insightDescription" [isAlign]="true" [ariaLabel]="viewModel.model.title">
           <div header>
             <div style="display: flex;align-items: center;min-height: 40px;">
               <status-icon class="mr-3" [status]="viewModel.model.status"></status-icon>
@@ -93,7 +93,7 @@
     <collapsible-list-item body>
       <div class="list-text">
         <div *ngFor="let viewModel of successfulViewModels" style="margin-bottom: 8px;">
-          <fab-card [expanded]="false">
+          <fab-card [expanded]="false" [ariaLabel]="viewModel.model.title">
             <div header>
               <div style="display: flex;align-items: center;min-height: 40px;">
                 <status-icon class="mr-3" [loading]="viewModel.model.loadingStatus" [status]="viewModel.model.status">
@@ -124,12 +124,12 @@
 
       <div class="list-text">
         <div *ngFor="let viewModel of failedLoadingViewModels" style="margin-bottom: 8px;">
-          <fab-card [isExpandable]="false" [isAlign]="true">
+          <fab-card [isExpandable]="false" [isAlign]="true" [ariaLabel]="viewModel.model.title">
             <div header>
               <div style="display: flex;align-items: center;min-height: 40px;">
                 <status-icon class="mr-3" [status]="HealthStatus.Warning">
                 </status-icon>
-                <div class="list-view-title">{{viewModel.model.title}}</div>
+                <div class="list-view-title" >{{viewModel.model.title}}</div>
               </div>
             </div>
             <div body>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-card/fab-card.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-card/fab-card.component.html
@@ -2,7 +2,7 @@
   <div [class.card-align]="!isExpandable && isAlign">
     <div *ngIf="isExpandable" class="btn-outer" [attr.aria-expanded]="ariaExpaned" [attr.aria-label]="ariaLabel">
       <button *ngIf="isExpandable" class="custom-caret" [class.custom-caret-down]="!expanded" (click)="toggleExpand()">
-        <fab-icon iconName="ChevronUp" ariaLabel="ChevronUp"></fab-icon>
+        <fab-icon iconName="ChevronUp" [ariaLabel]="ariaLabelChevronUp"></fab-icon>
       </button>
     </div>
   </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/fab-card/fab-card.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/fab-card/fab-card.component.ts
@@ -13,8 +13,14 @@ export class FabCardComponent {
   @Input() ariaLabel: string = "";
   @Input() background: string = "";
   @Input() hideBorder: boolean = false;
+
+  ariaLabelChevronUp: string = "";
+  ngOnInit(){
+    this.ariaLabelChevronUp=`${this.ariaLabel} chevronUp ${this.expanded? "expanded" : "collapsed"}`;
+  }
   get ariaExpaned() {
     if(!this.isExpandable) return null;
+    this.ariaLabelChevronUp=`${this.ariaLabel} chevronUp ${this.expanded? "expanded" : "collapsed"}`;
     return this.expanded ? "true" : "false";
   }
   toggleExpand() {


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
Changing ariaLabel for ChevronUp to include Name, Role, Value
<!--- Why is this change required? What problem does it solve? -->
Accessibility bug with Narrator not describing the ChevronUp correctly.
## Related Work Item
<!--- Please provide the work item number as well as its link: -->
https://msazure.visualstudio.com/Antares/_workitems/edit/17535630
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
<!--- An example of a solution description -->
Passing detector title to fab-card, so that it can be used as part of the ariaLabel that contains:
DetectorTitle chevronup collapsed/expanded (Name, Role, Value)

## How Can This Be Tested? <span>&#128269;</span>

1. Open the URL "http://ms.portal.azure.com/" in edge browser and login with valid credentials.
2. Search and select 'App Services' then will be navigated to 'App Services' page.
3. Select any already created app service and navigate to 'Custom domain' control in left pane and select it.
4. Navigate all controls under the 'Custom domain' blade.
5. Navigate to the 'Troubleshoot' control via tab key and select it using enter key.
6. Verify whether, Name is defined more descriptive for 'Chevron up' button and screen reader announce the state as expand/collapse for button present on the page or not.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://user-images.githubusercontent.com/7376302/232155615-873b98cc-7d93-4178-9082-4b9cb8566fb3.png)

## Screenshots After Fix (if appropriate):
![image](https://user-images.githubusercontent.com/7376302/232159598-95c8e5bb-151b-4bd6-9fb8-207cb9f3e0cb.png)

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
