### PR TITLE
Durian cross resource detectors and updated SG

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/dashboard/dashboard.component.ts
@@ -251,6 +251,11 @@ export class DashboardComponent implements OnDestroy {
     this._router.navigate(['unauthorized'], { queryParams: { isDurianEnabled: true } });
   }
 
+  isValidAzureResource(resourceId: string): boolean {
+    const azureResourceIdRegex = /^subscriptions\/[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}\/resourceGroups\/[^/]+\/providers\/Microsoft\.[^/]+\/[^/]+\/[^/]+$/i;  
+    return azureResourceIdRegex.test(resourceId);
+  }
+
   handleUserResponse(userResponse: ConfirmationOption) {
     let alias = this._adalService.userInfo.profile ? this._adalService.userInfo.profile.upn : '';
     if (userResponse.value === 'yes') {
@@ -259,9 +264,10 @@ export class DashboardComponent implements OnDestroy {
         this.displayErrorInDialog = true;
         return;
       }
-      this._telemetryService.logEvent(TelemetryEventNames.ResourceOutOfScopeUserResponse, { userId: alias, url: this._router.url, userResponse: userResponse.label, userJustification: this.crossSubJustification, caseNumber: this._diagnosticApiService.CustomerCaseNumber });
+      let resourceId = this.isValidAzureResource(this.alertInfo.resourceId)? this.alertInfo.resourceId: undefined      
+      this._telemetryService.logEvent(TelemetryEventNames.ResourceOutOfScopeUserResponse, { userId: alias, url: this._router.url, resourceId: resourceId, userResponse: userResponse.label, userJustification: this.crossSubJustification, caseNumber: this._diagnosticApiService.CustomerCaseNumber });
       this.showLoaderInDialog = true;
-      this._diagnosticService.unrelatedResourceConfirmation().subscribe(() => {
+      this._diagnosticService.unrelatedResourceConfirmation(resourceId).subscribe(() => {
         this.showLoaderInDialog = false;
         this.displayAlertDialog = false;
         this.alertInfo = null;

--- a/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
+++ b/AngularApp/projects/applens/src/app/shared/components/unauthorized/unauthorized.component.html
@@ -6,15 +6,8 @@
             <div style="flex: 0 1 auto;">
                 <p class="unauthorized-sub-header">Request for AppLens Access based on your role</p>
                 <ol>
-                    <li><a href="https://myaccess/identityiq/ui/rest/redirect?rp1=/accessRequest/accessRequest.jsf&rp2=accessRequest/review?role=AppLens+CSS+Access&autoSubmit=true" target="_blank" rel="noopener noreferrer">AppLens CSS Access</a> (for CSS Engineers and TAs only)</li>
+                    <li><a href="https://coreidentity.microsoft.com/manage/Entitlement/entitlement/applenscssac-vynx" target="_blank" rel="noopener noreferrer">AppLens CSS Access</a> (for CSS Engineers and TAs only)</li>
                     <li><a href="https://myaccess/identityiq/ui/rest/redirect?rp1=/accessRequest/accessRequest.jsf&rp2=accessRequest/review?role=AppLens+Non-CSS+Access&autoSubmit=true" target="_blank" rel="noopener noreferrer">AppLens Non-CSS Access</a> (for Escalation Engineers and Internal Microsoft Teams)</li>
-                </ol>
-                <p><u>If the above direct link does not work</u>, please follow the below steps to apply for access.</p>
-                <ol>
-                    <li>Go to <a href="https://myaccess" target="_blank" rel="noopener noreferrer">MyAccess</a></li>
-                    <li>Click on <strong>Request Access</strong></li>
-                    <li>Search for AppLens and select <strong>AppLens CSS Access</strong> or <strong>AppLens Non-CSS Access</strong> based on your role requirements.</li>
-                    <li>Click <strong>Next</strong> and move to Review and Submit</li>
                 </ol>
             </div>
         </div>

--- a/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-http-interceptor.service.ts
@@ -6,7 +6,6 @@ import { AlertService } from './alert.service';
 import { AdalService } from 'adal-angular4';
 import { AlertInfo, ConfirmationOption, UserAccessStatus } from 'diagnostic-data';
 import { HealthStatus } from "diagnostic-data";
-import { resource } from 'selenium-webdriver/http';
 
 @Injectable({
   providedIn: 'root'
@@ -42,7 +41,6 @@ export class AppLensInterceptorService implements HttpInterceptor {
     let headers = req.headers;
     let pathQuery = headers.get("x-ms-path-query");
     let resourceId = this.extractResourceIdFromPath(pathQuery);
-    console.log("ResourceId", resourceId);
     let errormsg = event.error;
     errormsg = errormsg.replace(/\\"/g, '"');
     errormsg = errormsg.replace(/\"/g, '"');

--- a/AngularApp/projects/diagnostic-data/src/lib/models/alerts.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/alerts.ts
@@ -7,6 +7,7 @@ export interface AlertInfo {
     confirmationOptions: ConfirmationOption[]; 
     alertStatus: HealthStatus;
     userAccessStatus:UserAccessStatus;
+    resourceId?: string;
 }
 
 export interface ConfirmationOption {


### PR DESCRIPTION
## Overview
Currently one scenario is not supported in Durian. This is the cross resource detector feature of Applens where user opens Applens for resource A, clicks a detector, which triggers some detectors for an underlying resource B (e.g. container apps detectors can triggers underlying AKS detectors, similarly for web apps on ASE). Durian can have issues with the confirmation for unrelated resource dialog box when the resource B detectors are fired and get unauthorized error. This PR aims to fix that.

Also, AppLens access SGs that were on MyAccess are now moving to CoreIdentity. This PR updates the url link of AppLens CSS Access group to the CoreIdentity page. Non-CSS Access group is not yet moved, will update that accordingly.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (**Updated documentation on Applens blog**)

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.
