### PR TITLE
Append hostname if missing for Daas Reports

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -40,6 +40,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
   allSessions: string = '../../diagnosticTools';
   subscription: Subscription;
   initializedOnce: boolean = false;
+  scmHostName: string = '';
 
   // For tooltip display
   directionalHint = DirectionalHint.rightTopEdge;
@@ -76,6 +77,7 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
     });
     this.enableSessionsPanel = this._route.snapshot.params['category'] != null || this._route.parent.snapshot.params['category'] != null;
     this.isWindowsApp = this._webSiteService.platform === OperatingSystem.windows;
+    this.scmHostName = this._webSiteService.resource.properties.enabledHostNames.find((hostname: string) => hostname.indexOf('.scm.') > 0);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -415,6 +417,10 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
   }
 
   openUrl(url: string) {
+    if (url.toLowerCase().startsWith('/api/')) {
+      url = "https://" + this.scmHostName + url;
+    }
+
     this._windowService.open(url);
   }
 


### PR DESCRIPTION
## Overview
It is possible that the DAAS Sessions will return the Reports link without the SCM host name. This happens because the logic to get the default host name in DaaS depends upon a sandbox property and that property may be empty if no requests came to that site




## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Solution description
With this change, we are correctly populating the SCM host name if the DAAS API returns the relativepath without the full host name.