### PR TITLE
Enable workflows back and handle duplication

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/generic-api.service.ts
@@ -20,11 +20,11 @@ export class GenericApiService {
 
     useLocal: boolean = false;
 
-    useApolloApi:boolean = false;
+    useApolloApi: boolean = false;
 
     effectiveLocale: string = "";
 
-    constructor(private _http: HttpClient, private _armService: ArmService, private _authService: AuthService, private _genericArmConfigService : GenericArmConfigService) {
+    constructor(private _http: HttpClient, private _armService: ArmService, private _authService: AuthService, private _genericArmConfigService: GenericArmConfigService) {
         this._authService.getStartupInfo().subscribe(info => {
             this.resourceId = info.resourceId;
             this.effectiveLocale = !!info.effectiveLocale ? info.effectiveLocale.toLowerCase() : "";
@@ -43,7 +43,7 @@ export class GenericApiService {
         // Enabling this flag to call both detectors and workflows
         //
 
-        let fetchDetectorsAndWorkflows = false;
+        let fetchDetectorsAndWorkflows = true;
         if (fetchDetectorsAndWorkflows) {
             return this.getDetectorsAndWorkflows(overrideResourceUri);
         }
@@ -55,8 +55,8 @@ export class GenericApiService {
             return this.invoke<DetectorResponse[]>(path, 'POST').pipe(map(response => response.map(detector => detector.metadata)));
         } else {
             const path = `${resourceId}/detectors`;
-            if(this.useApolloApi) {
-                return this._armService.invokeApolloApiForPassThrough<DetectorResponse[]>(path, resourceId, ApolloDiagApiMap.ListDetectors, null, false, queryParams).pipe(map( (response:DetectorResponse[]) => {
+            if (this.useApolloApi) {
+                return this._armService.invokeApolloApiForPassThrough<DetectorResponse[]>(path, resourceId, ApolloDiagApiMap.ListDetectors, null, false, queryParams).pipe(map((response: DetectorResponse[]) => {
                     this.detectorList = response?.map(listItem => listItem.metadata);
                     return this.detectorList;
                 }));
@@ -77,7 +77,7 @@ export class GenericApiService {
         } else {
             const path = `${this.resourceId}/detectors`;
             var queryParams = [{ "key": "text", "value": searchTerm }];
-            if(this.useApolloApi) {
+            if (this.useApolloApi) {
                 return this._armService.invokeApolloApiForPassThrough<DetectorResponse[]>(path, this.resourceId, ApolloDiagApiMap.ListDetectors, null, false, queryParams).pipe(map((response: DetectorResponse[]) => {
                     var searchResults = response.map(listItem => listItem.metadata).sort((a, b) => { return b.score > a.score ? 1 : -1; });
                     return searchResults;
@@ -88,7 +88,7 @@ export class GenericApiService {
                     var searchResults = response.map(listItem => listItem.properties.metadata).sort((a, b) => { return b.score > a.score ? 1 : -1; });
                     return searchResults;
                 }));
-            }            
+            }
         }
     }
 
@@ -105,8 +105,8 @@ export class GenericApiService {
                 path += additionalQueryParams;
             }
 
-            if(this.useApolloApi) {
-                if(resourceId.toLowerCase().indexOf('/resourcegroup/') > -1 ) {
+            if (this.useApolloApi) {
+                if (resourceId.toLowerCase().indexOf('/resourcegroup/') > -1) {
                     return this._armService.getArmResource<ArmResource>(resourceId).pipe(
                         concatMap(resource => {
                             let requestHeaders = new Map<string, string>();
@@ -221,7 +221,21 @@ export class GenericApiService {
                     allEntities = allEntities.concat(list);
                 });
 
-                this.detectorList = allEntities;
+                //
+                // For some resource types (e.g. AKS), the query strings are not passed
+                // to applens backend. They will up making 2 ListDetectors call. Till the
+                // time this is fixed, just remove duplicates from the collection to
+                // ensure that rest of the UI is not breaking or getting confused
+                //
+
+                let uniqueEntityList: DetectorMetaData[] = [];
+                for (let i of allEntities) {
+                    if (uniqueEntityList.findIndex(entity => entity.id === i.id) === -1) {
+                        uniqueEntityList.push(i);
+                    }
+                }
+
+                this.detectorList = uniqueEntityList;
                 return this.detectorList;
             }));
         }


### PR DESCRIPTION
## Overview
This PR enables workflows back and filters out the duplicate items for scenarios where resource types may not be passing query params to AppLens backend

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

@SharmaAjay19 - As you know how to reproduce the AKS scenario, can you validate that this PR is indeed fixing the issue that AKS ran in to ?