### PR TITLE
Making APIM as 1P service in Applens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,3 +407,4 @@ MigrationBackup/
 .ionide/
 
 .vscode/launch.json
+/package-lock.json

--- a/AngularApp/projects/applens/src/app/app.module.ts
+++ b/AngularApp/projects/applens/src/app/app.module.ts
@@ -112,6 +112,10 @@ export const Routes = RouterModule.forRoot([
                         loadChildren: () => import('./modules/ase/ase.module').then(m => m.AseModule)
                     },
                     {
+                      path: 'armresourceurlfinder/:provider/:service/:name',
+                      loadChildren: () => import('./modules/armresourceurlfinder/armresourceurlfinder.module').then(m => m.ArmResourceUrlFinderModule)
+                    },
+                    {
                         path: 'subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/:provider/:resourceTypeName/:resourceName',
                         loadChildren: () => import('./modules/dashboard/dashboard.module').then(m => m.DashboardModule),
                         resolve: { validResources: ValidResourceResolver }

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.html
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.html
@@ -1,0 +1,6 @@
+<applens-header></applens-header>
+<div class="container-fluid main-container content-under-header">
+  <div class="big-text" *ngIf="loading">Searching for the resource ...</div>
+  <div class="big-text" *ngIf="!loading && error">{{error}}</div>
+  <div class="big-text" *ngIf="!loading && !error">Redirecting to {{armUrl}}</div>
+</div>

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.scss
@@ -1,0 +1,24 @@
+.main-container {
+    background-color: #e4e4e4;
+}
+
+.multiple-sites {
+    width: 100%;
+    height: 100%;
+    padding: 50px;
+}
+
+.matching-site {
+    margin: 5px;
+    float: left;
+}
+
+.main-panel {
+    width: 40rem;
+}
+
+.big-text {
+    padding: 100px;
+    font-size: 30px;
+    height: 100%;
+}

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.spec.ts
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { ArmResourceUrlFinder } from './armresourceurlfinder.component';
+
+describe('StampFinderComponent', () => {
+  let component: ArmResourceUrlFinder;
+  let fixture: ComponentFixture<ArmResourceUrlFinder>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ArmResourceUrlFinder ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ArmResourceUrlFinder);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.ts
@@ -23,13 +23,9 @@ export class ArmResourceUrlFinder implements OnInit {
   }
 
   ngOnInit() {
-    console.log('Inside ngOnInit() of ArmResourceUrlFinder ... ');
-
     this.providerName = this._route.snapshot.params['provider'];
     this.serviceName = this._route.snapshot.params['service'];
     this.resourceName = this._route.snapshot.params['name'];
-
-    console.log(`provider :${this.providerName}, service: ${this.serviceName}, resource: ${this.resourceName}`);
 
     this._observerService.getArmResourceUrl(this.providerName, this.serviceName, this.resourceName).subscribe(_armUrl => {
       this.loading = false;

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ObserverService } from '../../shared/services/observer.service';
+import { JsonPipe } from '@angular/common';
+
+@Component({
+  selector: 'armresourceurl-finder',
+  templateUrl: './armresourceurlfinder.component.html',
+  styleUrls: ['./armresourceurlfinder.component.scss']
+})
+export class ArmResourceUrlFinder implements OnInit {
+
+  loading: boolean = true;
+  error: string;
+  contentHeight: string;
+  providerName: string;
+  serviceName: string;
+  resourceName: string;
+  armUrl : string;
+
+  constructor(private _route: ActivatedRoute, private _router: Router, private _observerService: ObserverService) {
+    this.contentHeight = window.innerHeight + 'px';
+  }
+
+  ngOnInit() {
+    console.log('Inside ngOnInit() of ArmResourceUrlFinder ... ');
+
+    this.providerName = this._route.snapshot.params['provider'];
+    this.serviceName = this._route.snapshot.params['service'];
+    this.resourceName = this._route.snapshot.params['name'];
+
+    console.log(`provider :${this.providerName}, service: ${this.serviceName}, resource: ${this.resourceName}`);
+
+    this._observerService.getArmResourceUrl(this.providerName, this.serviceName, this.resourceName).subscribe(_armUrl => {
+      this.loading = false;
+      this.armUrl = _armUrl;
+      this.navigateToArmUrl(this.armUrl);
+    }, (err: Response) => {
+      this.loading = false;
+      this.error = err["error"];
+    });
+  }
+
+  navigateToArmUrl(armUrl: string) {
+    let resourceArray: string[] = [armUrl];
+    this._router.navigate(resourceArray, { queryParamsHandling: "preserve" });
+  }
+
+}

--- a/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.module.ts
+++ b/AngularApp/projects/applens/src/app/modules/armresourceurlfinder/armresourceurlfinder.module.ts
@@ -1,0 +1,22 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ArmResourceUrlFinder } from './armresourceurlfinder.component';
+import { SharedModule } from '../../shared/shared.module';
+
+export const ArmResourceUrlFinderRoutes : ModuleWithProviders<ArmResourceUrlFinderModule> = RouterModule.forChild([
+  {
+    path: '',
+    component: ArmResourceUrlFinder
+  }
+]);
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ArmResourceUrlFinderRoutes,
+    SharedModule
+  ],
+  declarations: [ArmResourceUrlFinder]
+})
+export class ArmResourceUrlFinderModule { }

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -283,7 +283,8 @@ export class MainComponent implements OnInit {
       { name: "App Service Environment", imgSrc: "assets/img/ASE-Logo.jpg" },
       { name: "Virtual Machine", imgSrc: "assets/img/Icon-compute-21-Virtual-Machine.svg" },
       { name: "Container App", imgSrc: "assets/img/Azure-ContainerApp-Logo.png" },
-      { name: "Internal Stamp", imgSrc: "assets/img/Cloud-Service-Logo.svg" }];
+      { name: "Internal Stamp", imgSrc: "assets/img/Cloud-Service-Logo.svg" },
+      { name: "APIM Service", imgSrc: "assets/img/Azure-ApiManagement-Logo.png"}];
 
     // TODO: Use this to restrict access to routes that don't match a supported resource type
     this._http.get<ResourceServiceInputsJsonResponse>('assets/enabledResourceTypes.json').subscribe(jsonResponse => {

--- a/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
@@ -3,7 +3,7 @@ import { HttpInterceptor, HttpRequest, HttpResponse, HttpErrorResponse, HttpHand
 import { Observable, of, pipe } from 'rxjs';
 import { map, catchError, mergeMap } from 'rxjs/operators';
 import { AlertService } from './alert.service';
-import {AdalService} from 'adal-angular4';
+import { AdalService } from 'adal-angular4';
 import { AlertInfo, ConfirmationOption, UserAccessStatus } from '../models/alerts';
 import { HealthStatus } from "diagnostic-data";
 
@@ -14,7 +14,7 @@ export class AppLensInterceptorService implements HttpInterceptor {
   tokenRefreshRetry: boolean = true;
   constructor(private _alertService: AlertService, private _adalService: AdalService) { }
 
-  raiseAlert(event){
+  raiseAlert(event) {
     let errormsg = event.error;
     errormsg = errormsg.replace(/\\"/g, '"');
     errormsg = errormsg.replace(/\"/g, '"');
@@ -22,16 +22,16 @@ export class AppLensInterceptorService implements HttpInterceptor {
     let message = errobj.DetailText;
     message = message.trim();
     if (message) {
-      if (message[message.length-1] == '.') {
+      if (message[message.length - 1] == '.') {
         message = message.substring(0, message.length - 1);
       }
     }
     let alertInfo: AlertInfo = {
-        header: "Do you accept the risks?",
-        details: `${message}. If you choose to proceed, we will be logging it for audit purposes.`,
-        seekConfirmation: true,
-        confirmationOptions: [{label: 'Yes, proceed', value: 'yes'}, {label: 'No, take me back', value: 'no'}],
-        alertStatus: HealthStatus.Warning
+      header: "Do you accept the risks?",
+      details: `${message}. If you choose to proceed, we will be logging it for audit purposes.`,
+      seekConfirmation: true,
+      confirmationOptions: [{ label: 'Yes, proceed', value: 'yes' }, { label: 'No, take me back', value: 'no' }],
+      alertStatus: HealthStatus.Warning
     };
     this._alertService.sendAlert(alertInfo);
   }
@@ -39,11 +39,14 @@ export class AppLensInterceptorService implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
     return next.handle(req).pipe(map((event: HttpEvent<any>) => {
-        if (event instanceof HttpResponse && event.url.includes("api/invoke")) {
-        }
-        return event;
-      }), catchError((error: HttpErrorResponse) => {
-          let errorObj = JSON.parse(error.error);
+      if (event instanceof HttpResponse && event.url.includes("api/invoke")) {
+      }
+      return event;
+    }), catchError((error: HttpErrorResponse) => {
+
+      try {
+        let errorObj = JSON.parse(error.error);
+
         if (error.status === 403 && error.url.includes("api/invoke") && errorObj.Status == UserAccessStatus.ResourceNotRelatedToCase) {
           this.raiseAlert(error);
         }
@@ -54,16 +57,21 @@ export class AppLensInterceptorService implements HttpInterceptor {
               this._adalService.userInfo.token = token;
               return next.handle(req);
             }),
-            catchError((err) => {
-              location.reload();
-              return of(null);
-            }));
+              catchError((err) => {
+                location.reload();
+                return of(null);
+              }));
           }
           else {
             this._alertService.notifyUnAuthorized(error);
           }
         }
-        return Observable.throw(error);
-      }));
+      }
+      catch (e) {
+        // Most liely the error.error object was not a json object. Lets consume the json parsing exception and rethrow the original error.
+      }
+
+      return Observable.throw(error);
+    }));
   }
 }

