### PR TITLE
Enabling secure bing search method for AKS as well

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/content.service.ts
@@ -16,7 +16,7 @@ export class ContentService {
   private _config : DocumentSearchConfiguration;
   private featureEnabledForSupportTopic: boolean = false;
   httpOptions = {}
-  private bingDetectorEnabledPesIds = ["14748", "16072", "16170", "15791", "15551"]
+  private bingDetectorEnabledPesIds = ["14748", "16072", "16170", "15791", "15551", "16450"]
 
   
   constructor(private _http: HttpClient, private _resourceService: ResourceService, private _backendApi: BackendCtrlService, private _diagnosticService: DiagnosticService, private _detectorControlService: DetectorControlService) { 


### PR DESCRIPTION
## Overview
Enabling secure bing search method for our best partner AKS as well. This was earlier blocked due to AKS RP not passing query parameters to our backend but now they are so....

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/8492235/93022558-34af-4974-99e7-4b1603a7283a)


![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/8492235/55a8244e-37ca-4433-89e1-d830cd973aae)

