### PR TITLE
Show only allocated instances for DaaS for Elastic Premium SKU

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/configure-storage-account/configure-storage-account.component.ts
@@ -37,6 +37,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
   @Input() siteToBeDiagnosed: SiteDaasInfo;
   @Input() sessionInProgress: boolean;
   @Input() useDiagServerForLinux: boolean = false;
+  @Input() serverFarmSku: string;
   @Output() StorageAccountValidated: EventEmitter<DaasValidationResult> = new EventEmitter<DaasValidationResult>();
 
   chosenStorageAccount: string;
@@ -55,6 +56,7 @@ export class ConfigureStorageAccountComponent implements OnInit {
   ngOnInit() {
 
     this.checkingBlobSasUriConfigured = true;
+    this.validationResult.ServerFarmSku = this.serverFarmSku;
 
     this._daasService.getStorageConfiguration(this.siteToBeDiagnosed, this.useDiagServerForLinux).subscribe(daasStorageConfiguration => {
       if (!this.useDiagServerForLinux && (daasStorageConfiguration.ConnectionString || daasStorageConfiguration.SasUri)) {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.html
@@ -83,6 +83,7 @@
 
 <div class="col" *ngIf="storageAccountNeeded">
   <configure-storage-account [siteToBeDiagnosed]="siteToBeDiagnosed" [sessionInProgress]="sessionInProgress"
-    [useDiagServerForLinux]="useDiagServerForLinux && !isWindowsApp" (StorageAccountValidated)="onStorageAccountValidated($event)">
+    [useDiagServerForLinux]="useDiagServerForLinux && !isWindowsApp" (StorageAccountValidated)="onStorageAccountValidated($event)"
+    [serverFarmSku]="serverFarmSku">
   </configure-storage-account>
 </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas/daas-validator.component.ts
@@ -38,6 +38,7 @@ export class DaasValidatorComponent implements OnInit {
   daasAppSettingsCheck: DaasAppSettingsCheck;
   isWindowsApp: boolean = false;
   useDiagServerForLinux: boolean = false;
+  serverFarmSku: string = '';
 
   constructor(private _serverFarmService: ServerFarmDataService,
     private _siteService: SiteService, private _daasService: DaasService,
@@ -84,6 +85,16 @@ export class DaasValidatorComponent implements OnInit {
 
       if (serverFarm != null) {
         this.checkingSkuSucceeded = true;
+
+        //
+        // validationResult is created fresh in configure-stroage component due to which
+        // the serverFarmSku is assigned to a property in configure-storage component
+        // Also, for diagnosers not requiring storage, the serverFarmSku should be set
+        // on the actual validationResult as well.
+        //
+
+        this.serverFarmSku = serverFarm.sku.tier;
+        this.validationResult.ServerFarmSku = serverFarm.sku.tier;
         if (serverFarm.sku.tier === 'Standard' || serverFarm.sku.tier.indexOf('Premium') > -1 || serverFarm.sku.tier.indexOf('Isolated') > -1) {
           this.supportedTier = true;
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/models/daas.ts
@@ -216,6 +216,7 @@ export class DaasValidationResult {
     BlobSasUri: string = "";
     ConnectionString: string = "";
     UseDiagServerForLinux: boolean = false;
+    ServerFarmSku: string = '';
 }
 
 export class CrashMonitoringSettings {
@@ -278,6 +279,15 @@ export interface LinuxDaasSettings {
 export interface Instance {
     machineName: string;
     instanceId: string;
+}
+
+export interface InstanceProcess {
+    id: string;
+    name: string;
+    machineName: string;
+    instanceId: string;
+    href: string;
+    user_name: string;
 }
 
 export interface LinuxCommand {

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/daas.service.ts
@@ -7,7 +7,7 @@ import { SiteDaasInfo } from '../models/solution-metadata';
 import { ArmService } from './arm.service';
 import { AuthService } from '../../startup/services/auth.service';
 import { UriElementsService } from './urielements.service';
-import { DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, ValidateSasUriResponse, Session, LinuxDaasSettings, ValidateStorageAccountResponse, DaasStorageConfiguration, Instance, LinuxCommandOutput, LinuxCommand, DaasSettingsResponse } from '../models/daas';
+import { DiagnoserDefinition, DatabaseTestConnectionResult, MonitoringSession, MonitoringLogsPerInstance, ActiveMonitoringSession, DaasAppInfo, DaasSettings, ValidateSasUriResponse, Session, LinuxDaasSettings, ValidateStorageAccountResponse, DaasStorageConfiguration, Instance, LinuxCommandOutput, LinuxCommand, DaasSettingsResponse, InstanceProcess } from '../models/daas';
 import { SiteInfoMetaData } from '../models/site';
 import { SiteService } from './site.service';
 import { StorageAccountProperties } from '../../shared-v2/services/shared-storage-account.service';
@@ -70,6 +70,21 @@ export class DaasService {
                     }
                 });
                 return instances;
+            }
+        }));
+    }
+
+    getInstanceProcesses(site: SiteDaasInfo, instanceId: string): Observable<InstanceProcess[]> {
+        const resourceUri: string = this._uriElementsService.getInstanceProcesses(site, instanceId);
+        return this._armClient.getResourceCollection<any>(resourceUri, null, true).pipe(map(response => {
+            if (Array.isArray(response) && response.length > 0) {
+                let instaceProcesses: InstanceProcess[] = [];
+                response.forEach(instance => {
+                    if (instance && instance.properties && instance.properties["machineName"]) {
+                        instaceProcesses.push({ id: instance.properties["id"], machineName: instance.properties["machineName"], name: instance.properties["name"], href: instance.properties["href"], user_name: instance.properties["user_name"], instanceId: instanceId });
+                    }
+                });
+                return instaceProcesses;
             }
         }));
     }

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/services/urielements.service.ts
@@ -40,6 +40,7 @@ export class UriElementsService {
     private _killw3wpUrlFormat: string = this._supportApi + 'sites/{subscriptionId}/{resourceGroup}/{siteName}/killsiteprocess';
 
     private _instances: string = "/instances"
+    private _instaceProcesses: string = this._instances + "/{instanceId}/processes"
 
     /*
         TODO : Need to add start time and end time parameters
@@ -153,7 +154,7 @@ export class UriElementsService {
     getMonitoringSessionsUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasCpuMonitoringPath;
     }
-    
+
     getMonitoringSessionsListUrl(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._daasCpuMonitoringListSessionsPath;
     }
@@ -305,6 +306,11 @@ export class UriElementsService {
 
     getInstances(site: SiteDaasInfo) {
         return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._instances;
+    }
+
+    getInstanceProcesses(site: SiteDaasInfo, instanceId: string) {
+        return this._getSiteResourceUrl(site.subscriptionId, site.resourceGroupName, site.siteName, site.slot) + this._instaceProcesses
+        .replace('{instanceId}', instanceId);
     }
 
     private _getSiteResourceUrl(subscriptionId: string, resourceGroup: string, siteName: string, slot: string = '') {


### PR DESCRIPTION
## Overview
ElasticPremium instances have allotted and pre-warmed instances and app may not be allocated to run on pre-warmed instances and DaasRunner may not be running on those instances. The end result is that when someone submits a DaaS session for pre-warmed instance, the session will fail for that instance as DaasRunner will not be running to pick that instance. To fix the problem, we only show the allotted instances in DAAS Tools.

## Related Work Item
ICM:399254805

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Solution description
We needed to somehow identify all the allotted instances to the app. For this we use this logic 
- We get all processes from all instances (pre-warmed and allocated) `/instances/{InstanceId}/processes`
- Then, we check the `machineName` returned in the API call to identify which instance is "really" allotted to the app. The ARM API may return same results for two different instance ID calls but the `machineName `will be same.
- Then in the UI we only show the allotted instances.
 
This could slow down the populating instance's part, but this is a workaround we follow till we come up with something better

## Screenshots Before Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/e156d136-550a-43e2-82a5-d2104f36e0e3)

## Screenshots After Fix (if appropriate):

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/6eef46b0-6cfa-430c-ae5e-39dbffe6d67f)
