### PR TITLE
Address ArmResourceService for national clouds.

### DIFF
--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -129,7 +129,7 @@ namespace AppLensV3
             }
 
             services.AddSingleton<IRedisService<ArmResourceRedisModel>>(new ArmResourceRedisCache(Configuration, RedisConnection.InitializeAsync(true, connectionString: Configuration["ArmResourceService:RedisConnectionString"].ToString())));
-            services.AddSingleton<IArmResourceService, ArmResourceService>();
+            services.AddSingletonWhenEnabled<IArmResourceService, ArmResourceService, NullableArmResourceService>(Configuration, "ArmResourceService");
 
             services.AddMemoryCache();
             services.AddMvc().AddNewtonsoftJson();

--- a/ApplensBackend/Controllers/ResourceController.cs
+++ b/ApplensBackend/Controllers/ResourceController.cs
@@ -12,12 +12,10 @@ namespace AppLensV3
     public class ResourceController : Controller
     {
         IObserverClientService _observerService;
-        IArmResourceService _armResourceService;
 
-        public ResourceController(IObserverClientService observerService, IArmResourceService resourceService)
+        public ResourceController(IObserverClientService observerService)
         {
             _observerService = observerService;
-            _armResourceService = resourceService;
         }
 
         [HttpGet("api/sites/{siteName}")]
@@ -189,7 +187,7 @@ namespace AppLensV3
 
         [HttpGet]
         [Route("api/armresourceurl/{providerName}/{serviceName}/{resourceName}")]
-        public async Task<IActionResult> GetArmResourceUrl(string providerName, string serviceName, string resourceName)
+        public async Task<IActionResult> GetArmResourceUrl(string providerName, string serviceName, string resourceName, [FromServices] IArmResourceService resourceService)
         {
             try
             {
@@ -198,7 +196,7 @@ namespace AppLensV3
                     return BadRequest("arguments cannot be null or empty.");
                 }
 
-                var armID = await _armResourceService.GetArmResourceUrlAsync(providerName, serviceName, resourceName);
+                var armID = await resourceService.GetArmResourceUrlAsync(providerName, serviceName, resourceName);
                 return Ok(armID);
             }
             catch (NotFoundException ex)

--- a/ApplensBackend/Services/ArmResourceService/NullableArmResourceService.cs
+++ b/ApplensBackend/Services/ArmResourceService/NullableArmResourceService.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using AppLensV3.Helpers;
+
+namespace AppLensV3.Services
+{
+    public class NullableArmResourceService : IArmResourceService
+    {
+        public Task<string> GetArmResourceUrlAsync(string provider, string serviceName, string resourceName)
+        {
+            return Task.FromResult(FakeResource(provider, serviceName, resourceName));
+        }
+
+        private string FakeResource(string provider, string serviceName, string resourceName) =>
+            string.Format(ResourceConstants.ArmUrlTemplate, "00000000-0000-0000-0000-000000000000", "Fake-RG", provider, serviceName, resourceName);
+    }
+}


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

There was a breaking change that was not compatible with national clouds. This is addressing that.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
<!--- Describe your code changes in details for reviewers. -->
The reason for the breaking change is that ArmResourceService depends on KustoQueryService which is not enabled in n-clouds as we didn't have a use case for it but we may in the near future. In the mean time we want to work around this issue by creating a NullableArmResourceService that returns FakeResource for when APIM is selected in the drop down for selecting a resource.


## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

This is tested by running Applens locally setting the startup to start from ApplensV3NationalClouds.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.
