### PR TITLE
Olu/feat/kusto service access restrictions fe

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
@@ -449,7 +449,7 @@
                     <span class="fa status-icon" [ngClass]="getfaIconClass(item)"></span>
                   </div>
                   <div class="compilation-detailed-output-entryCell">
-                    <span>{{item.message}}</span>
+                    <span [innerHTML]="item.message"></span>
                   </div>
                 </div>
               </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -10,6 +10,7 @@ import {
 } from 'rxjs';
 import { flatMap, map } from 'rxjs/operators'
 import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { Package } from '../../../shared/models/package';
 import { GithubApiService } from '../../../shared/services/github-api.service';
 import { DetectorGistApiService } from '../../../shared/services/detectorgist-template-api.service';
@@ -342,7 +343,7 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
     public ngxSmartModalService: NgxSmartModalService, private _telemetryService: TelemetryService, private _activatedRoute: ActivatedRoute,
     private _applensCommandBarService: ApplensCommandBarService, private _router: Router, private _themeService: GenericThemeService, private _applensGlobal: ApplensGlobal,
     private matDialog: MatDialog, private _queryResponseService: QueryResponseService, private _userSettingService: UserSettingService,
-    private _workflowService: WorkflowService, public _chatContextService: ChatUIContextService, public _detectorCopilotService: DetectorCopilotService) {
+    private _workflowService: WorkflowService, public _chatContextService: ChatUIContextService, public _detectorCopilotService: DetectorCopilotService, public _sanitizer:DomSanitizer) {
     this.lightOptions = {
       theme: 'vs',
       language: 'csharp',
@@ -2420,6 +2421,9 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
     this.createWorkflow.uploadFlowData(text);
   }
 
+  safeHtml(html: string) {
+    return this._sanitizer.bypassSecurityTrustHtml(html);
+  }
   //#region Copilot Methods
 
   initalizeCoPilotServiceMembers() {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -10,7 +10,6 @@ import {
 } from 'rxjs';
 import { flatMap, map } from 'rxjs/operators'
 import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
 import { Package } from '../../../shared/models/package';
 import { GithubApiService } from '../../../shared/services/github-api.service';
 import { DetectorGistApiService } from '../../../shared/services/detectorgist-template-api.service';
@@ -343,7 +342,7 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
     public ngxSmartModalService: NgxSmartModalService, private _telemetryService: TelemetryService, private _activatedRoute: ActivatedRoute,
     private _applensCommandBarService: ApplensCommandBarService, private _router: Router, private _themeService: GenericThemeService, private _applensGlobal: ApplensGlobal,
     private matDialog: MatDialog, private _queryResponseService: QueryResponseService, private _userSettingService: UserSettingService,
-    private _workflowService: WorkflowService, public _chatContextService: ChatUIContextService, public _detectorCopilotService: DetectorCopilotService, public _sanitizer:DomSanitizer) {
+    private _workflowService: WorkflowService, public _chatContextService: ChatUIContextService, public _detectorCopilotService: DetectorCopilotService) {
     this.lightOptions = {
       theme: 'vs',
       language: 'csharp',
@@ -2419,10 +2418,6 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
     let file = $event.target.files[0];
     const text = await file.text();
     this.createWorkflow.uploadFlowData(text);
-  }
-
-  safeHtml(html: string) {
-    return this._sanitizer.bypassSecurityTrustHtml(html);
   }
   //#region Copilot Methods
 

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1566,16 +1566,17 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
           this.localDevButtonDisabled = false;
           this.markCodeLinesInEditor(this.detailedCompilationTraces);
         }, ((error: any) => {
+          const errorMessage = error?.error?.replace(/"/g, '');
           this.enableRunButton();
           this.publishingPackage = null;
           this.localDevButtonDisabled = false;
           this.runButtonText = "Run";
           this.runButtonIcon = "fa fa-play";
-          this.buildOutput.push("Something went wrong during detector invocation.");
+          this.buildOutput.push(error?.status === 401 ? errorMessage : "Something went wrong during detector invocation.");
           this.buildOutput.push("========== Build: 0 succeeded, 1 failed ==========");
           this.detailedCompilationTraces.push({
             severity: HealthStatus.Critical,
-            message: 'Something went wrong during detector invocation.',
+            message: `${error?.status === 401 ? errorMessage : 'Something went wrong during detector invocation.'}`,
             location: {
               start: {
                 linePos: 0,

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1572,11 +1572,11 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
           this.localDevButtonDisabled = false;
           this.runButtonText = "Run";
           this.runButtonIcon = "fa fa-play";
-          this.buildOutput.push(error?.status === 401 ? errorMessage : "Something went wrong during detector invocation.");
+          this.buildOutput.push(errorMessage?.length > 0 ? errorMessage : "Something went wrong during detector invocation.");
           this.buildOutput.push("========== Build: 0 succeeded, 1 failed ==========");
           this.detailedCompilationTraces.push({
             severity: HealthStatus.Critical,
-            message: `${error?.status === 401 ? errorMessage : 'Something went wrong during detector invocation.'}`,
+            message: `${errorMessage?.length > 0 ? errorMessage : "Something went wrong during detector invocation."}`,
             location: {
               start: {
                 linePos: 0,


### PR DESCRIPTION
## Overview
Currently, a user can use Applens to access any kusto cluster that they don’t have access to. The aim of this PR is to restrict unauthorized access to multiple kusto clusters.  

### Update:
This PR updates the error message to include the next steps on how to request access to a cluster.

## Related Work Item
https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/2916/

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Solution description
### This PR:
 - shows the unauthorized error message resulting from an unauthroized access to a kusto cluster by an Applens user.
 
## How Can This Be Tested? <span>&#128269;</span>
 - Create a new detector or edit an existing detector
 - In the Develop tab, run a kusto query to access a cluster you don't have access to.

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [x] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [x] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [x] I have requested review on this PR.

## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/24648672/97273766-75d3-4292-a8ad-6b36d26e8abb)


## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->