### PR TITLE
Adjust the size of the header to work on different screen resolution

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/kustogpt/kustogpt.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/kustogpt/kustogpt.component.ts
@@ -29,10 +29,7 @@ export class KustoGPTComponent {
     <img class='copilot-header-img-secondary' src='/assets/img/rocket.png' alt=''>
     <img class='copilot-header-img-secondary' src='/assets/img/rocket.png' alt=''"> 
     <div class = "copilot-header-secondary" >
-      Queries generated can be executed against <strong>Cluster:</strong>wawsaneus.eastus <strong>Database:</strong>wawsprod
-    </div>
-    <div class = "copilot-header-secondary">
-      For more information, see <a href='https://msazure.visualstudio.com/Antares/_wiki/wikis/Antares.wiki/50081/Getting-started-with-Antares-Analytics-Kusto-data'>Getting started with Antares Analytics Kusto data.</a>
+      Queries generated can be executed against <strong>Cluster:</strong>wawsaneus.eastus <strong>Database:</strong>wawsprod. For more information, see <a href='https://msazure.visualstudio.com/Antares/_wiki/wikis/Antares.wiki/50081/Getting-started-with-Antares-Analytics-Kusto-data'>Getting started with Antares Analytics Kusto data.</a>
     </div>
   </div>  
   `;

--- a/AngularApp/projects/applens/src/styles.scss
+++ b/AngularApp/projects/applens/src/styles.scss
@@ -35,7 +35,7 @@ body {
 }
 
 .copilot-header-secondary {
-  font-size: 2rem;
+  font-size: 1.5rem;
 }
 
 .copilot-header-img {


### PR DESCRIPTION
## Overview
Chat header was overlapping on chat UI samples when a header spanned multiple lines 


## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Solution description
Reduce lines in chat header and reduce the font size

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [X] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):
This is how it looked on a laptop screen
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/1d4ef2b0-8370-4674-b9e5-1b8b053861dc)

## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/a712fc93-254d-4001-9e58-809f540d38d3)

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
