### PR TITLE
Change localStorage logging in OpenaiComponent for InPrivate access

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/openai/openai.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/openai/openai.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit, ViewChildren, QueryList, ChangeDetectorRef } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 import { ITooltipOptions } from '@angular-react/fabric/lib/components/tooltip';
 import { FabTeachingBubbleComponent } from './../../modules/fab-teachingbubble/public-api';
@@ -52,7 +53,7 @@ export class OpenaiComponent implements OnInit {
     doNotLayer: true
   };
 
-  constructor(private chatService: OpenAIArmService, private telemetryService: TelemetryService, private changeDetectorRef: ChangeDetectorRef) { }
+  constructor(private chatService: OpenAIArmService, private telemetryService: TelemetryService, private _activatedRoute: ActivatedRoute, private changeDetectorRef: ChangeDetectorRef) { }
 
   ngOnInit() {
     this.initCoachmarkFlag();
@@ -67,8 +68,13 @@ export class OpenaiComponent implements OnInit {
     catch (error) {
       // Use TelemetryService logEvent when not able to access local storage.
       // Most likely due to browsing in InPrivate/Incognito mode.
-      const e = new Error(`Error trying to retrieve ${this.coachMarkCookieName} from localStorage: ` + error);
-      this.telemetryService.logException(e);
+      const eventProperties = {
+        'Subscription': this._activatedRoute.parent?.snapshot.params['subscriptionid'],
+        'ReportType': 'Openai',
+        'Error': error,
+        'Message': `Error trying to retrieve ${this.coachMarkCookieName} from localStorage`
+      }
+      this.telemetryService.logEvent(TelemetryEventNames.OpenAiInPrivateAccess, eventProperties);
     }
   }
 

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -72,6 +72,7 @@ export const TelemetryEventNames = {
     LoadingDetectorViewStarted: 'LoadingDetectorViewStarted',
     LoadingDetectorViewEnded: 'LoadingDetectorViewEnded',
     OpenAiMessageViewed: 'OpenAiMessageViewed',
+    OpenAiInPrivateAccess: 'OpenAiInPrivateAccess',
     OpenGenie: 'OpenGenie',
     OpenFeedbackPanel: 'OpenFeedbackPanel',
     RefreshClicked: 'RefreshClicked',


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
This PR changes logging in OpenaiComponent for InPrivate access from exception to a plain log.

## Related Work Item
<!--- Please provide the work item number as well as its link: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
When AppLens opens in InPrivate mode, any detector output involving OpenaiComponent throws exception. These errors are expected and should be either ignored or changed to a plain log.

### This PR:
<!--- An example of a solution description -->
<!--- - creates a new rendering type -->
<!--- - refactors the code -->
<!--- - adds a new function/enum to render a bar chart -->
This PR changes the logging type from exception to a plain log.

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