--- a/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/observer.service.ts
@@ -65,6 +65,10 @@ export class ObserverService {
     return this._diagnosticApiService.get<ObserverStampResponse>(`api/stamps/${stampName}`);
   }
 
+  public getArmResourceUrl(providerName: string, serviceName: string, resourceName: string) : Observable<string> {
+    return this._diagnosticApiService.get<string>(`api/armresourceurl/${providerName}/${serviceName}/${resourceName}`);
+  }
+
   private getSiteInfoWithSlot(site: ObserverSiteInfo): ObserverSiteInfo {
     const siteName = site.SiteName;
     let slot = '';

--- a/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
+++ b/AngularApp/projects/applens/src/app/shared/utilities/main-page-menu-options.ts
@@ -42,6 +42,15 @@ export const defaultResourceTypes: ResourceTypeState[] = [
       id: 'Static Web App'
     },
     {
+      resourceType: "Microsoft.ApiManagement/service",
+      resourceTypeLabel: 'APIM Service Name',
+      routeName: (name) => `armresourceurlfinder/Microsoft.ApiManagement/service/${name}`,
+      displayName: 'APIM Service',
+      enabled: true,
+      caseId: false,
+      id: 'APIM Service'
+    },
+    {
       resourceType: "Microsoft.Compute/virtualMachines",
       resourceTypeLabel: 'Virtual machine Id',
       routeName: (name) => getFakeArmResource('Microsoft.Compute', 'virtualMachines', name),

--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -128,6 +128,9 @@ namespace AppLensV3
                 services.AddSingleton<IOpenAIService, OpenAIServiceDisabled>();
             }
 
+            services.AddSingleton<IRedisService<ArmResourceRedisModel>>(new ArmResourceRedisCache(Configuration, RedisConnection.InitializeAsync(true, connectionString: Configuration["ArmResourceService:RedisConnectionString"].ToString())));
+            services.AddSingleton<IArmResourceService, ArmResourceService>();
+
             services.AddMemoryCache();
             services.AddMvc().AddNewtonsoftJson();
 

--- a/ApplensBackend/Controllers/InsightsController.cs
+++ b/ApplensBackend/Controllers/InsightsController.cs
@@ -41,16 +41,16 @@ namespace AppLensV3.Controllers
         public async Task<object> GetInsights(string subscriptionId, string resourceGroupName, string provider, string resourceType, string resourceName, string pesId = null, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null)
         {
             Task<ObserverResponse> getResourceTask = null;
-            var appServiceResources = new string[] { InsightsConstants.SiteResourceTypeName, InsightsConstants.HostingEnvironmentResourceTypeName };
+            var appServiceResources = new string[] { ResourceConstants.SiteResourceTypeName, ResourceConstants.HostingEnvironmentResourceTypeName };
 
             if (appServiceResources.Contains(resourceType))
             {
                 switch (resourceType)
                 {
-                    case InsightsConstants.SiteResourceTypeName:
+                    case ResourceConstants.SiteResourceTypeName:
                         getResourceTask = observerService.GetSite(resourceName);
                         break;
-                    case InsightsConstants.HostingEnvironmentResourceTypeName:
+                    case ResourceConstants.HostingEnvironmentResourceTypeName:
                         getResourceTask = observerService.GetHostingEnvironmentDetails(resourceName);
                         break;
                 }

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
@@ -195,7 +196,6 @@ namespace AppLensV3
                 if (string.IsNullOrWhiteSpace(providerName) || string.IsNullOrWhiteSpace(serviceName) || string.IsNullOrWhiteSpace(resourceName))
                 {
                     return BadRequest("arguments cannot be null or empty.");
-
                 }
 
                 var armID = await _armResourceService.GetArmResourceUrlAsync(providerName, serviceName, resourceName);
@@ -203,7 +203,11 @@ namespace AppLensV3
             }
             catch (NotFoundException ex)
             {
-                return NotFound(ex.Message);
+                return StatusCode(404, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, ex.Message);
             }
         }
 

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using AppLensV3.Services;
+using Octokit;
 
 namespace AppLensV3
 {
@@ -10,10 +11,12 @@ namespace AppLensV3
     public class ResourceController : Controller
     {
         IObserverClientService _observerService;
+        IArmResourceService _armResourceService;
 
-        public ResourceController(IObserverClientService observerService)
+        public ResourceController(IObserverClientService observerService, IArmResourceService resourceService)
         {
             _observerService = observerService;
+            _armResourceService = resourceService;
         }
 
         [HttpGet("api/sites/{siteName}")]
@@ -62,7 +65,7 @@ namespace AppLensV3
 
         [HttpGet]
         [Route("api/stamps/{stamp}/sites/{siteName}/sku")]
-        public async Task<IActionResult> GetSiteSku(string stamp,string siteName)
+        public async Task<IActionResult> GetSiteSku(string stamp, string siteName)
         {
             var siteSku = await _observerService.GetSiteSku(stamp, siteName);
             return Ok(new { Details = siteSku.Content });
@@ -181,6 +184,27 @@ namespace AppLensV3
         public async Task<IActionResult> GetKustoByGeo([FromServices] IKustoQueryService kustoQueryService, string geoRegionName)
         {
             return await GetKustoByGeoInternal(kustoQueryService, geoRegionName);
+        }
+
+        [HttpGet]
+        [Route("api/armresourceurl/{providerName}/{serviceName}/{resourceName}")]
+        public async Task<IActionResult> GetArmResourceUrl(string providerName, string serviceName, string resourceName)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(providerName) || string.IsNullOrWhiteSpace(serviceName) || string.IsNullOrWhiteSpace(resourceName))
+                {
+                    return BadRequest("arguments cannot be null or empty.");
+
+                }
+
+                var armID = await _armResourceService.GetArmResourceUrlAsync(providerName, serviceName, resourceName);
+                return Ok(armID);
+            }
+            catch (NotFoundException ex)
+            {
+                return NotFound(ex.Message);
+            }
         }
 
         private async Task<IActionResult> GetKustoByGeoInternal(IKustoQueryService kustoQueryService, string geoRegionName)

--- a/ApplensBackend/Helpers/Constants.cs
+++ b/ApplensBackend/Helpers/Constants.cs
@@ -53,10 +53,11 @@ namespace AppLensV3.Helpers
         internal const string ArticleTemplatePath = "https://api.github.com/repos/Azure/SelfHelpContent/contents/articles/{0}?ref=master";
     }
 
