### PR TITLE
Disable AutoHeal option for Diagnostics for Elastic Premium

### DIFF
--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.html
@@ -14,8 +14,14 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <div *ngIf="customActionType == 'Diagnostics'">
-
-        <div>
+        <div *ngIf="isElasticPremium">
+          <div class="error-details">
+            <i class="fa health-icon fa-times-circle unhealthy-icon-color" aria-hidden="true"></i>
+            Diagnostics via Auto-healing is currently not supported for Elastic Premium apps. Support for Elastic
+            Premimum will come in the next Azure App Service Platform update. Please stay tuned and sorry for the inconvenience.
+          </div>
+        </div>
+        <div *ngIf="!isElasticPremium">
           <div class="row">
             <div class="detail-cards">
               <ng-container *ngFor="let item of Diagnosers;let i = index">
@@ -40,8 +46,9 @@
                 <ng-container *ngFor="let option of DiagnoserOptions">
                   <div class="radio">
                     <label>
-                      <input type="radio" name="optradio" [checked]="diagnoserOption && diagnoserOption.option === option.option"
-                        [value]="option.option" (change)="chooseDiagnoserAction(option)"> {{ option.option }}
+                      <input type="radio" name="optradio"
+                        [checked]="diagnoserOption && diagnoserOption.option === option.option" [value]="option.option"
+                        (change)="chooseDiagnoserAction(option)"> {{ option.option }}
                     </label>
                   </div>
                 </ng-container>
@@ -75,7 +82,7 @@
             </div>
           </div>
         </div>
-        <div class="mt-3" *ngIf="diagnoser && diagnoser.Name">
+        <div class="mt-3" *ngIf="diagnoser && diagnoser.Name" [hidden]="isElasticPremium" >
           <daas-validator #daasValidatorRef [siteToBeDiagnosed]="siteToBeDiagnosed" [diagnoserName]="diagnoser.Name"
             (DaasValidated)="onDaasValidated($event)"></daas-validator>
         </div>

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.scss
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.scss
@@ -87,3 +87,9 @@ label {
     margin-top: 5px;
     margin-bottom: 5px;
 }
+
+.error-details {
+    background-color: rgb(254, 240, 240);
+    padding: 5px;
+    font-size: 14px;
+}

--- a/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
+++ b/AngularApp/projects/app-service-diagnostics/src/app/auto-healing/autohealing-custom-action/autohealing-custom-action.component.ts
@@ -29,7 +29,8 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
   showDiagnoserOptionWarning: boolean = false;
   validationResult: DaasValidationResult = new DaasValidationResult();
   updatedCustomAction: AutoHealCustomAction = new AutoHealCustomAction();
-
+  
+  isElasticPremium: boolean = false;
 
   Diagnosers = [{ Name: 'Memory Dump', Enabled: true, Description: 'Collects memory dumps of the process and the child processes hosting your app and analyzes them for errors' },
   { Name: 'CLR Profiler', Enabled: true, Description: 'Profiles ASP.NET application code to identify exceptions and performance issues' },
@@ -224,6 +225,11 @@ export class AutohealingCustomActionComponent implements OnInit, OnChanges, Afte
 
   onDaasValidated(event: DaasValidationResult) {
     this.validationResult = event;
+    this.isElasticPremium = event.ServerFarmSku != null && event.ServerFarmSku.toLowerCase().startsWith('elastic');
+    if (this.isElasticPremium) {
+      this.validationResult.Validated = false;
+    }
+
     this.updateDaasAction(false);
   }
 }


### PR DESCRIPTION
## Overview
Elastic Premium Apps do not have Always-On and Scale Controller does the job of warming up the main site's worker process, but it is not consistently doing this for the SCM Site due to which DaasRunner.exe may not be running when an Auto-Heal Condition is satisfied. Functions team is aware of this issue, and they have some optimization planned in ANT-101 but till then, disabling the option to configure Auto-Heal to run diagnostics in Auto-Heal UI for Elastic Premium apps.

This PR should be reverted once the functionality to warmup the Kudu site is addressed by Scale Controller team.

## Screenshots After Fix (if appropriate):

![image](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/f675bd39-e8ca-4eeb-bb5b-be5aa395f68b)
