### PR TITLE
Enabling feature to get workflows and detectors both

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
@@ -40,14 +40,10 @@ export class GenericApiService {
     public getDetectors(overrideResourceUri: string = ""): Observable<DetectorMetaData[]> {
 
         //
-        // Flag to fetch both Detectors and Workflows. This should stay as
-        //  'false' and should be enabled only when the UI code needs to be
-        // tested against both  detectors and workflows. Enabling this flag
-        // will double the latency of getting the detectors and the side panels
-        // will take too long to load.
+        // Enabling this flag to call both detectors and workflows
         //
 
-        let fetchDetectorsAndWorkflows = false;
+        let fetchDetectorsAndWorkflows = true;
         if (fetchDetectorsAndWorkflows) {
             return this.getDetectorsAndWorkflows(overrideResourceUri);
         }


### PR DESCRIPTION
## Overview
Post this change, the UI will make two ListDetectors call, one for workflows and one for detectors to fetch both. This is required for enabling workflows in public diagnose and solve blade.

## Extra Notes
This change will double the number of ListDetectors calls to our backend. I reviewed that code and most of the logic is getting served from the cache so this should not cause any issues but still I will inform on-calls and the team to keep an eye on ListDetectors latency and if this becomes a problem, we should revert this PR.