### PR TITLE
Adding more logging for better telemetry

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/optinsights/optinsights.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/optinsights/optinsights.service.ts
@@ -88,7 +88,7 @@ export class OptInsightsService {
       retry(2),
       map((aggregatedInsights: any) => {
         this.optInsightsResponse = this.parseRowsIntoTable(aggregatedInsights);
-        this.logOptInsightsEvent(this.appInsightsResourceUri, TelemetryEventNames.AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful, aggregatedInsights.length);
+        this.logOptInsightsEvent(this.appInsightsResourceUri, TelemetryEventNames.AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful, "", aggregatedInsights.length);
         if (this.optInsightsResponse.length <= 1) {
           return this.optInsightsResponse;
         }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
@@ -49,7 +49,9 @@ export class OptInsightsEnablementComponent implements OnInit {
         this._optInsightsService.getInfoForOptInsights(optInsightResourceInfo.resourceUri, optInsightResourceInfo.appId, this._route.parent.snapshot.params['site'], this._detectorControlService.startTime, this._detectorControlService.endTime, false).subscribe(res => {
           if (res) {
             this.table = res;
-            this._optInsightsService.logOptInsightsEvent(optInsightResourceInfo.resourceUri, TelemetryEventNames.AICodeOptimizerInsightsReceived);
+            if (this.table.length > 0) {
+                this._optInsightsService.logOptInsightsEvent(optInsightResourceInfo.resourceUri, TelemetryEventNames.AICodeOptimizerInsightsReceived);
+            }
           }
           this.loading = false;
         }, error => {
@@ -74,6 +76,7 @@ export class OptInsightsEnablementComponent implements OnInit {
     let optInsightsResource: OptInsightsResource = this.parseOptInsightsResource(this.appInsightsResourceUri, 0, 'microsoft.insights/components', false);
     let optInsightsTimeContext: OptInsightsTimeContext = { durationMs: durationMs, endTime: this._detectorControlService.endTime.toISOString(), createdTime: this._detectorControlService.startTime.toISOString(), isInitialTime: false, grain: 1, useDashboardTimeRange: false };
     this.portalActionService.openOptInsightsBladewithTimeRange(optInsightsResource, optInsightsTimeContext);
+    this._optInsightsService.logOptInsightsEvent(this.appInsightsResourceUri, TelemetryEventNames.AICodeOptimizerOpenOptInsightsBladewithTimeRange);
   }
 
 

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -131,6 +131,7 @@ export const TelemetryEventNames = {
     AICodeOptimizerInsightsOAuthAccessTokenFailure: 'AICodeOptimizerInsightsOAuthAccessTokenFailure',
     AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful: 'AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful',
     AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeFailure: 'AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeFailure',
+    AICodeOptimizerOpenOptInsightsBladewithTimeRange: 'AICodeOptimizerOpenOptInsightsBladewithTimeRange',
     LoadingTimeOut: 'LoadingTimeOut',
     EmptySearchTerm: 'EmptySearchTerm',
     ChatGPTARMQueryResults: 'ChatGPTARMQueryResults',


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
Adding Telemetry to measure when the button to open Code Optimizations blade is clicked and when we receive results from Code Optimizations
<!--- Why is this change required? What problem does it solve? -->
This will help us have telemetry for how many times we are showing insights to customers and how many times they are clicking on them to learn more details.


## Related Work Item
<!--- Please provide the work item number as well as its link: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
- Adding a AICodeOptimizerOpenOptInsightsBladewithTimeRange TelemetryEventName to measure when a user clicks in the insights, which will open Code Optimizations blade.
- Adding a check to only log  AICodeOptimizerInsightsReceived when results come in.
- When logging the total amount of results, adding an empty parameter so that the value of total amount of results it's not recognized as error.

## How Can This Be Tested? <span>&#128269;</span>
1. Go to Azure Portal and click Application Insights.
2. Open the DiagnosticsAndSolvePortal Application Insights component.
3. Open Logs and run the following query:
`customEvents
| where timestamp >= start
| where name == "AICodeOptimizerOpenOptInsightsBladewithTimeRange " or  name == "AICodeOptimizerInsightsReceived " or name == "AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful"
| extend TotalInsights = toint(customDimensions["TotalInsights"])`
Confirm that:

- AICodeOptimizerOpenOptInsightsBladewithTimeRange is being logged
- When AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful gets logged TotalInsights shows results
- We only log AICodeOptimizerInsightsReceived when TotalInsights is greater than 0
- 
## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
