### PR TITLE
Durian changes: Updating minimum length and fixing deep link context issue

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -182,7 +182,6 @@ export class DashboardComponent implements OnDestroy {
     this._alertService.getUnAuthorizedAlerts().subscribe((error: HttpErrorResponse) => {
       let errorObj = JSON.parse(error.error);
       if (errorObj && errorObj.DetailText) {
-        localStorage.setItem('targetedPathBeforeUnauthorized', this._router.url.toString());
         this.accessError = errorObj.DetailText;
         this.navigateBackToHomePage();
       }
@@ -213,7 +212,8 @@ export class DashboardComponent implements OnDestroy {
       errorMessage: this.accessError,
       resourceType: mainPageResourceType? mainPageResourceType.resourceType: "armresourceid",
       resourceName: resourceInfo.resourceName,
-      resourceId: this._resourceService.getCurrentResourceId()
+      resourceId: this._resourceService.getCurrentResourceId(),
+      targetPathBeforeError: this._router.url.toString()
     };
     const queryString = new URLSearchParams(queryParams).toString();
     window.location.href = "/?" + queryString;

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -135,8 +135,8 @@ export class MainComponent implements OnInit {
   }
 
   validateCaseNumber() {
-    if (!this.caseNumber || this.caseNumber.length < 12) {
-      this.caseNumberValidationError = "Case number too short. It should be a minimum of 12 digits.";
+    if (!this.caseNumber || this.caseNumber.length < 15) {
+      this.caseNumberValidationError = "Case number too short. It should be a minimum of 15 digits.";
       return false;
     }
     if (this.caseNumber.length > 18) {

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -60,6 +60,7 @@ export class MainComponent implements OnInit {
   inIFrame = false;
   errorMessage = "";
   status = HealthStatus.Critical;
+  targetPathBeforeError: string = "";
 
   fabDropdownOptions: IDropdownOption[] = [];
   fabDropdownStyles: IDropdownProps["styles"] = {
@@ -119,6 +120,9 @@ export class MainComponent implements OnInit {
     if (this._activatedRoute.snapshot.queryParams['caseNumberNeeded']) {
       this.caseNumberNeededForProduct = true;
     }
+    if (this._activatedRoute.snapshot.queryParams['targetPathBeforeError']) {
+      this.targetPathBeforeError = this._activatedRoute.snapshot.queryParams['targetPathBeforeError'];
+    }
     if (this._activatedRoute.snapshot.queryParams['resourceType']) {
       let foundResourceType = this.defaultResourceTypes.find(resourceType => resourceType.resourceType.toLowerCase() === this._activatedRoute.snapshot.queryParams['resourceType'].toLowerCase());
       if (!foundResourceType) {
@@ -135,7 +139,7 @@ export class MainComponent implements OnInit {
   }
 
   validateCaseNumber() {
-    if (!this.caseNumber || this.caseNumber.length < 15) {
+    if (!this.caseNumber || this.caseNumber.length < 12) {
       this.caseNumberValidationError = "Case number too short. It should be a minimum of 15 digits.";
       return false;
     }
@@ -426,10 +430,8 @@ export class MainComponent implements OnInit {
       }
     }
 
-    let targetedPathBeforeUnauthorized = localStorage.getItem('targetedPathBeforeUnauthorized');
-    if (targetedPathBeforeUnauthorized && targetedPathBeforeUnauthorized.length>0) {
-      localStorage.removeItem('targetedPathBeforeUnauthorized');
-      var extraction = this.extractQueryParams(targetedPathBeforeUnauthorized);
+    if (this.targetPathBeforeError && this.targetPathBeforeError.length>0) {
+      var extraction = this.extractQueryParams(this.targetPathBeforeError);
       route = extraction.url;
       //Case number should not be passed to the targeted path
       if (extraction.queryParams.hasOwnProperty('caseNumber')) {


### PR DESCRIPTION
## Overview
It seems MSaaS API breaks down with any case number that is less than 15 digits.
Updating the validation here to prevent us from saying "MSaaS API is down" when it's just a bad case number.


The second issue that this PR fixes is related to using localStorage to keep context of where the user was going in applens when they come from a deep link. Here is the issue details:

If a user tries to open applens for Resource A and gets an error --> we would store Path A in local storage.

- Now if the user goes and adds a case number etc, we read the Path A, clear the localstorage and navigate to the path.
- However **if the user does not bother to fix the case number issue**, Path A will be persisted in their localstorage and when they come to AppLens normally, Path A will still be in storage and even if user fills Resource B, we will navigate them to Path A.

The fix is to not use localStorage and rather use query params.