### PR TITLE
Adding Support Topic mapping for Workflow authors

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/resource-home/resource-home.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/resource-home/resource-home.component.ts
@@ -197,6 +197,8 @@ export class SupportTopicResult {
     supportTopicL2Name: string;
     supportTopicL3Name: string;
     supportTopicPath: string;
+    sapSupportTopicId:string;
+    sapProductId:string;
 }
 
 export class SupportTopicItem {

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
@@ -45,6 +45,60 @@
         <input name="category" class="form-control input-sm" [(ngModel)]="publishBody.Category">
       </div>
     </div>
+
+    <div class="form-row" *ngIf="!publishBody.IsInternal">
+      <div class="form-group col-md-12">
+        <table class="table table-bordered table-condensed" style="margin-bottom: 0px;">
+          <thead>
+            <tr>
+              <th>Support Topics</th>
+              <th style="width: 15%;">
+                <button class="btn btn-sm ml" (click)="addingSupportTopic = true">
+                  <i class="fa fa-lg  fa-plus text-success"></i>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngIf="publishBody.SupportTopicPaths && publishBody.SupportTopicPaths.length === 0">
+              <td colspan="2">No support topics mapped to this workflow. Please click the Add (+) button to add a
+                support topic.</td>
+            </tr>
+            <tr *ngFor="let supportTopicPath of publishBody.SupportTopicPaths">
+              <td>{{ supportTopicPath}}</td>
+              <td>
+                <button class="btn btn-sm ml-1" (click)="deleteSupportTopic(supportTopicPath)">
+                  <i class="fa fa-lg fa-trash text-danger"></i>
+                </button>
+              </td>
+            </tr>
+            <tr *ngIf="addingSupportTopic">
+              <td>
+                <select class="form-control input-sm" style="width: 1000px;" [(ngModel)]="chosenSupportTopic"
+                  name="selectSupportTopic">
+                  <option *ngFor="let supportTopicPath of supportTopicPaths" [value]="supportTopicPath">{{
+                    supportTopicPath }}</option>
+                </select>
+              </td>
+              <td>
+                <div *ngIf="loadingExistingSupportTopics">
+                  <fab-spinner [label]="'Loading existing support topic information. Please wait...'"></fab-spinner>
+                </div>
+                <div *ngIf="!loadingExistingSupportTopics">
+                  <button class="btn btn-sm" (click)="addSupportTopic()">
+                    <i class="fa fa-lg fa-floppy-o text-primary"></i>
+                  </button>
+                  <button class="btn btn-sm" (click)="addingSupportTopic = false">
+                    <i class="fa fa-lg fa-times-circle text-primary"></i>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
     <div class="form-row">
       <ng-container *ngIf="service === 'SiteService'">
         <div class="form-group col-md-3">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.scss
@@ -34,7 +34,29 @@ textarea {
   margin-bottom: 10px;
 }
 
-::ng-deep .ng-select .ng-select-container , ::ng-deep .ng-select.ng-select-multiple .ng-select-container{
+::ng-deep .ng-select .ng-select-container,
+::ng-deep .ng-select.ng-select-multiple .ng-select-container {
   min-height: 6px;
   font-size: 0.9em;
+}
+
+.table-condensed>thead>tr>th,
+.table-condensed>tbody>tr>th,
+.table-condensed>tfoot>tr>th,
+.table-condensed>thead>tr>td,
+.table-condensed>tbody>tr>td,
+.table-condensed>tfoot>tr>td {
+  padding: 5px;
+}
+
+.btn {
+  background: none;
+}
+
+.table {
+  font-size: smaller;
+}
+
+th {
+  vertical-align: middle !important;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -88,7 +88,7 @@ export interface SupportTopic {
     id: string;
     pesId: string;
     sapSupportTopicId: string;
-    sapPesId: string;
+    sapProductId: string;
 }
 
 export enum DetectorType {

--- a/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
@@ -127,6 +127,7 @@ export class workflowPublishBody {
   ResourceType: string;
   ResourceProvider: string;
   Category: string;
+  SupportTopicPaths: string[] = [];
 }
 
 export interface workflowNodeResult {

--- a/ApplensBackend/Models/SupportTopic.cs
+++ b/ApplensBackend/Models/SupportTopic.cs
@@ -18,5 +18,9 @@ namespace AppLensV3.Models
         public string SupportTopicL3Name { get; set; }
 
         public string SupportTopicPath { get; set; }
+
+        public string SapProductId { get; set; }
+
+        public string SapSupportTopicId { get; set; }
     }
 }

--- a/ApplensBackend/Services/SupportTopicService/SupportTopicService.cs
+++ b/ApplensBackend/Services/SupportTopicService/SupportTopicService.cs
@@ -19,7 +19,7 @@ namespace AppLensV3.Services
         cluster('azsupportfollower.westus2').database('AzureSupportability').ActiveSupportTopicTree
         | where ProductId in ('{PRODUCTID}') 
         | where Timestamp > ago(3d)
-        | summarize by ProductId, SupportTopicId = SupportTopicL3Id, ProductName, SupportTopicL2Name, SupportTopicL3Name
+        | summarize by ProductId, SupportTopicId = SupportTopicL3Id, ProductName, SupportTopicL2Name, SupportTopicL3Name, SapProductId, SapSupportTopicId = SapSupportTopicL3Id
         | where SupportTopicId != '' and SupportTopicL2Name != '' and SupportTopicL3Name != ''
         | extend SupportTopicPath = strcat(ProductName, ""/"", SupportTopicL2Name,""/"", SupportTopicL3Name)
         ";
@@ -57,7 +57,9 @@ namespace AppLensV3.Services
                     ProductName = row["ProductName"].ToString(),
                     SupportTopicL2Name = row["SupportTopicL2Name"].ToString(),
                     SupportTopicL3Name = row["SupportTopicL3Name"].ToString(),
-                    SupportTopicPath = row["SupportTopicPath"].ToString()
+                    SupportTopicPath = row["SupportTopicPath"].ToString(),
+                    SapSupportTopicId = row["SapSupportTopicId"].ToString(),
+                    SapProductId = row["SapProductId"].ToString(),
                 };
 
                 supportTopicsList.Add(supportTopic);


### PR DESCRIPTION
## Overview
The PR adds ability for Workflow Authors to map support topics to their workflows that can then be shown in Case submission. This should be merged when the backend is merged and deployed - https://dev.azure.com/msazure/One/_git/AAPT-Antares-AppServiceDiagnostics/pullrequest/8414162

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots After Fix (if appropriate):
The UI when you mark a workflow as InternalOnly False

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/1db0a96d-9b71-40ac-ab9d-69ff3adb69b3)

A user can add multiple ST's

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/0e69320e-dc0a-4218-8bcc-0f7f86c27bba)

Error when trying to choose an existing support topic
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/e429e608-ab18-4839-a2ee-6a0cb172ba9c)
