### PR TITLE
Avoid multiple /sessions/list calls for DaaS Linux Web App

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared/components/daas-sessions/daas-sessions.component.ts
@@ -115,7 +115,12 @@ export class DaasSessionsComponent implements OnChanges, OnDestroy {
   }
 
   getDaasSessionsV2(): Observable<Session[]> {
-    return this._daasService.getSessions(this.siteToBeDiagnosed, false).pipe(retry(2))
+    if (this.isWindowsApp) {
+      return this._daasService.getSessions(this.siteToBeDiagnosed, false).pipe(retry(2))
+    }
+
+    let emptyArray: Session[] = [];
+    return of(emptyArray);
   }
 
   getLinuxDiagnosticServerSessions(): Observable<Session[]> {


### PR DESCRIPTION
## Overview
For DAAS currently we are making **/extensions/daas/sessions/list** and **/extensions/daas/v2/sessions/list** to retrieve Sessions for Linux Web Apps and the first call is un-necessary and could result in 400 BAD requests for apps that have not picked up the latest DiagnosticServer or KuduLite bits. 

While this logic will get resolved once the Linux Web Apps will pick up the latest site extension bits but the UI can also avoid making this call till the latest bits are picked up everywhere.