### PR TITLE
Nmallick1/no resource daa s fix

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
@@ -71,7 +71,7 @@ export class UriUtilities {
 
     static isNoResourceCall(resourceUri: string): boolean {
         // Temporary fix for DaaS, it genuinely passes in a resourceUri of "NoResource" in the format /subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageaccounts and the call should be created appropriately.
-        return `${resourceUri}`.toLowerCase().indexOf('/providers/microsoft.storage/storageaccounts/') > -1 || `${resourceUri}`.toLowerCase().indexOf('/resourcegroups/') < 0;
+        return `${resourceUri}`.toLowerCase().indexOf('/providers/microsoft.storage/storageaccounts') > -1 ? false : `${resourceUri}`.toLowerCase().indexOf('/resourcegroups/') < 0;
     }
 
     static isApolloApiCall(resourceUri: string): boolean {

--- a/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/utilities/uri-utilities.ts
@@ -70,7 +70,8 @@ export class UriUtilities {
     }
 
     static isNoResourceCall(resourceUri: string): boolean {
-        return `${resourceUri}`.toLowerCase().indexOf('/resourcegroups/') < 0;
+        // Temporary fix for DaaS, it genuinely passes in a resourceUri of "NoResource" in the format /subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageaccounts and the call should be created appropriately.
+        return `${resourceUri}`.toLowerCase().indexOf('/providers/microsoft.storage/storageaccounts/') > -1 || `${resourceUri}`.toLowerCase().indexOf('/resourcegroups/') < 0;
     }
 
     static isApolloApiCall(resourceUri: string): boolean {


### PR DESCRIPTION
## Overview
isNoResourceCall method in \AngularApp\projects\diagnostic-data\src\lib\utilities\uri-utilities.ts gets the parameter as "/subscriptions/6b6db65f-680e-4650-b97d-e82ed6a0f583/providers/Microsoft.Storage/storageAccounts" and it thinks that this is a noResourceCall as it is missing /resourceGroups/

Then the rest of the code incorrectly assumes that this is a "no resource call" and constructs the URL incorrectly

## Related Work Item
NA

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
Explicitly checking for "/providers/Microsoft.Storage/storageAccounts"  in the string. It'll work for now as we do not have storage team onboarded. This will need to be re-evaluated if we onboard them.

### This PR:
Explicitly checking for "/providers/Microsoft.Storage/storageAccounts"  in the string. It'll work for now as we do not have storage team onboarded. This will need to be re-evaluated if we onboard them.

## How Can This Be Tested? <span>&#128269;</span>
Navigate to storage blade

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/eda55b01-9e09-4e0a-8a55-b80b9fa33280)


## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/2efdb5b8-4098-4f2e-a5c5-9b7b6786e3f4)


## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
