### PR TITLE
Improve logic of link interceptor service slightly

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/link-interceptor.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/link-interceptor.service.ts
@@ -89,6 +89,12 @@ export class LinkInterceptorService {
   //
 
   addCategoryIdIfNeeded(linkURL: string) {
+    //
+    // Do not modify URLs with relative URL paths
+    //
+    if (linkURL.startsWith('..')) {
+      return linkURL;
+    }
     const entityTypes = ['detectors', 'analysis', 'workflows'];
     for (let index = 0; index < entityTypes.length; index++) {
       const entityType = entityTypes[index];


### PR DESCRIPTION
Bail out early enough from link interceptor service if the path passed is a relative path.