### PR TITLE
Fix for dropdown not showing scroll when zoom in

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/styles.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/styles.scss
@@ -49,10 +49,6 @@ fab-command-bar .ms-SearchBox {
     width: 270px;
 }
 
-.ms-Callout-container .ms-Callout-main {
-    overflow-y: hidden!important;
-}
-
 
 .ms-Callout-container fab-date-picker {
     padding-right:0px!important;


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
Fix for dropdown not showing scroll when zoom in

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Screenshots Before Fix (if appropriate):
No Scroll for dropdown
![image](https://user-images.githubusercontent.com/23129934/234101116-5cb1a352-655a-4c75-8db4-ad4341cf1a87.png)

## Screenshots After Fix (if appropriate):
Having Scroll for dropdown
![image](https://user-images.githubusercontent.com/23129934/234100878-14a4e01f-4e9f-45cb-9270-0416655d2d7e.png)


