### PR TITLE
Fix for refreshing in portal

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/detector-control.service.ts
@@ -237,7 +237,7 @@ export class DetectorControlService {
   }
 
   public refresh(instanceId: string = "") {
-    this._duration ? this.selectDuration(this._duration) : this._refreshData(instanceId);
+    this._refreshData(instanceId);
   }
 
   public toggleInternalExternal() {


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
This PR is for fixing refreshing when click "refresh" button in the command bar in Portal

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

1. Go to D&S portal and go to any detector
2. In time picker, change the time duration
3. Click "refresh" button in the command bar
4. Check if detector is showing data within time period you specified.