### PR TITLE
Add command for not using CDN for n-cloud

### DIFF
--- a/AngularApp/package.json
+++ b/AngularApp/package.json
@@ -17,6 +17,7 @@
     "build-ncloud-applens-prod": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration=nationalcloud-production",
     "build-ncloud-applens-local": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build applens --configuration=nationalcloud-local",
     "build-asd": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build app-service-diagnostics --configuration production --deploy-url https://app-service-diagnostics-portal.azureedge.net/ --sourceMap=true",
+    "build-asd-no-cdn": "npm run fixAngularReact && node --max_old_space_size=8192 node_modules/@angular/cli/bin/ng build app-service-diagnostics --configuration production --sourceMap=true",
     "build-ng-flowchart": "ng build ng-flowchart --configuration production",
     "build": "npm run fixAngularReact && npm run build-lib && npm run build-applens && npm run build-asd && npm run build-ng-flowchart",
     "test": "ng test",


### PR DESCRIPTION
## Overview
<!--- Provide a brief description of your changes -->
<!--- Why is this change required? What problem does it solve? -->
Adding `npm run build-asd-no-cdn` for building app-service-diagnostic for N-cloud that not requires for CDN
