### PR TITLE
Fix - Use ApplensAccess Policy for IncidentAssistance and Survey Endpoints

### DIFF
--- a/ApplensBackend/Controllers/IncidentAssistanceController.cs
+++ b/ApplensBackend/Controllers/IncidentAssistanceController.cs
@@ -16,7 +16,7 @@ using System.IdentityModel.Tokens.Jwt;
 namespace AppLensV3.Controllers
 {
     [Route("api/icm/")]
-    [Authorize(Policy = "DefaultAccess")]
+    [Authorize(Policy = "ApplensAccess")]
     public class IncidentAssistanceController : Controller
     {
         private readonly IIncidentAssistanceService _incidentAssistanceService;
@@ -58,10 +58,10 @@ namespace AppLensV3.Controllers
             {
                 return BadRequest("incidentId cannot be empty");
             }
-            return Unauthorized();
-            // var response = await _incidentAssistanceService.GetIncidentInfo(incidentId);
-            // var responseTask = response.Content.ReadAsStringAsync();
-            // return StatusCode((int)response.StatusCode, await responseTask);
+
+            var response = await _incidentAssistanceService.GetIncidentInfo(incidentId);
+            var responseTask = response.Content.ReadAsStringAsync();
+            return StatusCode((int)response.StatusCode, await responseTask);
         }
 
         [HttpPost("validateAndUpdateIncident")]
@@ -78,10 +78,9 @@ namespace AppLensV3.Controllers
                 return BadRequest("IncidentId cannot be empty");
             }
 
-            return Unauthorized();
-            // var response = await _incidentAssistanceService.ValidateAndUpdateIncident(incidentId, body, update);
-            // var responseTask = response.Content.ReadAsStringAsync();
-            // return StatusCode((int)response.StatusCode, await responseTask);
+            var response = await _incidentAssistanceService.ValidateAndUpdateIncident(incidentId, body, update);
+            var responseTask = response.Content.ReadAsStringAsync();
+            return StatusCode((int)response.StatusCode, await responseTask);
         }
 
         [HttpGet("getOnboardedTeams")]

--- a/ApplensBackend/Controllers/SurveysController.cs
+++ b/ApplensBackend/Controllers/SurveysController.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Caching.Memory;
 namespace AppLensV3.Controllers
 {
     [Route("api/surveys/")]
-    [Authorize(Policy = "DefaultAccess")]
+    [Authorize(Policy = "ApplensAccess")]
     public class SurveysController : Controller
     {
         private readonly ISurveysService _surveysService;


### PR DESCRIPTION
## Overview    
The App Lens Incident APIs have been configured without authentication.  

An example of this is shown below where a customers incident information could be retrieved with an HTTP GET request.
```
GET /api/icm/getIncident/407454838 HTTP/1.1
Host: applens.trafficmanager.net


HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Date: Sat, 22 Jul 2023 11:11:49 GMT
Server: Microsoft-IIS/10.0
Set-Cookie: ARRAffinity=0eb22d20c19edaf9580d00da8793ef25da2f8fb32f441bf713accbe41900887b;Path=/;HttpOnly;Secure;Domain=applens.trafficmanager.net
Set-Cookie: ARRAffinitySameSite=0eb22d20c19edaf9580d00da8793ef25da2f8fb32f441bf713accbe41900887b;Path=/;HttpOnly;SameSite=None;Secure;Domain=applens.trafficmanager.net
Request-Context: appId=cid-v1:448da79b-5c62-499d-b02f-83fd00681ad2
Content-Security-Policy: default-src: https:; frame-ancestors &#39;self&#39; https://azuresupportcenter.msftcloudes.com/ https://azuresupportcenterppe.msftcloudes.com/ https://azuresupportcentertest.azurewebsites.net/ https://eu.azuresupportcenter.azure.com
X-Powered-By: ASP.NET
Strict-Transport-Security: max-age=31536000; includeSubDomains
Content-Length: 752

{&quot;incidentId&quot;:&quot;407454838&quot;,&quot;title&quot;:&quot;WA-WebSites:LINUX  [BC] [[Construction Industry Council]Files can be downloaded by using uppercase file extension in any URL][Construction Industry Council]Files can be downloaded by using uppercase file extension in any URL&quot;,&quot;validationResults&quot;:[{&quot;name&quot;:&quot;Title&quot;,&quot;value&quot;:&quot;WA-WebSites:LINUX  [BC] [[Construction Industry Council]Files can be downloaded by using uppercase file extension in any URL][Construction Industry Council]Files can be downloaded by using uppercase file extension in any URL&quot;,&quot;validationStatus&quot;:true},{&quot;name&quot;:&quot;Name of the Web App/Function App&quot;,&quot;value&quot;:&quot;&lt;div&gt;ebb-prd-app-iar-war&lt;br&gt;&lt;/div&gt;&quot;,&quot;validationStatus&quot;:true},{&quot;name&quot;:&quot;Impact Start Time (UTC)&quot;,&quot;value&quot;:&quot;2023-06-02&quot;,&quot;validationStatus&quot;:true}]}
```

To retrieve incident records, only an Incident id is required. These are sequential numbers that can be easily enumerated.
    
## Steps to Reproduce 

This can be reproduced by navigating to the following URL in a web browser:

https://applens.trafficmanager.net/api/icm/getIncident/407454838

## Related Work Item
<!--- Please provide the work item number as well as its link: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Solution description
<!--- Describe your code changes in details for reviewers. -->
### This PR:
 - updates the code to use ApplensAccess policy for ICM controller and Surveys controller 
## How Can This Be Tested? <span>&#128269;</span>
<!--- Please provide instructions on how to test your changes so that the reviewer can reproduce -->
<!--- Include details of your testing environment -->
<!--- Please also list any relevant details for your test configuration -->

## Checklist <span>&#9989;</span>
- [x] I have looked over the diffs.
- [ ] I have run the linter to catch any errors.
- [x] There are no errors from my changes on this branch.
- [ ] I have ensured that my changes support accessibility and can be accessed with the keyboard alone
- [ ] I have added tests for this feature (if applicable)
- [ ] I have incorporated telemetry into this code to capture and analyze relevant metrics (if applicable)
- [x] I have requested review on this PR.

## Screenshots Before Fix (if appropriate):

## Screenshots After Fix (if appropriate):

## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
