### PR TITLE
ARM Resource Service : Add resource to durian cache to skip ACIS validation

### DIFF
--- a/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
+++ b/ApplensBackend/Services/ArmResourceService/ArmResourceService.cs
@@ -76,6 +76,9 @@ namespace AppLensV3.Services
 
                 cacheValue = armId;
                 await redisService.SetKey(cacheKey, cacheValue);
+                
+                // Push the armId to durian cache as well to skip ACIS validation in runtimehost
+                await redisService.SetKey((armId.StartsWith("/") ? armId[1..] : armId).ToLower(), true.ToString());
             }
 
             return cacheValue;


### PR DESCRIPTION

## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

This is a fix from a followup conversation on Applens channel.
For APIM or any service using ARM Resource service in applens, When we are able to get the ARM resource Id from the resource name using their Kusto query, there is no further need to validate the ARM url in our backend (using acis)
So adding the armId to durian cache to avoid acis validation

## Related Work Item
<!--- Please provide the work item number as well as its link: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
<!--- An example of a solution description -->
<!--- - creates a new rendering type -->
<!--- - refactors the code -->
<!--- - adds a new function/enum to render a bar chart -->

## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

## Checklist <span>&#9989;</span>
- [ ] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [ ] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [ ] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
