### PR TITLE
Re-adding telemetry and correct time usage

### DIFF
--- a/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts
@@ -82,13 +82,18 @@ export class OptInsightsEnablementComponent implements OnInit {
   }
 
   public openOptInsightsBladewithTimeRange() {
-    //const currentMoment = moment.utc();
-    var durationMs = this._detectorControlService.endTime.diff(this._detectorControlService.startTime, 'milliseconds');
+    const currentMoment = moment.utc();
+    var durationMs = currentMoment.diff(this._detectorControlService.startTime, 'milliseconds');
     let optInsightsResource: OptInsightsResource = this.parseOptInsightsResource(this.appInsightsResourceUri, 0, 'microsoft.insights/components', false);
     let optInsightsTimeContext: OptInsightsTimeContext = { durationMs: durationMs, endTime: this._detectorControlService.endTime.toISOString(), createdTime: this._detectorControlService.startTime.toISOString(), isInitialTime: false, grain: 1, useDashboardTimeRange: false};
     this.portalActionService.openOptInsightsBladewithTimeRange(optInsightsResource, optInsightsTimeContext, this._route.parent.snapshot.parent.params['resourcename']);
+    let codeOptimizationsLogEvent: CodeOptimizationsLogEvent = {
+      resourceUri: this.appInsightsResourceUri,
+      telemetryEvent: TelemetryEventNames.AICodeOptimizerOpenOptInsightsBladewithTimeRange,
+      site: this._route.parent.snapshot.parent.params['resourcename']
+    };
+    this._optInsightsService.logOptInsightsEvent(codeOptimizationsLogEvent);
   }
-
 
   parseOptInsightsResource(resourceUri: string, linkedApplicationType: number, resourceType: string, isAzureFirst: boolean): OptInsightsResource {
     var output: OptInsightsResource = {

--- a/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/services/telemetry/telemetry.common.ts
@@ -132,6 +132,7 @@ export const TelemetryEventNames = {
     AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful: 'AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeSuccessful',
     AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeFailure: 'AICodeOptimizerInsightsAggregatedInsightsbyTimeRangeFailure',
     AICodeOptimizerInsightsFailureGettingOPIResources: 'AICodeOptimizerInsightsFailureGettingOPIResources',
+    AICodeOptimizerOpenOptInsightsBladewithTimeRange: 'AICodeOptimizerOpenOptInsightsBladewithTimeRange',
     LoadingTimeOut: 'LoadingTimeOut',
     EmptySearchTerm: 'EmptySearchTerm',
     ChatGPTARMQueryResults: 'ChatGPTARMQueryResults',


### PR DESCRIPTION
## Overview
A previous deployment unintentionally removed two required changes:
- Logging events for when a user clicked on Code Optimizations insights:
    - TelemetryEventNames.AICodeOptimizerOpenOptInsightsBladewithTimeRange
    - Using moment.utc() to calculate time
 This PR is readding those changes.
 
<!--- Why is this change required? What problem does it solve? -->
TelemetryEventNames.AICodeOptimizerOpenOptInsightsBladewithTimeRange is required to estimate from our side how many users interacted with Code Optimizations
Using moment.utc() responds to a change in the portal project done by XiaoXu several months ago, to better estimate times.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
- It adds TelemetryEventNames.AICodeOptimizerOpenOptInsightsBladewithTimeRange and logs it whenever a user clicks on Code Insights results (openOptInsightsBladewithTimeRange()) which in turn will redirect them to the Code Optimizations' blade.
 - It changes the way we were calculating time so that it uses moment.utc() just like the rest of the project.

## How Can This Be Tested? <span>&#128269;</span>
1. Add a breakpoint to [opt-insights-enablement.component.ts](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/blob/main/AngularApp/projects/diagnostic-data/src/lib/components/opt-insights-enablement/opt-insights-enablement.component.ts) on line 85:
    const currentMoment = moment.utc();
2. Browse to Azure Portal and open an App Service Web App (Windows) that has Application Insights and Code Optimizations Insights
3. Browse to Diag and Solve problems\Availability and Performance. This will load Application Insights component followed by the Code Optimizations component. Click on one of the results, this should hit the breakpoint:

- First make sure is calculating the time using moment.utc() and that the time is correct.
- Then keep stepping over the next lines until you reach line 95 which is the call to log the event:
    this._optInsightsService.logOptInsightsEvent(codeOptimizationsLogEvent);

## Checklist <span>&#9989;</span>
- [X] I have looked over the diffs.
- [X] I have run the linter to catch any errors.
- [X] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [ ] I have added tests for this feature (if applicable)
- [X] I have incorporated telemetry into this code to capture and analyze relevant metrics (if applicable)
- [X] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