-    internal static class InsightsConstants
+    internal static class ResourceConstants
     {
         internal const string SiteResourceTypeName = "sites";
         internal const string HostingEnvironmentResourceTypeName = "hostingEnvironments";
+        internal const string ArmUrlTemplate = "/subscriptions/{0}/resourceGroups/{1}/providers/{2}/{3}/{4}";
     }
 
     public static class HeaderConstants

--- a/ApplensBackend/Services/ArmResourceService/ArmResourceRedisCache.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceRedisCache.cs
@@ -1,0 +1,35 @@
+﻿using AppLensV3.Services.RedisCache;
+using Microsoft.Extensions.Configuration;
+using System.Configuration;
+using System;
+using System.Threading.Tasks;
+
+namespace AppLensV3.Services
+{
+    public class ArmResourceRedisModel
+    {
+        // intentionally left blank.
+        // This is just used to identify the right Redis cache service for dependency injection.
+    }
+
+    public class ArmResourceRedisCache : RedisServiceBase<ArmResourceRedisModel>, IRedisService<ArmResourceRedisModel>
+    {
+        public ArmResourceRedisCache(IConfiguration config, Task<RedisConnection> redisConnectionFactory)
+            : base(true, redisConnectionFactory, 7)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            bool.TryParse(config["ArmResourceService:RedisEnabled"], out _redisEnabled);
+
+            if (_redisEnabled)
+            {
+                var expiryTimeInDays = string.IsNullOrWhiteSpace(config["ArmResourceService:DefaultCacheExpiryInDays"]) ? config["ArmResourceService:DefaultCacheExpiryInDays"] : "7";
+                int expiryTime = int.TryParse(expiryTimeInDays, out int val) ? val : 7;
+                DefaultExpiryTime = TimeSpan.FromDays(expiryTime);
+            }
+        }
+    }
+}

