### PR TITLE
Authentication on SignalR connection for Copilot

### DIFF
--- a/AngularApp/projects/applens/src/app/shared/services/applens-openai-chat.service.ts
+++ b/AngularApp/projects/applens/src/app/shared/services/applens-openai-chat.service.ts
@@ -8,6 +8,7 @@ import { ResourceService } from './resource.service';
 import { environment } from '../../../environments/environment';
 import * as signalR from "@microsoft/signalr";
 import { error } from 'console';
+import { AdalService } from 'adal-angular4';
 
 @Injectable()
 export class ApplensOpenAIChatService {
@@ -26,7 +27,7 @@ export class ApplensOpenAIChatService {
   private signalRLogLevel: any;
   private messageBuilder: string;
 
-  constructor(private _backendApi: DiagnosticApiService, private _resourceService: ResourceService, private telemetryService: TelemetryService) {
+  constructor(private _adalService: AdalService, private _backendApi: DiagnosticApiService, private _resourceService: ResourceService, private telemetryService: TelemetryService) {
     this.resourceProvider = `${this._resourceService.ArmResource.provider}/${this._resourceService.ArmResource.resourceTypeName}`.toLowerCase();
     this.productName = this._resourceService.searchSuffix + ((this.resourceProvider === 'microsoft.web/sites') ? ` ${this._resourceService.displayName}` : '');
     this.onMessageReceive = new BehaviorSubject<ChatResponse>(null);
@@ -102,7 +103,10 @@ export class ApplensOpenAIChatService {
       if (!this.signalRConnection || this.signalRConnection.state !== signalR.HubConnectionState.Connected) {
 
         this.signalRConnection = new signalR.HubConnectionBuilder()
-          .withUrl(this.signalRChatEndpoint)
+          .withUrl(this.signalRChatEndpoint, {  
+            accessTokenFactory: () => {  
+              return this._adalService.userInfo.token;
+            }})
           .configureLogging(this.signalRLogLevel)
           .withAutomaticReconnect()
           .build();

--- a/ApplensBackend/Extensions/AuthServiceCollectionExtensions.cs
+++ b/ApplensBackend/Extensions/AuthServiceCollectionExtensions.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (environment.IsDevelopment())
             {
-                services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerLocalDevelopment>();
+                services.AddSingleton<IAuthorizationHandler, SecurityGroupHandler>();
+                //services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerLocalDevelopment>();
             }
             else
             {

--- a/ApplensBackend/Extensions/AuthServiceCollectionExtensions.cs
+++ b/ApplensBackend/Extensions/AuthServiceCollectionExtensions.cs
@@ -114,8 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (environment.IsDevelopment())
             {
-                services.AddSingleton<IAuthorizationHandler, SecurityGroupHandler>();
-                //services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerLocalDevelopment>();
+                services.AddSingleton<IAuthorizationHandler, SecurityGroupHandlerLocalDevelopment>();
             }
             else
             {

--- a/ApplensBackend/Hubs/OpenAIChatCompletionHub.cs
+++ b/ApplensBackend/Hubs/OpenAIChatCompletionHub.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AppLensV3.Models;
 using AppLensV3.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -15,6 +16,7 @@ namespace AppLensV3.Hubs
     /// <summary>
     /// Open AI Chat Completion Hub Class.
     /// </summary>
+    [Authorize(Policy = "ApplensAccess")]
     public class OpenAIChatCompletionHub : Hub
     {
         private IOpenAIRedisService openAIRedisService;


### PR DESCRIPTION
## Overview
Our Copilots talk to the backend via SignalR over WSS. This PR adds security on the SignalR connection negotiation call so only authenticated clients/users can interact with the Copilots.

This PR changes nothing in terms of the existing experience, only adds security.
