### PR TITLE
Force UI code to use DiagServer everywhere

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
@@ -142,10 +142,6 @@ export class DaasValidatorComponent implements OnInit {
   }
 
   checkDiagServerForLinux(): Observable<boolean> {
-    if (!this.allLinuxInstancesOnAnt98) {
-      return of(false);
-    }
-
     return this._daasService.isDiagServerEnabledForLinux(this.siteToBeDiagnosed);
   }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -277,9 +277,10 @@ export class DaasService {
     }
 
     isDiagServerEnabledForLinux(site: SiteDaasInfo): Observable<boolean> {
-        if (this.linuxDiagServerEnabledChecked) {
-            return of(this.linuxDiagServerEnabled);
-        }
+        return of(true);
+        // if (this.linuxDiagServerEnabledChecked) {
+        //     return of(this.linuxDiagServerEnabled);
+        // }
 
         //
         // Commenting this out because of a bug in /daas/v2/sesssions/settings implementation
@@ -298,25 +299,25 @@ export class DaasService {
         //         return of(this.linuxDiagServerEnabled)
         //     }));
 
-        const resourceUri: string = this._uriElementsService.getLinuxCommandUrl(site);
-        let command: LinuxCommand = { command: "printenv WEBSITE_USE_DIAGNOSTIC_SERVER" };
-        return this._armClient.postResourceWithoutEnvelope<LinuxCommandOutput, LinuxCommand>(resourceUri, command, null, true).pipe(
-            map((resp: LinuxCommandOutput) => {
-                if (resp && resp.Output) {
-                    this.linuxDiagServerEnabled = resp.Output.toLowerCase().startsWith('true');
-                    this.linuxDiagServerEnabledChecked = true;
-                    return this.linuxDiagServerEnabled;
-                } else {
-                    this.linuxDiagServerEnabled = false;
-                    this.linuxDiagServerEnabledChecked = true;
-                    return this.linuxDiagServerEnabled;
-                }
-            }),
-            catchError(e => {
-                this.linuxDiagServerEnabled = false;
-                this.linuxDiagServerEnabledChecked = true;
-                return of(this.linuxDiagServerEnabled)
-            }));
+        // const resourceUri: string = this._uriElementsService.getLinuxCommandUrl(site);
+        // let command: LinuxCommand = { command: "printenv WEBSITE_USE_DIAGNOSTIC_SERVER" };
+        // return this._armClient.postResourceWithoutEnvelope<LinuxCommandOutput, LinuxCommand>(resourceUri, command, null, true).pipe(
+        //     map((resp: LinuxCommandOutput) => {
+        //         if (resp && resp.Output) {
+        //             this.linuxDiagServerEnabled = resp.Output.toLowerCase().startsWith('true');
+        //             this.linuxDiagServerEnabledChecked = true;
+        //             return this.linuxDiagServerEnabled;
+        //         } else {
+        //             this.linuxDiagServerEnabled = false;
+        //             this.linuxDiagServerEnabledChecked = true;
+        //             return this.linuxDiagServerEnabled;
+        //         }
+        //     }),
+        //     catchError(e => {
+        //         this.linuxDiagServerEnabled = false;
+        //         this.linuxDiagServerEnabledChecked = true;
+        //         return of(this.linuxDiagServerEnabled)
+        //     }));
     }
 
     putStdoutSetting(resourceUrl: string, enabled: boolean): Observable<{ Stdout: string }> {


### PR DESCRIPTION
## Overview
This PR just assumes that DiagServer for Linux is enabled everywhere as the DiagServer deployment in Linux went live long back