--- a/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
@@ -1,0 +1,108 @@
+﻿using System.Threading.Tasks;
+using System;
+using Microsoft.Extensions.Configuration;
+using AppLensV3.Helpers;
+using Octokit;
+using Newtonsoft.Json;
+
+namespace AppLensV3.Services
+{
+    public interface IArmResourceService
+    {
+        /// <summary>
+        /// This service is enabled or not.
+        /// </summary>
+        /// <returns>true/false</returns>
+        bool IsEnabled();
+
+        /// <summary>
+        /// Returns Arm url for the resource.
+        /// </summary>
+        /// <param name="provider">Provider name.</param>
+        /// <param name="serviceName">Service name.</param>
+        /// <param name="resourceName">Resource name.</param>
+        /// <returns>Arm Resource Url.</returns>
+        public Task<string> GetArmResourceUrlAsync(string provider, string serviceName, string resourceName);
+    }
+
+    /// <summary>
+    /// Arm resource class.
+    /// </summary>
+    public class ArmResourceService : IArmResourceService
+    {
+        private readonly bool enabled;
+        private readonly IRedisService<ArmResourceRedisModel> redisService;
+        private readonly IKustoQueryService kustoQueryService;
+        private readonly IConfiguration config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArmResourceService"/> class.
+        /// </summary>
+        /// <param name="configuration">config object</param>
+        /// <param name="redisConnFactory">redis connection factory</param>
+        public ArmResourceService(IConfiguration configuration, IRedisService<ArmResourceRedisModel> redis, IKustoQueryService kustoQuerySvc)
+        {
+            config = configuration;
+            enabled = configuration.GetValue("ArmResourceService:Enabled", false);
+            redisService = redis;
+            kustoQueryService = kustoQuerySvc;
+        }
+
+        /// <inheritdoc/>
+        public bool IsEnabled()
+        {
+            return enabled;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetArmResourceUrlAsync(string provider, string serviceName, string resourceName)
+        {
+            if (!enabled)
+            {
+                return FakeResource(provider, serviceName, resourceName);
+            }
+
+            var cacheKey = string.Join("/", provider, serviceName, resourceName);
+            var cacheValue = await redisService.GetKey(cacheKey);
+            if (string.IsNullOrWhiteSpace(cacheValue))
+            {
+                var dictKey = $"{string.Join("/", provider, serviceName)}:{MultiCloudExtensions.GetCloudDomain(config)}".ToLower();
+                ArmResourceServiceConfig.ArmKustoQueryPerService.TryGetValue(dictKey, out var kustoInfo);
+                if (kustoInfo == null)
+                {
+                    throw new Exception($"No Arm kusto query found for provider : {provider} and service : {serviceName}");
+                }
+
+                var dt = await kustoQueryService.ExecuteQueryAsync(
+                    cluster: kustoInfo.Item1,
+                    database: kustoInfo.Item2,
+                    query: string.Format(kustoInfo.Item3, resourceName),
+                    operationName: "Get Arm Resource for Applens");
+
+                if (dt == null || dt.Rows == null || dt.Rows.Count == 0)
+                {
+                    throw new NotFoundException(
+                        $"Unable to fetch arm resource for {string.Join("/", provider, serviceName, resourceName)}. " +
+                        $"Kusto query returned 0 results." +
+                        $"Cluster: {kustoInfo.Item1}, Database: {kustoInfo.Item2}, Query: {string.Format(kustoInfo.Item3, resourceName)}",
+                        System.Net.HttpStatusCode.NotFound);
+                }
+
+                string? armId = dt.Rows[0]["armId"] == null ? string.Empty : dt.Rows[0]["armId"].ToString();
+
+                if (string.IsNullOrWhiteSpace(armId))
+                {
+                    throw new Exception($"Unable to fetch arm resource for {string.Join("//", provider, serviceName, resourceName)}. Kusto query results doesnt contain column 'armId'.");
+                }
+
+                cacheValue = armId;
+                await redisService.SetKey(cacheKey, cacheValue);
+            }
+
+            return cacheValue;
+        }
+
+        private string FakeResource(string provider, string serviceName, string resourceName) =>
+            string.Format(ResourceConstants.ArmUrlTemplate, "00000000-0000-0000-0000-000000000000", "Fake-RG", provider, serviceName, resourceName);
+    }
+}

--- a/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
@@ -70,7 +70,7 @@ namespace AppLensV3.Services
                 ArmResourceServiceConfig.ArmKustoQueryPerService.TryGetValue(dictKey, out var kustoInfo);
                 if (kustoInfo == null)
                 {
-                    throw new Exception($"No Arm kusto query found for provider : {provider} and service : {serviceName}");
+                    throw new Exception($"No Arm kusto query found for provider : {provider} and service : {serviceName}. Most likely ARM url resolution is not enabled for this service.");
                 }
 
                 var dt = await kustoQueryService.ExecuteQueryAsync(
@@ -82,7 +82,7 @@ namespace AppLensV3.Services
                 if (dt == null || dt.Rows == null || dt.Rows.Count == 0)
                 {
                     throw new NotFoundException(
-                        $"Unable to fetch arm resource for {string.Join("/", provider, serviceName, resourceName)}. " +
+                        $"Unable to fetch arm resource for '{string.Join("/", provider, serviceName, resourceName)}'. " +
                         $"Kusto query returned 0 results." +
                         $"Cluster: {kustoInfo.Item1}, Database: {kustoInfo.Item2}, Query: {string.Format(kustoInfo.Item3, resourceName)}",
                         System.Net.HttpStatusCode.NotFound);
@@ -92,7 +92,7 @@ namespace AppLensV3.Services
 
                 if (string.IsNullOrWhiteSpace(armId))
                 {
-                    throw new Exception($"Unable to fetch arm resource for {string.Join("//", provider, serviceName, resourceName)}. Kusto query results doesnt contain column 'armId'.");
+                    throw new Exception($"Unable to fetch arm resource for '{string.Join("//", provider, serviceName, resourceName)}'. Kusto query results doesnt contain column 'armId'.");
                 }
 
                 cacheValue = armId;

--- a/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
@@ -92,7 +92,7 @@ namespace AppLensV3.Services
 
                 if (string.IsNullOrWhiteSpace(armId))
                 {
-                    throw new Exception($"Unable to fetch arm resource for '{string.Join("//", provider, serviceName, resourceName)}'. Kusto query results doesnt contain column 'armId'.");
+                    throw new Exception($"Unable to fetch arm resource for '{string.Join("/", provider, serviceName, resourceName)}'. Kusto query results doesnt contain column 'armId'.");
                 }
 
                 cacheValue = armId;

--- a/ApplensBackend/Services/ArmResourceService/ArmResourceServiceConfig.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceServiceConfig.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AppLensV3.Services
+{
+    public class ArmResourceServiceConfig
+    {
+        /// <summary>
+        /// This dictionary contains the kusto query per azure service to give the Arm Id.
+        /// Please note:
+        /// The kusto query should take only one input : {0}. We will replace this with the resource name.
+        /// The kusto query should output atleast one column with title 'armId'.
+        /// </summary>
+        public static Dictionary<string, Tuple<string, string, string>> ArmKustoQueryPerService = new Dictionary<string, Tuple<string, string, string>>()
+        {
+            { "microsoft.apimanagement/service:publicazure", new Tuple<string, string, string>("apim", "APIMProd", "GetApimServiceArmResourceId('{0}') | project armId") }
+        };
+    }
+}

--- a/ApplensBackend/Services/RedisCache/IRedisService.cs
+++ b/ApplensBackend/Services/RedisCache/IRedisService.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace AppLensV3.Services
+{
+    public interface IRedisService<T>
+    {
+        bool IsEnabled();
+        Task<string> GetKey(string key);
+        Task<bool> SetKey(string key, string value, TimeSpan? expiryTime = null);
+        Task<bool> DeleteKey(string key);
+    }
+}

--- a/ApplensBackend/Services/RedisCache/RedisServiceBase.cs
+++ b/ApplensBackend/Services/RedisCache/RedisServiceBase.cs
@@ -1,0 +1,65 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace AppLensV3.Services.RedisCache
+{
+    public abstract class RedisServiceBase<T> : IRedisService<T> where T : class
+    {
+        public bool _redisEnabled;
+        public readonly Task<RedisConnection> _redisConnectionFactory;
+        public RedisConnection _redisConnection;
+        public TimeSpan DefaultExpiryTime;
+
+        public RedisServiceBase(bool redisEnabled, Task<RedisConnection> redisConnectionFactory, int expiryTimeInHours = 72)
+        {
+            _redisEnabled = redisEnabled;
+            if (_redisEnabled)
+            {
+                _redisConnectionFactory = redisConnectionFactory;
+                DefaultExpiryTime = TimeSpan.FromHours(expiryTimeInHours);
+            }
+        }
+
+        public bool IsEnabled()
+        {
+            return _redisEnabled;
+        }
+
+        public async Task<string> GetKey(string key)
+        {
+            if (!_redisEnabled) { return null; }
+            _redisConnection = await _redisConnectionFactory;
+            return (await _redisConnection.BasicRetryAsync(async (db) => await db.StringGetAsync(key))).ToString();
+        }
+
+        public async Task<bool> SetKey(string key, string value, TimeSpan? expiryTime = null)
+        {
+            if (!_redisEnabled) { return false; }
+            _redisConnection = await _redisConnectionFactory;
+            if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
+            {
+                var setResult = await _redisConnection.BasicRetryAsync(async (db) => await db.StringSetAsync(key, value, expiryTime != null ? expiryTime : DefaultExpiryTime));
+                return setResult;
+            }
+            else
+            {
+                throw new Exception($"The following parameters are empty: {(string.IsNullOrWhiteSpace(key) ? "key" : string.Empty)} {(string.IsNullOrWhiteSpace(value) ? "value" : string.Empty)}");
+            }
+        }
+
+        public async Task<bool> DeleteKey(string key)
+        {
+            if (!_redisEnabled) { return true; }
+            _redisConnection = await _redisConnectionFactory;
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                var deleteResult = await _redisConnection.BasicRetryAsync(async (db) => await db.KeyDeleteAsync(key));
+                return deleteResult;
+            }
+            else
+            {
+                throw new Exception("The provided key is empty");
+            }
+        }
+    }
+}

--- a/ApplensBackend/appsettings.json
+++ b/ApplensBackend/appsettings.json
@@ -178,8 +178,14 @@
     "RedisConnectionString": "",
     "DefaultCacheExpiryInDays": 7
   },
+  "ArmResourceService": {
+    "Enabled": false,
+    "RedisEnabled": false,
+    "RedisConnectionString": "",
+    "DefaultCacheExpiryInDays": 7
+  },
   "NetworkTraceAnalysisTool": {
     "Enabled": true,
     "APIUrl": "https://ntwk-trace-analysis-tool-app.purpleground-97896349.eastus.azurecontainerapps.io/"
-  } 
+  }
 }


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->

The change is to:
- Add support for services in future to become 1P easily (i.e. we are able to identify arm url from the resource name)
- Since we dont have ARM/Resource Graph access, APIM has a kusto query that would help with the arm url resolution.
- In future, if any other service also has this support, we should be able to very quickly add them,

<!--- Why is this change required? What problem does it solve? -->
- This is needed to strengthen the security of our system with resource validation.

## Screenshots After Fix (if appropriate):

![image](https://user-images.githubusercontent.com/11183841/235243063-b41992e5-e198-428b-a9f9-17959eeb7d29.png)



