### PR TITLE
Preserve query params in ASE finder

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/ase/ase-finder/ase-finder.component.ts
@@ -43,7 +43,7 @@ export class AseFinderComponent implements OnInit {
       'providers','Microsoft.Web',
       'hostingEnvironments', matchingAse.Name];
 
-    this._router.navigate(resourceArray);
+    this._router.navigate(resourceArray, { queryParamsHandling: 'preserve' });
   }
 
 }


### PR DESCRIPTION
## Overview
ASE Finder is not preserving query params, due to which CSS users are getting case number not entered, even after it has been entered.
