### PR TITLE
Rename the authRequestFailed to downpage to avoid confusion

### DIFF
--- a/AngularApp/projects/applens/src/app/app.module.ts
+++ b/AngularApp/projects/applens/src/app/app.module.ts
@@ -147,7 +147,7 @@ export const Routes = RouterModule.forRoot([
         component: UnauthorizedComponent
     },
     {
-        path: 'authRequestFailed',
+        path: 'downpage',
         component: AuthRequestFailedComponent
     },
     {

--- a/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
@@ -51,7 +51,7 @@ export class AadAuthGuard implements CanActivate {
                         this._router.navigate(['tokeninvalid']);
                     }
                     else {
-                        this._router.navigate(['pingRequestFailed']);
+                        this._router.navigate(['downpage']);
                     }
                     return observableThrowError(false);
                 }));

--- a/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
@@ -51,7 +51,7 @@ export class AadAuthGuard implements CanActivate {
                         this._router.navigate(['tokeninvalid']);
                     }
                     else {
-                        this._router.navigate(['authRequestFailed']);
+                        this._router.navigate(['pingRequestFailed']);
                     }
                     return observableThrowError(false);
                 }));


### PR DESCRIPTION
Today if the first ping we send to applens backend fails users are show a page that says applens backend is down but the url reads "authRequestFailed" which may be misleading as some people may think their auth is failing.

Renaming it to "downpage"