### PR TITLE
Updating Apollo self-help content call to adjust with Apollo API

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -72,6 +72,8 @@ export class SupportTopicService {
 
             // To generate a unique apollo search Id, we use resource name, current timestamp and a guid.
             let apolloResourceId = `${this._resourceService.resource.name}-${Math.floor(Date.now() / 1000)}-${uuid()}`;
+            let fullResourceUri = this._resourceService.resource.id;
+            let partialResourceUri = `/subscriptions/${fullResourceUri.split("subscriptions/")[1].split("/")[0]}/providers/${fullResourceUri.split("/providers/")[1].split("/")[0]}/${fullResourceUri.split("/providers/")[1].split("/")[1].split("?")[0]}`;
             let requestBody =
             {
                 "properties": {
@@ -84,11 +86,12 @@ export class SupportTopicService {
                     "parameters": {
                         "SearchText": "error found",
                         "ProductId": this.pesId,
-                        "LegacyTopicId": this.supportTopicId
+                        "LegacyTopicId": this.supportTopicId,
+                        "PartialResourceUri": partialResourceUri
                     }
                 }
             };
-            let resourceUri = `${this._resourceService.resource.id}/${this.apolloApiConfig.apolloResourceProvider}/${apolloResourceId}`;
+            let resourceUri = `/subscriptions/${this._resourceService.subscriptionId}/${this.apolloApiConfig.apolloResourceProvider}/${apolloResourceId}`;
             let apolloHeaders = new Map<string, string>();
             apolloHeaders.set("x-ms-client-agent", "AppServiceDiagnostics");
             return this._armService.putResource(resourceUri, requestBody, this.apolloApiConfig.apiVersion, true, apolloHeaders).pipe(map((response: ResponseMessageEnvelope<any>) => {


### PR DESCRIPTION
## Overview
Apollo API behavior has changed in the past months where it returns a dummy article for nearly 80-85% of our requests that we make to fetch self-help content to show in case submission. This is due to some configuration changes on their side that were needed for Help 2.0 to work. We had been falling back on the Legacy MPAC API in these scenarios but that API has the risk of returning stale content. So, to get the real content from Apollo, we are now required to make the call using partial resource uri so that we can get the actual self-help content and not the dummy article.

![image (1)](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/8492235/13994b8e-af43-4e15-82c6-d7516d1ec4b8)
