### PR TITLE
Fix Hyperlinks for markdown nodes for Workflows

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
@@ -39,7 +39,7 @@
     <div class="panel-body">
       <div *ngIf="data.description" tabindex="0" class="description-text">{{ data.description }}</div>
       <div *ngIf="data.markdownText" tabindex="0" class="markdown-text">
-        <markdown [data]="data.markdownText"></markdown>
+        <markdown-text [markdownData]="data.markdownText" [isMarkdownView]="true"></markdown-text>
       </div>
       <workflow-accept-userinput *ngIf="data.inputNodeSettings" [data]="data"
         #acceptUserInput></workflow-accept-userinput>


### PR DESCRIPTION
## Overview
Currently hyperlinks in markdown generated by workflow nodes are not honoring the linkInterceptorService logic due to which the links are either broken or not opening in a new window

## Type of change
With this change, linkInterceptorService will start intercepting links for Diagnose and Solve workflow nodes

- [x] Bug fix (non-breaking change which fixes an issue)