### PR TITLE
Enable load test tile for Linux web apps

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/resources/web-sites/services/sites-category.service.ts
@@ -423,7 +423,7 @@ export class SitesCategoryService extends CategoryService {
     if (this._armService.isPublicAzure) {
       this._sitesCategories.push({
         appType: AppType.WebApp,
-        platform: OperatingSystem.windows,
+        platform: OperatingSystem.windows | OperatingSystem.linux,
         stack: '',
         sku: Sku.All,
         hostingEnvironmentKind: HostingEnvironmentKind.All,


### PR DESCRIPTION
## Overview
Enabling load testing tile even for Linux Web Apps

## Screenshots After Fix (if appropriate):
![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/6b942b4c-7ef7-4184-b8f4-5595c7ab2aa8)