### PR TITLE
LogicAppsStandard pesId info for genie to work with detectors

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/web-sites.service.ts
@@ -89,6 +89,9 @@ export class WebSitesService extends ResourceService {
             else if (this.appType == AppType.FunctionApp) {
                 return of("16072");
             }
+            else if (this.appType == AppType.WorkflowApp) {
+                return of("17378");
+            }
             else {
                 return of(null);
             }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/search.ts
@@ -2,7 +2,7 @@ interface PreferredSitesConfig {
     [index: string]: string[];
 }
 
-export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15791", "15551", "16450"];
+export var detectorSearchEnabledPesIds: string[] = ["14748", "16072", "16170", "15791", "15551", "16450", "17378"];
 export var detectorSearchEnabledSapProductIds: string[] = [
     'b4d0e877-0166-0474-9a76-b5be30ba40e4',
     'b452a42b-3779-64de-532c-8a32738357a6',


### PR DESCRIPTION
## Overview
Project Shield has been enabled for Logic Apps Standard, but the detector search doesn't work because the resourceService.getPesId method returns null for AppType = WorkflowApp.

Made the change to return pesId for LA Standard.

**Before fix:**
![image](https://user-images.githubusercontent.com/8492235/236599421-781f5302-2ae9-484a-99af-bfe18aef040d.png)


**After fix:**
![image](https://user-images.githubusercontent.com/8492235/236599394-20e0c82e-b9f5-4113-8b20-fe3bd6c76f10.png)
