### PR TITLE
Add WithExposedHeaders for all headers for local development

### DIFF
--- a/ApplensBackend/Configuration/Startup.cs
+++ b/ApplensBackend/Configuration/Startup.cs
@@ -190,7 +190,8 @@ namespace AppLensV3
                         builder => builder.WithOrigins("http://localhost:4200")
                         .AllowAnyMethod()
                         .AllowAnyHeader()
-                        .AllowCredentials());
+                        .AllowCredentials()
+                        .WithExposedHeaders("*"));
                 });
             }
         }


### PR DESCRIPTION
## Overview
Applens UI code is relying on HTTP headers to get ETAG and other stuff and due to CORS issue those headers are not available. We need to expose all the headers so that angular gets access to them and UI code for applens can function as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)