### PR TITLE
Nmallick1/fix app lens home page entry screen

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -445,7 +445,7 @@ export class MainComponent implements OnInit {
   }
 
   onSubmit() {
-    if(!!this.errorMessage && this.errorMessage != 'Invalid subscription id.') {
+    if(!!this.errorMessage) {
       return;
     }
     
@@ -618,6 +618,16 @@ export class MainComponent implements OnInit {
 
   updateResourceName(e: { event: Event, newValue?: string }) {
     this.resourceName = e.newValue.toString();
+    if(this.isNoResource) {
+      if(!Guid.isGuid(this.resourceName.trim())) {
+        this.errorMessage = 'Invalid subscription id.';
+      }
+      else {
+        if(this.errorMessage === 'Invalid subscription id.') {
+          this.errorMessage = '';
+        }
+      }
+    }
     this.hasResourceCaseNumberEnforced();
   }
 

--- a/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/main/main/main.component.ts
@@ -445,9 +445,10 @@ export class MainComponent implements OnInit {
   }
 
   onSubmit() {
-    if(!!this.errorMessage) {
+    if(!!this.errorMessage && this.errorMessage != 'Invalid subscription id.') {
       return;
     }
+    
     this._userSettingService.updateDefaultServiceType(this.selectedResourceType.id);
     let resourceUri = '';
     if (!(this.caseNumber == "internal") && this.caseNumberNeededForUser && (this.selectedResourceType && this.caseNumberNeededForRP)) {


### PR DESCRIPTION
## Overview
If a user entered an invalid subscription id for no resource, an error would appear, after that, even if they entered the correct id, the error would not be reset and we won't allow them to proceed

## Related Work Item
NA

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## Solution description
Add validation logic in the onchange event of the text box to clear off invalid subscription error if it was present.

## How Can This Be Tested? <span>&#128269;</span>
Enter a non GUID value after selecting I do not have a resource to get the error, then enter a valid GUID and you should now be able to continue further

## Checklist <span>&#9989;</span>
- [X ] I have looked over the diffs.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/5ffddf33-cbc8-44a9-9ad0-61a3ddec0e9a)
