### PR TITLE
Add sourcemap for Applens

### DIFF
--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -13,7 +13,7 @@
     "ssl-local-poll": "npm run fixAngularReact && npm run ssl -- --poll 2000 -c local",
     "asd": "concurrently -k \"npm run ssl\" \"npm run lib\"",
     "build-lib": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build diagnostic-data",
-    "build-applens": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration production",
+    "build-applens": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration production --sourceMap=true",
     "build-ncloud-applens-prod": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration=nationalcloud-production",
     "build-ncloud-applens-local": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration=nationalcloud-local",
     "build-asd": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build app-service-diagnostics --configuration production --deploy-url https://app-service-diagnostics-portal.azureedge.net/ --sourceMap=true",

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -312,7 +312,8 @@ export class SupportTopicService {
 
                                 this._telemetryService.logEvent("KeywordsListForKeyStone", {
                                     "Keywords": keystoneInsight["Title"],
-                                    "KeystoneSolutionApplied": String(keystoneSolutionApplied)
+                                    "KeystoneSolutionApplied": String(keystoneSolutionApplied),
+                                    "CaseSubject": searchTerm
                                 });
                             }
                             


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
This PR is for,

- Enable generate source map for Applens
- Add logging for support-topic

## Related Work Item
<!--- Please provide the work item number as well as its link: -->
[WI 3569 Store source maps for Applens deployment to a storage account](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/3569)
## Type of change

<!-- Please delete options that are not relevant. -->


- [X] New feature (non-breaking change which adds functionality)


