### PR TITLE
Ensure owners.txt populated for workflows

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -1817,7 +1817,32 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
       this.owners.forEach(o => {
         if (o.match(/^\s*$/) == null) reviewers = reviewers.concat(o, '\n');
       });
+    } else {
+      if (this.isWorkflowDetector && this.workflowPublishBody != null) {
+        if (this.workflowPublishBody.AppType != null) {
+          this.workflowPublishBody.AppType.split(',').forEach(apt => {
+            if (Object.keys(this.DevopsConfig.appTypeReviewers).includes(apt)) {
+              this.DevopsConfig.appTypeReviewers[apt].forEach(rev => {
+                if (!this.owners.includes(rev)) this.owners.push(rev);
+              });
+            }
+          });
+        }
+        if (this.workflowPublishBody.Platform != null) {
+          this.workflowPublishBody.Platform.split(',').forEach(plt => {
+            if (Object.keys(this.DevopsConfig.platformReviewers).includes(plt)) {
+              this.DevopsConfig.platformReviewers[plt].forEach(rev => {
+                if (!this.owners.includes(rev)) this.owners.push(rev);
+              });
+            }
+          });
+        }
+        this.owners.forEach(o => {
+          if (o.match(/^\s*$/) == null) reviewers = reviewers.concat(o, '\n');
+        });
+      }
     }
+
     return reviewers;
   }
 


### PR DESCRIPTION
## Overview
Due to some async issue, `this.queryResponse` object is not populated correctly in the onboarding component for workflows. This PR just ensures that the `owners.txt` get populated from the `workflowPublishBody` in case `this.queryResponse`  is NULL and if grad publish is happening for workflow detectors.

Underneath somewhere an aync issue exists so this is just a band-aid fix to take care of that problem.
