### PR TITLE
Ensure Detector output is part of Detector node

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
@@ -18,6 +18,12 @@
                             <option *ngFor="let detector of workflowNodeDetectors" [value]="detector.id">{{
                                 detector.name }}</option>
                         </select>
+                        <div>
+                            <label class="checkbox-inline">
+                                <input [(ngModel)]="data.addDetectorOutput" id="addDetectorOutput"
+                                    name="chkAddDetectorOutput" type="checkbox" />
+                                Append detector output to node </label>
+                        </div>
                     </div>
 
                 </div>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
@@ -1,10 +1,10 @@
 <div [attr.name]="data.name" #canvasContent>
-  <div class="panel panel-default">
+  <div class="panel panel-default" [ngClass]="{'min-width-detector': data.detectorResponse}">
     <div class="panel-heading">
 
       <div class="node-heading">
         <status-icon class="mr-3" [status]="status"></status-icon>
-        <div class="mr-3" tabindex="0"><strong [attr.aria-label]="data.title" >{{ data.title }}</strong></div>
+        <div class="mr-3" tabindex="0"><strong [attr.aria-label]="data.title">{{ data.title }}</strong></div>
         <div class="tool-tip-icon">
           <div class="mr-2">
             <i *ngIf="isLoading && ((data.children && data.children.length > 0) || data.type.toLowerCase() === 'input')"
@@ -40,6 +40,11 @@
       <div *ngIf="data.description" tabindex="0" class="description-text">{{ data.description }}</div>
       <div *ngIf="data.markdownText" tabindex="0" class="markdown-text">
         <markdown-text [markdownData]="data.markdownText" [isMarkdownView]="true"></markdown-text>
+      </div>
+      <div #detectorViewDiv *ngIf="data.detectorResponse" class="mr-3 min-width-detector-section">
+        <detector-view [detectorResponse]="data.detectorResponse" [developmentMode]="false" hideDetectorControl="true"
+          [startTime]="startTime" [endTime]="endTime">
+        </detector-view>
       </div>
       <workflow-accept-userinput *ngIf="data.inputNodeSettings" [data]="data"
         #acceptUserInput></workflow-accept-userinput>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
@@ -98,3 +98,11 @@
   width: 20px;
   margin-right: 5px;
 }
+
+.min-width-detector {
+  min-width: 600px;
+}
+
+.min-width-detector-section {
+  min-width: 500px;
+}

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-result/workflow-result.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-result/workflow-result.component.html
@@ -1,38 +1,40 @@
-<h4>Node Properties</h4>
-<table class="table table-bordered">
-    <thead>
-    </thead>
-    <tbody>
-        <tr>
-            <th>Description</th>
-            <td>{{ renderingProperties.description }}</td>
-        </tr>
-        <tr>
-            <th>Status</th>
-            <td>{{ status }}</td>
-        </tr>
-        <tr>
-            <th>Markdown</th>
-            <td>{{ markdown }}</td>
-        </tr>
-    </tbody>
-</table>
-<h4>Variables</h4>
-<table class="table table-bordered">
-    <thead>
-        <tr>
-            <th>name</th>
-            <th>type</th>
-            <th>value</th>
-            <th>runtimeValue</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr *ngFor="let variable of variables">
-            <td>{{ variable.name }}</td>
-            <td>{{ variable.type }}</td>
-            <td>{{ variable.value }}</td>
-            <td>{{ variable.runtimeValue }}</td>
-        </tr>
-    </tbody>
-</table>
+<ng-container *ngIf="!isInWorkflow">
+    <h4>Node Properties</h4>
+    <table class="table table-bordered">
+        <thead>
+        </thead>
+        <tbody>
+            <tr>
+                <th>Description</th>
+                <td>{{ renderingProperties.description }}</td>
+            </tr>
+            <tr>
+                <th>Status</th>
+                <td>{{ status }}</td>
+            </tr>
+            <tr>
+                <th>Markdown</th>
+                <td>{{ markdown }}</td>
+            </tr>
+        </tbody>
+    </table>
+    <h4>Variables</h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>name</th>
+                <th>type</th>
+                <th>value</th>
+                <th>runtimeValue</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr *ngFor="let variable of variables">
+                <td>{{ variable.name }}</td>
+                <td>{{ variable.type }}</td>
+                <td>{{ variable.value }}</td>
+                <td>{{ variable.runtimeValue }}</td>
+            </tr>
+        </tbody>
+    </table>
+</ng-container>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-result/workflow-result.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-result/workflow-result.component.ts
@@ -17,6 +17,7 @@ export class WorkflowResultComponent extends DataRenderBaseComponent {
   status: string = '';
   markdown: string = '';
   variables: stepVariable[] = [];
+  isInWorkflow: boolean = false;
 
   constructor(protected telemetryService: TelemetryService, @Inject(DIAGNOSTIC_DATA_CONFIG) config: DiagnosticDataConfig) {
     super(telemetryService);
@@ -35,10 +36,12 @@ export class WorkflowResultComponent extends DataRenderBaseComponent {
       let statusColIndex: number = 0;
       let markdownColIndex: number = 1;
       let variablesColIndex: number = 2;
+      let isInWorkflowColIndex: number = 3;
 
       this.status = table.rows[0][statusColIndex];
       this.markdown = table.rows[0][markdownColIndex];
       this.variables = JSON.parse(table.rows[0][variablesColIndex]);
+      this.isInWorkflow = table.rows[0][isInWorkflowColIndex];
     }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/workflow.ts
@@ -1,5 +1,5 @@
 import { CompilationProperties } from "./compilation-properties";
-import { DataTableResponseColumn, PropertyBag } from "./detector";
+import { DataTableResponseColumn, DetectorResponse, PropertyBag } from "./detector";
 
 export interface Dictionary<T> {
   [K: string]: T;
@@ -76,6 +76,7 @@ export class workflowNodeData {
   switchOnValue: string;
   switchCaseValue: string;
   foreachVariable: string;
+  addDetectorOutput: boolean = false;
   inputNode: inputNode = new inputNode();
   kustoNode: kustoNode = new kustoNode();
 }
@@ -150,6 +151,8 @@ export interface workflowNodeResult {
   metadataPropertyBag: PropertyBag[]
   inputNodeSettings: inputNodeSettings;
   workflowPackage: any;
+  detectorId: string;
+  detectorResponse: DetectorResponse;
 }
 
 export interface inputNodeSettings {


### PR DESCRIPTION
## Overview
Changes required to the UI project to support adding full detector output of a detector to a workflow node

- [x] New feature (non-breaking change which adds functionality)

## Solution description

### This PR:
The UI PR to go along with backend changes PR - https://dev.azure.com/msazure/One/_git/AAPT-Antares-AppServiceDiagnostics/pullrequest/8581708

## Screenshots After Fix (if appropriate):

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/704582e7-4327-4c1f-b3a5-08175f288e04)

The below checkbox has to be checked if Detector Author wants the detector output to be part of workflow node

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/621f9194-ee12-446c-a588-28d32e5b9dac)
