### PR TITLE
Allows authors to specify category and InternalOnly for workflows

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1968,6 +1968,7 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
   updatePublishingPackageIfWorkflow() {
     if (this.isWorkflowDetector) {
       this.publishingPackage = this.workflowPackage;
+      this.code = this.publishingPackage.codeString;
       if (this.publishingPackage.metadata == null) {
         this.publishingPackage.metadata = "{}";
       }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
@@ -31,6 +31,20 @@
       </div>
 
     </div>
+
+    <div class="form-row">
+      <div class="form-group col-md-6">
+        <label for="internalOnly">Internal Only</label>
+        <select name="internalOnly" class="form-control input-sm" [(ngModel)]="publishBody.IsInternal">
+          <option [ngValue]="false">false</option>
+          <option [ngValue]="true">true</option>
+        </select>
+      </div>
+      <div class="form-group col-md-6">
+        <label for="category">Category</label>
+        <input name="category" class="form-control input-sm" [(ngModel)]="publishBody.Category">
+      </div>
+    </div>
     <div class="form-row">
       <ng-container *ngIf="service === 'SiteService'">
         <div class="form-group col-md-3">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
@@ -133,6 +133,7 @@ export class CreateWorkflowComponent implements OnInit, AfterViewInit, OnChanges
       this.publishBody.Description = packageJson.Description;
       this.publishBody.IsInternal = packageJson.IsInternal;
       this.publishBody.WorkflowName = packageJson.name;
+      this.publishBody.Category = packageJson.Category;
 
       if (this.resourceService.service === 'SiteService') {
         this.publishBody.AppType = packageJson.AppType;

--- a/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
@@ -126,6 +126,7 @@ export class workflowPublishBody {
   StackType: string;
   ResourceType: string;
   ResourceProvider: string;
+  Category: string;
 }
 
 export interface workflowNodeResult {


### PR DESCRIPTION
## Overview
With this change, workflow authors will be able to specify InternalOnly and Category metadata for workflows. 

Note: Category is not propagated properly to the backend code yet. Raising a PR for that as well.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/06c57ca1-d6a1-44e6-acde-e310749c9e41)
