### PR TITLE
Fix subject of feedback email message for Chat

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/openai-chat-container/openai-chat-container.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/openai-chat-container/openai-chat-container.component.ts
@@ -130,7 +130,7 @@ export class OpenAIChatContainerComponent implements OnInit {
 
   sendFeedback = () => {
     let newline = '%0D%0A';
-    const subject = encodeURIComponent(`${this.chatHeader} Feedback`);
+    const subject = encodeURIComponent(`${this.chatIdentifier} Feedback`);
     let body = encodeURIComponent('Please provide feedback here:');
     let link = "";
 


### PR DESCRIPTION
## Overview
Email subject for feedback email was using chat Header, the header can contain HTML tags and that messes up the subject making it look garbled..

Something like below

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/01a06ec5-7b7e-449a-80e6-77aec3c33108)

This PR will use chat identifier as the feedback subject instead of the chat header.
