### PR TITLE
Show all Apollo self help content in case submission for AKS and WebApps

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement', 'microsoft.app'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement', 'microsoft.app', 'microsoft.containerregistry', 'microsoft.containerinstance', 'microsoft.redhatopenshift'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement', 'microsoft.app', 'microsoft.containerregistry', 'microsoft.containerinstance', 'microsoft.redhatopenshift', 'microsoft.servicefabric'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement', 'microsoft.app'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement', 'microsoft.app', 'microsoft.containerregistry', 'microsoft.containerinstance', 'microsoft.redhatopenshift'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -63,7 +63,7 @@ export class SupportTopicService {
 
     private cleanSelfHelpContentApollo(selfHelpResponse) {
         let docContent = selfHelpResponse.properties.content;
-        let result = cleanApolloSolutions(docContent);
+        let result = cleanApolloSolutions(docContent, this.showAllSelfHelpContent());
         return result;
     }
 
@@ -107,15 +107,23 @@ export class SupportTopicService {
         return throwError("Cannot get self content from Apollo");
     }
 
+    private showAllSelfHelpContent():boolean {
+        let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice'];
+        return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
+    }
+
     private cleanSelfHelpContentLegacy(selfHelpResponse) {
         if (selfHelpResponse && selfHelpResponse.length > 0) {
             var htmlContent = selfHelpResponse[0]["htmlContent"];
             // Custom javascript code to remove top header from support document html string
             var tmp = document.createElement("DIV");
             tmp.innerHTML = htmlContent;
-            var h2s = tmp.getElementsByTagName("h2");
-            if (h2s && h2s.length > 0) {
-                h2s[0].remove();
+            if(!this.showAllSelfHelpContent()) {
+                var h2s = tmp.getElementsByTagName("h2");
+                if (h2s && h2s.length > 0) {
+                    h2s[0].remove();
+                }
             }
 
             return tmp.innerHTML;

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/services/support-topic.service.ts
@@ -109,7 +109,7 @@ export class SupportTopicService {
 
     private showAllSelfHelpContent():boolean {
         let rp =  `${this._resourceService?.resource?.id}`.toLowerCase().split('/providers/')[1].split('/')[0];
-        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow'];
+        let rpsToShowAllContent = ['microsoft.web', 'microsoft.containerservice', 'microsoft.domainregistration', 'microsoft.certificateregistration', 'microsoft.workflow', 'microsoft.apimanagement'];
         return rpsToShowAllContent.some((rpToShowAllContent) => rp.includes(rpToShowAllContent));
     }
 

--- a/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/shared-v2/utils/apollo-utils.ts
@@ -20,13 +20,16 @@ var sectionParser = (content: string) => {
 	return sections;
 }
 
-export var cleanApolloSolutions = (docContent) => {
+export var cleanApolloSolutions = (docContent, returnAllContent:boolean) => {
 	var sections = sectionParser(docContent);
 	//Remove sections which have Apollo replacement string
 	var targetParts = sections.filter((x:string) => x.length > 1 && !isReplacementString(x));
 
-	//Also remove the FIRST SECTION if it has h2 tag or if it doesn't contain any links
-	targetParts = targetParts[0].includes("<h2>") || !targetParts[0].includes("a href") ? targetParts.slice(1, targetParts.length): targetParts;
+	//Also remove the FIRST SECTION if it has h2 tag or if it doesn't contain any links only if the returnAllContent flag is false
+	if(!returnAllContent) {
+		targetParts = (returnAllContent && targetParts[0].includes("<h2>")) || !targetParts[0].includes("a href") ? targetParts.slice(1, targetParts.length): targetParts;
+	}
+	
 	let result = targetParts ? targetParts.join('\n'): '';
 	const hrefTerm = "a href";
 	const searchRegExp = new RegExp(hrefTerm, 'g');


### PR DESCRIPTION

## Overview
Show the entire static self help document in case submission and not just the H3 content. Got a request from SPMs for this change.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)


## Solution description
Show the entire static self help document in case submission and not just the H3 content. Got a request from SPMs for this change.



## Screenshots Before Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/dc68dd2e-98ea-4ee8-b946-b3deb7435095)


## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/20996681/f018971b-a4c2-4bda-833f-cc384f9acb39)


## Extra Notes
<!-- Please include any extra note(s) the reviewers need to know -->
