### PR TITLE
Add AllowAppId checking for log in

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
@@ -18,7 +18,7 @@ export class AadAuthGuard implements CanActivate {
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Observable<boolean> {
         this._adalService.handleWindowCallback();
-
+        const appIdNotMatchErrorMsg = "appId cannot match with allowedAppId";
         if (!this._adalService.userInfo.authenticated) {
             if (state.url.indexOf('#') === -1) {
                 localStorage.setItem(loginRedirectKey, state.url);
@@ -35,11 +35,18 @@ export class AadAuthGuard implements CanActivate {
             if (this.isAuthorized || state.url.startsWith("/icm/")) {
                 return true;
             }
-            return this._diagnosticApiService.hasApplensAccess().pipe(map(res => {
-                // Application insights initialization call requires user to be authorized first.
-                this._applensAITelemetry.initialize();
-                this.isAuthorized = true;
-                return true;
+            return this._diagnosticApiService.getAllowedAppId().pipe(map(allowedAppId => {
+                const appId: string = this._adalService.userInfo.profile?.aud;
+                const isAllowed = allowedAppId.toLowerCase() === appId.toLowerCase();
+                if (isAllowed) {
+                    // Application insights initialization call requires user to be authorized first.
+                    this._applensAITelemetry.initialize();
+                    this.isAuthorized = true;
+                    return true;
+                } else {
+                    throw new Error(appIdNotMatchErrorMsg);
+                }
+
             }),
                 catchError(err => {
                     this.isAuthorized = false;

--- a/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
@@ -34,8 +34,7 @@ export class AadAuthGuard implements CanActivate {
             if (this.isAuthorized || state.url.startsWith("/icm/")) {
                 return true;
             }
-            const appId: string = this._adalService?.userInfo?.profile?.aud;
-            return this._diagnosticApiService.validateAppId(appId).pipe(map(res => {
+            return this._diagnosticApiService.hasApplensAccess().pipe(map(res => {
                 this._applensAITelemetry.initialize();
                 this.isAuthorized = true;
                 return true;

--- a/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/auth/aad-auth-guard.service.ts
@@ -34,7 +34,7 @@ export class AadAuthGuard implements CanActivate {
             if (this.isAuthorized || state.url.startsWith("/icm/")) {
                 return true;
             }
-            const appId: string = this._adalService.userInfo.profile?.aud;
+            const appId: string = this._adalService?.userInfo?.profile?.aud;
             return this._diagnosticApiService.validateAppId(appId).pipe(map(res => {
                 this._applensAITelemetry.initialize();
                 this.isAuthorized = true;

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -442,9 +442,9 @@ export class DiagnosticApiService {
     return request;
   }
 
-  public getAllowedAppId(): Observable<string> {
-    let path = "api/appsettings/AllowedAppId";
-    return this.get<string>(path);
+  public validateAppId(appId: string): Observable<any> {
+    let path = `api/isappidallowed/${appId}`;
+    return this.get<any>(path);
   }
 
   private getCacheKey(method: HttpMethod, path: string) {

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -442,11 +442,6 @@ export class DiagnosticApiService {
     return request;
   }
 
-  public validateAppId(appId: string): Observable<any> {
-    let path = `api/isappidallowed/${appId}`;
-    return this.get<any>(path);
-  }
-
   private getCacheKey(method: HttpMethod, path: string) {
     return `${HttpMethod[method]}-${path}`;
   }

--- a/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/diagnostic-api.service.ts
@@ -442,6 +442,11 @@ export class DiagnosticApiService {
     return request;
   }
 
+  public getAllowedAppId(): Observable<string> {
+    let path = "api/appsettings/AllowedAppId";
+    return this.get<string>(path);
+  }
+
   private getCacheKey(method: HttpMethod, path: string) {
     return `${HttpMethod[method]}-${path}`;
   }

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -130,32 +130,6 @@ namespace AppLensV3.Controllers
             }
         }
 
-        [HttpGet("isappidallowed/{appId}")]
-        public IActionResult ValidateAppId(string appId)
-        {
-            //For NCloud it's using DSTS, so always return 200
-            if(!config.IsPublicAzure())
-            {
-                return Ok();
-            }
-
-            if (string.IsNullOrEmpty(appId))
-            {
-                return BadRequest();
-            }
-
-            var allowedAppIds = config["AzureAd:AllowedAppId"].Split(',');
-
-            if (allowedAppIds.Any(allowedAppId => allowedAppId.Equals(appId, StringComparison.OrdinalIgnoreCase)))
-            {
-                return Ok();
-            }
-            else
-            {
-                return Unauthorized($"AppId {appId} is not allowed");
-            }
-        }
-
         [HttpGet("workflows/isuserallowed/{userAlias}")]
         public IActionResult IsUserAllowed(string userAlias)
         {

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -133,6 +133,12 @@ namespace AppLensV3.Controllers
         [HttpGet("isappidallowed/{appId}")]
         public IActionResult ValidateAppId(string appId)
         {
+            //For NCloud it's using DSTS, so always return 200
+            if(!config.IsPublicAzure())
+            {
+                return Ok();
+            }
+
             if (string.IsNullOrEmpty(appId))
             {
                 return BadRequest();

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -133,7 +133,6 @@ namespace AppLensV3.Controllers
         [HttpGet("isappidallowed/{appId}")]
         public IActionResult ValidateAppId(string appId)
         {
-
             if (string.IsNullOrEmpty(appId))
             {
                 return BadRequest();
@@ -141,7 +140,7 @@ namespace AppLensV3.Controllers
 
             var allowedAppIds = config["AzureAd:AllowedAppId"].Split(',');
 
-            if (allowedAppIds.Any(allowedAppId => allowedAppId.Equals(appId,StringComparison.OrdinalIgnoreCase)))
+            if (allowedAppIds.Any(allowedAppId => allowedAppId.Equals(appId, StringComparison.OrdinalIgnoreCase)))
             {
                 return Ok();
             }

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -133,14 +133,15 @@ namespace AppLensV3.Controllers
         [HttpGet("isappidallowed/{appId}")]
         public IActionResult ValidateAppId(string appId)
         {
-            string allowedAppId = config["AllowedAppId"];
 
-            if(string.IsNullOrEmpty(appId))
+            if (string.IsNullOrEmpty(appId))
             {
                 return BadRequest();
             }
 
-            if (allowedAppId.Equals(appId, StringComparison.OrdinalIgnoreCase))
+            var allowedAppIds = config["AzureAd:AllowedAppId"].Split(',');
+
+            if (allowedAppIds.Any(allowedAppId => allowedAppId.Equals(appId,StringComparison.OrdinalIgnoreCase)))
             {
                 return Ok();
             }

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -45,7 +45,7 @@ namespace AppLensV3.Controllers
         private readonly bool detectorDevelopmentEnabled;
         private readonly IList<string> apiEndpointsForDetectorDevelopment;
         private readonly string[] allowedUsers;
-        private readonly string[] AllowedSections = new string[] { "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch", "NetworkTraceAnalysisTool", "AllowedAppId" };
+        private readonly string[] AllowedSections = new string[] { "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch", "NetworkTraceAnalysisTool" };
 
         private class InvokeHeaders
         {
@@ -127,6 +127,26 @@ namespace AppLensV3.Controllers
             else
             {
                 return NotFound($"App setting with the name '{name}' is not found");
+            }
+        }
+
+        [HttpGet("isappidallowed/{appId}")]
+        public IActionResult ValidateAppId(string appId)
+        {
+            string allowedAppId = config["AllowedAppId"];
+
+            if(string.IsNullOrEmpty(appId))
+            {
+                return BadRequest();
+            }
+
+            if (allowedAppId.Equals(appId, StringComparison.OrdinalIgnoreCase))
+            {
+                return Ok();
+            }
+            else
+            {
+                return Unauthorized($"AppId {appId} is not allowed");
             }
         }
 
@@ -225,7 +245,7 @@ namespace AppLensV3.Controllers
             }
 
             headers.Add("x-ms-user-token", Request.Headers["Authorization"].ToString());
-            
+
             // For Publishing Detector Calls, validate if user has access to publish the detector
             if (invokeHeaders.Path.EndsWith("/diagnostics/publish", StringComparison.OrdinalIgnoreCase))
             {

--- a/ApplensBackend/Controllers/DiagnosticController.cs
+++ b/ApplensBackend/Controllers/DiagnosticController.cs
@@ -45,7 +45,7 @@ namespace AppLensV3.Controllers
         private readonly bool detectorDevelopmentEnabled;
         private readonly IList<string> apiEndpointsForDetectorDevelopment;
         private readonly string[] allowedUsers;
-        private readonly string[] AllowedSections = new string[] { "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch", "NetworkTraceAnalysisTool" };
+        private readonly string[] AllowedSections = new string[] { "ApplicationInsights", "AcceptOriginSuffix:Origins", "CodeCompletion", "DetectorDevelopmentEnabled", "DetectorDevelopmentEnv", "PPEHostname", "APPLENS_ENVIRONMENT", "APPLENS_HOST", "SystemInvokers:ResourceIDString", "SystemInvokers:DocumentationStagingBranch", "SystemInvokers:DocumentationRoot", "SystemInvokers:DiagnosticsMainBranch", "NetworkTraceAnalysisTool", "AllowedAppId" };
 
         private class InvokeHeaders
         {

--- a/ApplensBackend/appsettings.PublicAzure.json
+++ b/ApplensBackend/appsettings.PublicAzure.json
@@ -6,5 +6,7 @@
     "diagnosticObserverEnabled": true
   },
   "IFrameAllowedOrigins": "https://azuresupportcenter.msftcloudes.com/ https://azuresupportcenterppe.msftcloudes.com/ https://azuresupportcentertest.azurewebsites.net/ https://eu.azuresupportcenter.azure.com",
-  "AllowedAppId": "192bd8f2-c844-4977-aefd-77407619e80c"
+  "AzureAd": {
+    "AllowedAppId": "192bd8f2-c844-4977-aefd-77407619e80c"
+  }
 }

--- a/ApplensBackend/appsettings.PublicAzure.json
+++ b/ApplensBackend/appsettings.PublicAzure.json
@@ -5,5 +5,6 @@
     "endpoint": "https://wawsobserver.trafficmanager.net/api/",
     "diagnosticObserverEnabled": true
   },
-  "IFrameAllowedOrigins": "https://azuresupportcenter.msftcloudes.com/ https://azuresupportcenterppe.msftcloudes.com/ https://azuresupportcentertest.azurewebsites.net/ https://eu.azuresupportcenter.azure.com"
+  "IFrameAllowedOrigins": "https://azuresupportcenter.msftcloudes.com/ https://azuresupportcenterppe.msftcloudes.com/ https://azuresupportcentertest.azurewebsites.net/ https://eu.azuresupportcenter.azure.com",
+  "AllowedAppId": "192bd8f2-c844-4977-aefd-77407619e80c"
 }

--- a/ApplensBackend/appsettings.json
+++ b/ApplensBackend/appsettings.json
@@ -198,5 +198,6 @@
   "NetworkTraceAnalysisTool": {
     "Enabled": true,
     "APIUrl": "https://ntwk-trace-analysis-tool-app.purpleground-97896349.eastus.azurecontainerapps.io/"
-  }
+  },
+  "AllowedAppId": ""
 }

--- a/ApplensBackend/appsettings.json
+++ b/ApplensBackend/appsettings.json
@@ -52,7 +52,8 @@
     "Instance": "",
     "ClientId": "",
     "TenantId": "",
-    "Domain": ""
+    "Domain": "",
+    "AllowedAppId":""
   },
   "Kusto": {
     "Enabled": true,
@@ -198,6 +199,5 @@
   "NetworkTraceAnalysisTool": {
     "Enabled": true,
     "APIUrl": "https://ntwk-trace-analysis-tool-app.purpleground-97896349.eastus.azurecontainerapps.io/"
-  },
-  "AllowedAppId": ""
+  }
 }


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->

This PR is to add AppId checking for custom rerouting after disabling easy auth

Add AllowedAppId into appsettings, only appId from ADAL matches from appsettings, will redirect to landing page, otherwise it will be blocked 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




