### PR TITLE
Fix logic to check for resource name in Diagnose And Solve page

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/fabric-ui/components/category-summary/category-summary.component.ts
@@ -91,7 +91,7 @@ export class CategorySummaryComponent implements OnInit {
             this.category = categories.find(category => category.id.toLowerCase() === this._activatedRoute.snapshot.params.category.toLowerCase() ||  category.name.replace(/\s/g, '').toLowerCase() === decodedCategoryName);
             this._chatState.category = this.category;
             this.categoryName = this.category ? this.category.name : "";
-            if(this._resourceService.resource.id && UriUtilities.isNoResourceCall(this._resourceService.resource.id)) {
+            if(this._resourceService.resource.id && !UriUtilities.isNoResourceCall(this._resourceService.resource.id)) {
                 this.resourceName = this._activatedRoute.snapshot.parent.params.resourcename;
             } else {
                 this.resourceName = '';


### PR DESCRIPTION
## Overview
Fix logic to check for resource name in Diagnose And Solve page. Resource name was not being displayed on the portal when navigating inside a category

## Related Work Item
NA

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
Fix logic to check for resource name in Diagnose And Solve page so that resource name is displayed inside a category.

## How Can This Be Tested? <span>&#128269;</span>
Navigate into a category and you should be able to see the resource name.

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/de57645e-d88e-4d51-9912-3eee51e8e683)

## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/8a68ea62-5d36-4990-8195-905627bda9ec)


