### PR TITLE
Code optimizations fix empty banner

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.html
@@ -134,41 +134,43 @@
     </div>
   </div>
 </div>
-
-<div *ngIf="isEnabledInProd && !loadingSettings && appInsightsValiationError.length == 0" class="animated fadeIn panel panel-info width-90">
-  <div class="banner">
-    <div class="banner-child">
-      <div class="ml-3">
-        <div *ngIf="loadingSettings">
-          <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
-          Verifying Optimization Insights...
-        </div>
-        <div *ngIf="!loadingSettings">
-          <div *ngIf="!connecting && !error">
-            <div *ngIf="isAppInsightsEnabled">
-              <table *ngIf="hasWriteAccess && !isAppInsightsConnected && canCreateApiKeys">
-                <tbody>
-                  <tr>
-                    <td><i class="fa fa-exclamation-triangle warning-icon-color mr-2"></i>
-                    </td>
-                    <td>Connect Application Insights with App Service Diagnostics to allow App Service Diagnostics
-                      to
-                      access Code Optimizations insights.
-                    </td>
-                    <td>
-                      <div class="ml-2">
-                        <a href="https://aka.ms/serviceprofiler"
-                          aria-label="Click to know more about Code Optimizations insights" target="_blank">Learn
-                          more</a>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <ng-container *ngIf="appInsightsValidated">
-                <div><opt-insights-enablement
-                    [optInsightResourceInfo]="optInsightResourceInfoSubject"></opt-insights-enablement></div>
-              </ng-container>
+<div *ngIf="isBetaSubscription">
+  <div *ngIf="isEnabledInProd && !loadingSettings && appInsightsValiationError.length == 0"
+    class="animated fadeIn panel panel-info width-90">
+    <div class="banner">
+      <div class="banner-child">
+        <div class="ml-3">
+          <div *ngIf="loadingSettings">
+            <i class="fa fa-circle-o-notch fa-spin spin-icon" aria-hidden="true"></i>
+            Verifying Optimization Insights...
+          </div>
+          <div *ngIf="!loadingSettings">
+            <div *ngIf="!connecting && !error">
+              <div *ngIf="isAppInsightsEnabled">
+                <table *ngIf="hasWriteAccess && !isAppInsightsConnected && canCreateApiKeys">
+                  <tbody>
+                    <tr>
+                      <td><i class="fa fa-exclamation-triangle warning-icon-color mr-2"></i>
+                      </td>
+                      <td>Connect Application Insights with App Service Diagnostics to allow App Service Diagnostics
+                        to
+                        access Code Optimizations insights.
+                      </td>
+                      <td>
+                        <div class="ml-2">
+                          <a href="https://aka.ms/serviceprofiler"
+                            aria-label="Click to know more about Code Optimizations insights" target="_blank">Learn
+                            more</a>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <ng-container *ngIf="appInsightsValidated">
+                  <div><opt-insights-enablement
+                      [optInsightResourceInfo]="optInsightResourceInfoSubject"></opt-insights-enablement></div>
+                </ng-container>
+              </div>
             </div>
           </div>
         </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/app-insights-enablement/app-insights-enablement.component.ts
@@ -6,6 +6,8 @@ import { BackendCtrlQueryService } from '../../services/backend-ctrl-query.servi
 import { TelemetryEventNames } from '../../services/telemetry/telemetry.common';
 import { MessageBarType } from 'office-ui-fabric-react';
 import { BehaviorSubject } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { DemoSubscriptions } from '../../../lib/models/betaSubscriptions';
 
 const maxApiKeysPerAiResource: number = 10;
 
@@ -19,10 +21,12 @@ export class AppInsightsEnablementComponent implements OnInit {
 
   constructor(private _appInsightsService: AppInsightsQueryService,
     private _backendCtrlService: BackendCtrlQueryService,
-    private _settingsService: SettingsService) {
+    private _settingsService: SettingsService,
+    private _route: ActivatedRoute) {
   }
 
   loadingSettings: boolean = true;
+  loadingCodeOptimizationSettings: boolean = true;
   isAppInsightsEnabled: boolean = false;
   isAppInsightsConnected: boolean = false;
   appInsightsValidated: boolean = false;
@@ -39,11 +43,16 @@ export class AppInsightsEnablementComponent implements OnInit {
   test1: string = "Value1";
   test2: string = "Value2";
   optInsightResourceInfoSubject = new BehaviorSubject<{ resourceUri: string, appId: string }>({ resourceUri: "", appId: "" });
+  subscriptionId: string;
+  isBetaSubscription: boolean = false;
 
   @Input()
   resourceId: string = "";
 
   ngOnInit() {
+    this.subscriptionId = this._route.parent.snapshot.parent.params['subscriptionid'];
+    // allowlisting beta subscriptions for testing purposes
+    this.isBetaSubscription = DemoSubscriptions.betaSubscriptions.indexOf(this.subscriptionId) >= 0;
     if (this.isEnabledInProd) {
       this.appInsightsValiationError = "";
       this._appInsightsService.loadAppInsightsResourceObservable.subscribe(loadStatus => {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
@@ -6,7 +6,7 @@ import { DetectorControlService } from '../../services/detector-control.service'
 import { PortalActionGenericService } from '../../services/portal-action.service';
 import { TelemetryEventNames } from '../../services/telemetry/telemetry.common';
 import { ActivatedRoute } from '@angular/router';
-import { DemoSubscriptions } from 'projects/diagnostic-data/src/lib/models/betaSubscriptions';
+import { DemoSubscriptions } from '../../../lib/models/betaSubscriptions';
 import * as moment from 'moment';
 
 


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
Removing empty banner being displayed to non-beta subscriptions.
<!--- Why is this change required? What problem does it solve? -->
Non-beta subscriptions are seeing an empty banner
## Related Work Item
<!--- Please provide the work item number as well as its link: -->
N/A
## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
Added the check for beta subscriptions to app-insights-enablement component

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->
1. In the Azure Portal, under a non-beta subscription, go to a Web App integrated with Application Insights which has profilers enabled and Code Optimization Insights.
2. Click on Diagnose and Solve problems then in Availability and Performance. This will load the Overview detector.
3.  In the Overview detector first it will try to show Application Insights there should not be an empty banner under the Application Insights banner.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://user-images.githubusercontent.com/7376302/235778041-f476e197-655c-4bd7-86f2-3632a83f1699.png)

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
