### PR TITLE
Add logging for detectors matching in case submission

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -246,6 +246,19 @@ export class SupportTopicService {
                     }
                     
                     if (matchingDetectors && matchingDetectors.length > 0) {
+                        this._telemetryService.logEvent("MatchingDetectorsInCaseSubmission", {
+                            "MatchingDetectors": JSON.stringify(matchingDetectors.map(detector => {
+                                return { 
+                                    id: detector.id, 
+                                    type: detector.type
+                                };
+                            })),
+                            "SapSupportTopicId": sapSupportTopicId,
+                            "SupportTopicId": supportTopicId,
+                            "PesId": pesId,
+                            "SapProductId": sapProductId,
+                            "CaseSubject": searchTerm
+                        });
                         if (matchingDetectors.length === 1 && matchingDetectors[0] && matchingDetectors[0].id) {
                             if (matchingDetectors[0].type === DetectorType.Analysis) {
                                 detectorPath = `/analysis/${matchingDetectors[0].id}`;
@@ -260,6 +273,14 @@ export class SupportTopicService {
                         }
                     }
                     else {
+                        this._telemetryService.logEvent("MatchingDetectorsInCaseSubmission", {
+                            "MatchingDetectors": '[]',
+                            "SapSupportTopicId": sapSupportTopicId,
+                            "SupportTopicId": supportTopicId,
+                            "PesId": pesId,
+                            "SapProductId": sapProductId,
+                            "CaseSubject": searchTerm
+                        });
                         detectorPath = `/analysis/searchResultsAnalysis/search`;
                     }
                 }


### PR DESCRIPTION
Add logging for detectors matching in case submission to help with reporting needs.

## Overview
Add logging for detectors matching in case submission to help with reporting needs.

## Solution description
Add logging for detectors matching in case submission to help with reporting needs.
