### PR TITLE
FE - Enforce Kusto Service Authorization Across Multiple Clusters

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1566,16 +1566,17 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
           this.localDevButtonDisabled = false;
           this.markCodeLinesInEditor(this.detailedCompilationTraces);
         }, ((error: any) => {
+          const errorMessage = error?.error?.replace(/"/g, '');
           this.enableRunButton();
           this.publishingPackage = null;
           this.localDevButtonDisabled = false;
           this.runButtonText = "Run";
           this.runButtonIcon = "fa fa-play";
-          this.buildOutput.push("Something went wrong during detector invocation.");
+          this.buildOutput.push(error?.status === 401 ? errorMessage : "Something went wrong during detector invocation.");
           this.buildOutput.push("========== Build: 0 succeeded, 1 failed ==========");
           this.detailedCompilationTraces.push({
             severity: HealthStatus.Critical,
-            message: 'Something went wrong during detector invocation.',
+            message: `${error?.status === 401 ? errorMessage : 'Something went wrong during detector invocation.'}`,
             location: {
               start: {
                 linePos: 0,

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1572,11 +1572,11 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
           this.localDevButtonDisabled = false;
           this.runButtonText = "Run";
           this.runButtonIcon = "fa fa-play";
-          this.buildOutput.push(error?.status === 401 ? errorMessage : "Something went wrong during detector invocation.");
+          this.buildOutput.push(errorMessage?.length > 0 ? errorMessage : "Something went wrong during detector invocation.");
           this.buildOutput.push("========== Build: 0 succeeded, 1 failed ==========");
           this.detailedCompilationTraces.push({
             severity: HealthStatus.Critical,
-            message: `${error?.status === 401 ? errorMessage : 'Something went wrong during detector invocation.'}`,
+            message: `${errorMessage?.length > 0 ? errorMessage : "Something went wrong during detector invocation."}`,
             location: {
               start: {
                 linePos: 0,


### PR DESCRIPTION
## Overview
Currently, a user can use Applens to access any kusto cluster that they don’t have access to. The aim of this PR is to restrict unauthorized access to multiple kusto clusters.  

## Related Work Item
https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2916/

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Solution description
### This PR:
 - shows the unauthorized error message resulting from an unauthroized access to a kusto cluster by an Applens user.
 
## How Can This Be Tested? <span>&#128269;</span>
 - Create a new detector or edit an existing detector
 - In the Develop tab, run a kusto query to access a cluster you don't have access to.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots After Fix (if appropriate):

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/24648672/027f920b-a2c3-4a2a-a68f-c137a679afa2)

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
