### PR TITLE
Adding downtime selector in Workflow nodes

### DIFF
--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.html
@@ -357,6 +357,8 @@
         (click)="downloadWorkflow()"></fab-command-bar-item>
       <fab-command-bar-item *ngIf="isWorkflowDetector" key="upload" text="Upload" [iconProps]="{ iconName: 'PublishContent' }"
         (click)="uploader.click()"></fab-command-bar-item>
+      <fab-command-bar-item *ngIf="isWorkflowDetector" key="refreshVariables" text="Refresh variables" [iconProps]="{ iconName: 'Refresh' }"
+        (click)="refreshWorkflowVariables()"></fab-command-bar-item>
       <fab-command-bar-item *ngIf="!isWorkflowDetector" key="gistVersion" text="Gist version"
         [iconProps]="{ iconName: 'BackToWindow' }" (click)="showGistDialog()"></fab-command-bar-item>
       <fab-command-bar-item [style]="commitHistoryVisibilityStyle" key="commitHistory" text="Commit History"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/onboarding-flow/onboarding-flow.component.ts
@@ -2472,6 +2472,10 @@ export class OnboardingFlowComponent implements OnInit, OnDestroy, IDeactivateCo
     this.createWorkflow.showFlowData();
   }
 
+  refreshWorkflowVariables(){
+    this.createWorkflow.refreshVariables();
+  }
+
   async uploadWorkflow($event) {
     let file = $event.target.files[0];
     const text = await file.text();

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent class="condition">
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
     <div class="panel panel-default">
         <div class="panel-heading panel-title-else">
-            <node-title [data]="data" [disableEdit]="true" [customClass]="'background-red'"
+            <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-red'"
                 [customClassIcon]="'fa-times'">
             </node-title>
         </div>
-        <div class="panel-body">
+        <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
             <div class="mt-3">
                 <div class="mb-5">Executes if condition is false</div>
                 <node-actions [isConditionNode]="true" (onNodeAdded)="addNode($event)"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.scss
@@ -1,7 +1,3 @@
-.condition{
-    min-width: 400px;
-}
-
 .panel-title-else{
     background-color: #FEEEED;
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iffalse-step/condition-iffalse-step.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({
@@ -14,5 +14,6 @@ export class ConditionIffalseStepComponent extends WorkflowNodeBaseClass impleme
   }
 
   ngOnInit(): void {
+    this.data.title = "If false";
   }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent class="condition">
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-if">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-light-green'"
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-light-green'"
         [customClassIcon]="'fa-check'">
       </node-title>
     </div>
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <div class="mt-3">
         <div class="mb-5">Executes if condition is true</div>
         <node-actions [isConditionNode]="true" (onNodeAdded)="addNode($event)"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.scss
@@ -1,7 +1,3 @@
 .panel-title-if{
     background-color: #EDFAEE;
 }
-
-.condition{
-    min-width: 400px;
-}

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/condition-iftrue-step/condition-iftrue-step.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({
@@ -14,6 +14,7 @@ export class ConditionIftrueStepComponent extends WorkflowNodeBaseClass implemen
   }
 
   ngOnInit(): void {
+    this.data.title = "If true";
   }
 
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.html
@@ -1,7 +1,3 @@
-<div class="form-group row" [hidden]="true">
-  <button class="btn btn-sm btn-primary ml-2" (click)="showFlowData()">View Json</button>
-</div>
-
 <div *ngIf="loadingCode">
   <fab-spinner [label]="'Loading...'"></fab-spinner>
 </div>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/create-workflow/create-workflow.component.ts
@@ -464,4 +464,16 @@ export class CreateWorkflowComponent implements OnInit, AfterViewInit, OnChanges
       this.supportTopicsInUse.push({ id: id, supportTopicPath: this.correctSupportTopicPath(this.allSupportTopics[idx].supportTopicPath) });
     }
   }
+
+  refreshVariables() {
+    let rootNode = this.canvas.getFlow().getRoot();
+    if (rootNode != null) {
+      this._workflowService.refreshVariables(rootNode);
+      let wf = new workflow();
+      wf.root = rootNode;
+      let jsonString = JSON.stringify(wf, null, 4);
+      this.canvas.getFlow().upload(jsonString);
+      this._workflowService.showMessageBox("Success", "Variables refreshed successfully", false);
+    }
+  }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
@@ -18,6 +18,8 @@
                             <option *ngFor="let detector of workflowNodeDetectors" [value]="detector.id">{{
                                 detector.name }}</option>
                         </select>
+                        <button [disabled]="data.detectorId ==='choosedetector'" type="button" class="btn btn-sm ml-2"
+                            (click)="refreshVariables()"><i class="fa fa-refresh" title="Click here to refresh the variables"></i></button>
                         <div>
                             <label class="checkbox-inline">
                                 <input [(ngModel)]="data.addDetectorOutput" id="addDetectorOutput"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.html
@@ -1,10 +1,10 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
     <div class="panel panel-default">
         <div class="panel-heading panel-title-detector">
-            <node-title [data]="data" [customClass]="'background-blue'" [customClassIcon]="'fa-solid fa-bolt'">
+            <node-title (collapseChange)="onCollapseChange($event)" [data]="data" [customClass]="'background-blue'" [customClassIcon]="'fa-solid fa-bolt'">
             </node-title>
         </div>
-        <div class="panel-body">
+        <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
             <h5 class="mb-2 text-muted">{{ data.name }}</h5>
             <form>
                 <div class="mb-3">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.ts
@@ -52,6 +52,10 @@ export class DetectorNodeComponent extends WorkflowNodeBaseClass implements OnIn
     let idNumber = this._workflowServicePrivate.getIdNumberForNode(this, detectorId);
     this.data.name = this.data.detectorId + idNumber;
 
+    this.loadDetector();
+  }
+
+  loadDetector() {
     let allRouteQueryParams = this._route.snapshot.queryParams;
     let additionalQueryString = '';
     let knownQueryParams = ['startTime', 'endTime'];
@@ -77,6 +81,7 @@ export class DetectorNodeComponent extends WorkflowNodeBaseClass implements OnIn
   private parseData(dataSet: DiagnosticData) {
     let table: DataTableResponseObject = dataSet.table;
     let rendering: Rendering = dataSet.renderingProperties;
+    this.data.variables = [];
 
     if (table.rows.length > 0) {
 
@@ -99,6 +104,12 @@ export class DetectorNodeComponent extends WorkflowNodeBaseClass implements OnIn
         element.name = this.data.name + '_' + element.name;
         this.data.variables.push(element);
       });
+    }
+  }
+
+  refreshVariables() {
+    if (this.data.detectorId != 'choosedetector') {
+      this.loadDetector();
     }
   }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/detector-node/detector-node.component.ts
@@ -3,8 +3,8 @@ import { ActivatedRoute } from '@angular/router';
 import { DataTableResponseObject, DetectorControlService, DetectorMetaData, DetectorType, DiagnosticData, Rendering, RenderingType } from 'diagnostic-data';
 import { ApplensDiagnosticService } from '../../services/applens-diagnostic.service';
 import { promptType, workflowNodeData, stepVariable } from "diagnostic-data";
-import { WorkflowNodeBaseClass } from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
+import WorkflowNodeBaseClass from '../node-base-class';
 
 @Component({
   selector: 'detector-node',

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/foreach-node/foreach-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/foreach-node/foreach-node.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
     <div class="panel panel-default">
         <div class="panel-heading panel-title-foreach">
-            <node-title [data]="data" [disableEdit]="true" [customClass]="'background-green'"
+            <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-green'"
                 [customClassIcon]="'fa-list'">
             </node-title>
         </div>
-        <div class="panel-body">
+        <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
             <mat-form-field class="example-full-width" appearance="fill">
                 <mat-label>Variable</mat-label>
                 <input type="text" placeholder="Choose a variable" aria-label="Number" matInput

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/foreach-node/foreach-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/foreach-node/foreach-node.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.html
@@ -1,10 +1,10 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-condition">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-gray'"
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-gray'"
         [customClassIcon]="'fa-code'"></node-title>
     </div>
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <form>
         <div class="form-group row">
           <div class="col-sm-12">
@@ -60,8 +60,8 @@
         <form *ngIf="dataType !=='sbyte' && dataType !=='boolean'" class="example-form">
           <mat-form-field class="example-full-width" appearance="fill">
             <mat-label class="matlabel">Value</mat-label>
-            <input type="text" placeholder="Choose a variable or type a static value" aria-label="Number" id="rightControl" matInput
-              [formControl]="rightControl" [matAutocomplete]="autoRight"
+            <input type="text" placeholder="Choose a variable or type a static value" aria-label="Number"
+              id="rightControl" matInput [formControl]="rightControl" [matAutocomplete]="autoRight"
               (input)="updateVariable($event.target.value, 'ifconditionRightValue')">
             <mat-autocomplete autoActiveFirstOption #autoRight="matAutocomplete"
               (optionSelected)="updateVariable($event.option.value, 'ifconditionRightValue')">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/ifelse-condition-step/ifelse-condition-step.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { map, startWith } from 'rxjs/operators';
 import { WorkflowService } from '../services/workflow.service';
 

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/input-node/input-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/input-node/input-node.component.html
@@ -1,10 +1,10 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-input">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-green'" [customClassIcon]="'fa-list'">
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-green'" [customClassIcon]="'fa-list'">
       </node-title>
     </div>
-    <div class="panel-body panel-input-body">
+    <div #nodeBodyDiv class="panel-body panel-input-body" [hidden]="collapsed">
       <form class="form" style="height: 90%;">
         <div>
           <label for="chooseInputType">Choose Input type</label>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/input-node/input-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/input-node/input-node.component.ts
@@ -3,7 +3,7 @@ import { FormControl } from '@angular/forms';
 import { inputType } from 'diagnostic-data';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-kusto">
-      <node-title [data]="data" [customClass]="'background-purple'" [customClassIcon]="'fa-bar-chart'">
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [customClass]="'background-purple'" [customClassIcon]="'fa-bar-chart'">
       </node-title>
     </div>
 
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <pre class="kusto-query mt-1">
 {{ getQueryText(data.queryText) }}
 </pre>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/kusto-node/kusto-node.component.ts
@@ -5,7 +5,7 @@ import { NgFlowchartStepComponent } from 'projects/ng-flowchart/dist';
 import { ConfigureVariablesComponent } from '../configure-variables/configure-variables.component';
 import { KustoQueryDialogComponent } from '../kusto-query-dialog/kusto-query-dialog.component';
 import { kustoQueryDialogParams } from '../models/kusto';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 import { ResourceService } from '../../../../shared/services/resource.service';
 import { DetectorGistApiService } from '../../../../shared/services/detectorgist-template-api.service';

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/markdown-node/markdown-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/markdown-node/markdown-node.component.html
@@ -1,10 +1,10 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
     <div class="panel panel-default">
         <div class="panel-heading panel-title-markdown">
-            <node-title [data]="data" [customClass]="'background-green'" [customClassIcon]="'fa-html5'">
+            <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [customClass]="'background-green'" [customClassIcon]="'fa-html5'">
             </node-title>
         </div>
-        <div class="panel-body">
+        <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
             <div class="markdown-editor">
                 <div class="markdown-text mt-2">{{ data.markdownText }}</div>
                 <button class="btn btn-primary btn-sm" (click)="configureMarkdown()">Configure markdown</button>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/markdown-node/markdown-node.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/markdown-node/markdown-node.component.ts
@@ -4,7 +4,7 @@ import { MarkdownService } from 'ngx-markdown';
 import { MarkdownQueryDialogComponent } from '../markdown-query-dialog/markdown-query-dialog.component';
 import { markdownDialogParams } from '../models/markdown';
 import { workflowNodeData } from "projects/diagnostic-data/src/lib/models/workflow";
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-styles.scss
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-styles.scss
@@ -31,3 +31,7 @@ select {
 ::ng-deep .mat-form-field-appearance-fill ::ng-deep .mat-form-field-flex {
     background-color: var(--bodyBackground);
 }
+
+.workflow-node {
+    min-width: 400px;
+}

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-title/node-title.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-title/node-title.component.html
@@ -9,10 +9,14 @@
     <input *ngIf="data.isEditingTitle" type="text" [(ngModel)]="data.title" name="cardTitle">
   </div>
 
-  <ng-container *ngIf="!disableEdit">
+  <ng-container>
     <div class="filler"></div>
     <div class="center">
-      <button (click)="data.isEditingTitle = !data.isEditingTitle" class="fa mr-2" [ngClass]="data.isEditingTitle ? 'fa-save' : 'fa-pencil'">
+      <button *ngIf="!disableEdit" (click)="data.isEditingTitle = !data.isEditingTitle" class="fa"
+        [ngClass]="data.isEditingTitle ? 'fa-save' : 'fa-pencil'">
+      </button>
+      <button *ngIf="!hideCollapse" (click)="toggleCollapsed()">
+        <i class="fa" [ngClass]="collapsed ? 'fa-plus' : 'fa-minus'"></i>
       </button>
     </div>
   </ng-container>

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-title/node-title.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/node-title/node-title.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'node-title',
@@ -7,14 +7,24 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class NodeTitleComponent implements OnInit {
 
+  collapsed: boolean = true;
+
   @Input() data: any;
   @Input() customClass: string = '';
   @Input() customClassIcon: string = '';
   @Input() disableEdit: boolean = false;
+  @Input() hideCollapse: boolean = false;
+
+  @Output() collapseChange = new EventEmitter<boolean>();
 
   constructor() { }
 
   ngOnInit(): void {
+  }
+
+  toggleCollapsed() {
+    this.collapsed = !this.collapsed;
+    this.collapseChange.emit(this.collapsed);
   }
 
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/services/workflow.service.ts
@@ -377,6 +377,15 @@ export class WorkflowService {
     return false;
   }
 
+  isConditionNode(node:NgFlowchartStepComponent<workflowNodeData>){
+    if (node.type === 'ifelsecondition'
+      || node.type === 'switchCondition') {
+      return true;
+    }
+
+    return false;
+  }
+
   getVariableCompletionOptions(node: NgFlowchartStepComponent<workflowNodeData>, includeCurrentNode: boolean = true): stepVariable[] {
     let allVariables: stepVariable[] = [];
     let currentNode = node;
@@ -497,8 +506,8 @@ export class WorkflowService {
     return atob(input);
   }
 
-  showMessageBox(title: string, message: string) {
-    swalWithBootstrapButtons.fire(title, message, 'error');
+  showMessageBox(title: string, message: string, showError: boolean = true) {
+    swalWithBootstrapButtons.fire(title, message, showError ? 'error' : 'success');
   }
 
   showMessageBoxWithFooter(title: string, message: string, footer: string, width?: string) {
@@ -548,4 +557,16 @@ export class WorkflowService {
     return `${variable.name} > 100 ? \"Critical\" : \"Success\"`;
   }
 
+  refreshVariables(workflowNode: NgFlowchartStepComponent<workflowNodeData>) {
+    if (this.isActionNode(workflowNode) || this.isConditionNode(workflowNode)) {
+      workflowNode.data.completionOptions = this.getVariableCompletionOptions(workflowNode, false);
+    }
+
+    for (let index = 0; index < workflowNode.children.length; index++) {
+      const child = workflowNode.children[index];
+      if (child != null) {
+        this.refreshVariables(child);
+      }
+    }
+  }
 }

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-default-step/switch-case-default-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-default-step/switch-case-default-step.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-switch">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-gray'"
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-gray'"
         [customClassIcon]="'fa-check'">
       </node-title>
     </div>
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <div>If no case contains a matching value</div>
       <div class="mb-5"></div>
       <node-actions [isConditionNode]="true" (onNodeAdded)="addNode($event)"

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-default-step/switch-case-default-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-default-step/switch-case-default-step.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-switch">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-gray'"
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-gray'"
         [customClassIcon]="'fa-toggle-on'">
       </node-title>
     </div>
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <input type="text" [disabled]="!editMode" class="form-control form-control-sm" [(ngModel)]="switchCaseValue"
         name="switchCaseControl">
       <div class="mt-2 mb-2">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-case-step/switch-case-step.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { stepVariable } from "projects/diagnostic-data/src/lib/models/workflow";
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.html
@@ -1,11 +1,11 @@
-<div [attr.name]="data.name" #canvasContent>
+<div [attr.name]="data.name" #canvasContent class="workflow-node">
   <div class="panel panel-default">
     <div class="panel-heading panel-title-switch">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-gray'"
+      <node-title [data]="data" (collapseChange)="onCollapseChange($event)" [disableEdit]="true" [customClass]="'background-gray'"
         [customClassIcon]="'fa-list'">
       </node-title>
     </div>
-    <div class="panel-body">
+    <div #nodeBodyDiv class="panel-body" [hidden]="collapsed">
       <form class="example-form">
         <div class="form-group row">
           <div class="col-sm-12">

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.ts
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/switch-step/switch-step.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
-import { WorkflowNodeBaseClass } from '../node-base-class';
+import WorkflowNodeBaseClass from '../node-base-class';
 import { WorkflowService } from '../services/workflow.service';
 
 @Component({

--- a/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-root-node/workflow-root-node.component.html
+++ b/AngularApp/projects/applens/src/app/modules/dashboard/workflow/workflow-root-node/workflow-root-node.component.html
@@ -1,7 +1,8 @@
 <div [attr.name]="data.name" #canvasContent>
   <div class="panel panel-default">
     <div class="panel-heading panel-title-root">
-      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-blue'" [customClassIcon]="'fa-plus'">
+      <node-title [data]="data" [disableEdit]="true" [customClass]="'background-blue'" [customClassIcon]="'fa-plus'"
+        [hideCollapse]="true">
       </node-title>
     </div>
     <div class="panel-body">

--- a/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/detector-view/detector-view.component.html
@@ -77,11 +77,23 @@
     </loader-detector-view>
   </ng-container>
   <ng-container *ngIf="errorState">
-    <span class="critical-color" *ngIf="errorState.error && !isPublic && !forbiddenError"> Error: {{errorState.error}}</span>
+    <span class="critical-color" *ngIf="errorState.error && !isPublic && !forbiddenError"> Error:
+      {{errorState.error}}</span>
     <span class="critical-color" *ngIf="isPublic && errorState || !errorState.error">Sorry, an error occurred. Please
       refresh the page and try again.</span>
   </ng-container>
 </ng-container>
+
+<div *ngIf="_isWorkflowNode && supportsDownTime">
+  Before proceeding further, please <strong>choose</strong> a downtime or <strong>select a range</strong> on the above graph
+  <div class="mt-2">
+    <fab-dropdown [disabled]="selectWorkflowDownTimeDisabled" role="combobox" [options]="downTimeOptions"
+      (onChange)="onWorkflowDowntimeChange($event)" [defaultSelectedKey]="defaultSelectedKey">
+    </fab-dropdown>
+  </div>
+  <button type="button" class="mt-3 mb-2 btn btn-primary btn-sm" [disabled]="nextButtonDisabled"
+    (click)="clickNext()">Next</button>
+</div>
 
 <ng-template #detectorName>
   <span>{{detectorDataLocalCopy.metadata.name}}</span>

--- a/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/highcharts-graph/highcharts-graph.component.ts
@@ -631,6 +631,15 @@ export class HighchartsGraphComponent implements OnInit {
             this.options.xAxis.plotBands = chartPlotBands;
         }
 
+        //
+        // Used by DownTime selector in Workflow Nodes to reset the plotBand
+        // when an end user chooses 'Choose a downtime' from the dropdown
+        //
+
+        if (!!this.xAxisPlotBands && this.xAxisPlotBands.length === 0) {
+            this.options.xAxis.plotBands = [];
+        }
+
         if (this.chartOptions) {
             this._updateObject(this.options, this.chartOptions);
         }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-condition-node/workflow-condition-node.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-condition-node/workflow-condition-node.component.ts
@@ -3,6 +3,7 @@ import { DetectorControlService } from '../../services/detector-control.service'
 import { DiagnosticService } from '../../services/diagnostic.service';
 import { WorkflowHelperService } from '../../services/workflow-helper.service';
 import { WorkflowNodeComponent } from '../workflow-node/workflow-node.component';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'workflow-condition-node',
@@ -12,8 +13,8 @@ import { WorkflowNodeComponent } from '../workflow-node/workflow-node.component'
 export class WorkflowConditionNodeComponent extends WorkflowNodeComponent implements OnInit {
 
   constructor(private _diagnosticServicePrivate: DiagnosticService, private _detectorControlServicePrivate: DetectorControlService,
-    private _workflowHelperServicePrivate: WorkflowHelperService) {
-    super(_diagnosticServicePrivate, _detectorControlServicePrivate, _workflowHelperServicePrivate);
+    private _workflowHelperServicePrivate: WorkflowHelperService, private _activatedRoutePrivate: ActivatedRoute, private _routerPrivate: Router) {
+    super(_diagnosticServicePrivate, _detectorControlServicePrivate, _workflowHelperServicePrivate, _activatedRoutePrivate, _routerPrivate);
   }
 
   ngOnInit(): void {

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.html
@@ -42,8 +42,8 @@
         <markdown-text [markdownData]="data.markdownText" [isMarkdownView]="true"></markdown-text>
       </div>
       <div #detectorViewDiv *ngIf="data.detectorResponse" class="mr-3 min-width-detector-section">
-        <detector-view [detectorResponse]="data.detectorResponse" [developmentMode]="false" hideDetectorControl="true"
-          [startTime]="startTime" [endTime]="endTime">
+        <detector-view [isWorkflowNode]="true" [detectorResponse]="data.detectorResponse" [developmentMode]="false" hideDetectorControl="true"
+          [startTime]="startTime" [endTime]="endTime" (ProgressToNextNode)="onProgressToNextNode($event)">
         </detector-view>
       </div>
       <workflow-accept-userinput *ngIf="data.inputNodeSettings" [data]="data"

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.scss
@@ -105,4 +105,6 @@
 
 .min-width-detector-section {
   min-width: 500px;
+  overflow-wrap: break-word;
+  word-break: break-all;
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.ts
@@ -377,9 +377,8 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
 
   onProgressToNextNode(event: DownTime) {
     if (event) {
-
       if (this._activatedRoute == null || this._activatedRoute.firstChild == null || !this._activatedRoute.firstChild.snapshot.paramMap.has('detector') || this._activatedRoute.firstChild.snapshot.paramMap.get('detector').length < 1) {
-        this._router.navigate([`./`], {
+        this._router.navigate([], {
           relativeTo: this._activatedRoute,
           queryParams: { startTimeChildDetector: event.StartTime.format(this.stringFormat), endTimeChildDetector: event.EndTime.format(this.stringFormat) },
           queryParamsHandling: 'merge',

--- a/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/components/workflow-node/workflow-node.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Moment } from 'moment';
 import { NgFlowchart, NgFlowchartStepComponent } from 'projects/ng-flowchart/dist';
-import { HealthStatus } from '../../models/detector';
+import { DetectorResponse, DownTime, HealthStatus, RenderingType } from '../../models/detector';
 import { workflowNodeResult, workflowNodeState } from '../../models/workflow';
 import { DetectorControlService } from '../../services/detector-control.service';
 import { DiagnosticService } from '../../services/diagnostic.service';
@@ -9,6 +9,10 @@ import { WorkflowHelperService } from "../../services/workflow-helper.service";
 import { WorkflowConditionNodeComponent } from '../workflow-condition-node/workflow-condition-node.component';
 import Swal from 'sweetalert2';
 import { WorkflowAcceptUserinputComponent } from '../workflow-accept-userinput/workflow-accept-userinput.component';
+import { ActivatedRoute, Router } from '@angular/router';
+import * as momentNs from 'moment';
+
+const moment = momentNs;
 
 @Component({
   selector: 'workflow-node',
@@ -26,6 +30,8 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
 
   @ViewChild('detectorViewDiv') detectorViewDiv: ElementRef;
 
+  readonly stringFormat: string = 'YYYY-MM-DDTHH:mm';
+
   isLoading: boolean = false;
   error: any;
   status: HealthStatus = HealthStatus.Info;
@@ -36,14 +42,21 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
   resizeObserver: ResizeObserver;
 
   constructor(private _diagnosticService: DiagnosticService, private _detectorControlService: DetectorControlService,
-    private _workflowHelperService: WorkflowHelperService) {
+    private _workflowHelperService: WorkflowHelperService, private _activatedRoute: ActivatedRoute, private _router: Router) {
     super();
   }
 
   ngOnInit(): void {
     this.updateStatus();
     if (this.data.promptType && this.data.promptType === 'automatic' && this.data.type !== "IfElseCondition" && this.data.type !== "SwitchCondition") {
-      this.runNext(this.data.children);
+
+      //
+      // Do not run children for the detector node if it is a downtime detector 
+      //
+
+      if (!(this.data.type.toLowerCase() === "detector" && this.isDownTimeDetector(this.data.detectorResponse))) {
+        this.runNext(this.data.children); 
+      }
     }
 
     this.setupResizeObserver();
@@ -143,9 +156,10 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
       Resource: null,
       UserInputs: userInputs
     }
+    let { startTime, endTime } = this.getCorrectTimeRange();
     this._diagnosticService.getWorkflowCompilerResponse(body,
-      this._detectorControlService.startTimeString,
-      this._detectorControlService.endTimeString,
+      startTime,
+      endTime,
       {
         scriptETag: this.data.compilationProperties.scriptETag,
         assemblyName: this.data.compilationProperties.assemblyName,
@@ -186,8 +200,7 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
   }
 
   executeNode(child: workflowNodeState, userInputs: any = null) {
-    let startTime = this._detectorControlService.startTimeString;
-    let endTime = this._detectorControlService.endTimeString;
+    let { startTime, endTime } = this.getCorrectTimeRange();
 
     this._diagnosticService.getWorkflowNode(this.data.workflowId, this.data.workflowExecutionId, child.id, startTime, endTime,
       this._detectorControlService.isInternalView, null, null, userInputs)
@@ -224,8 +237,7 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
 
   addAdditionalNodesIfNeeded(nodeResult: workflowNodeResult, description: string, addedNode: NgFlowchartStepComponent<workflowNodeResult>) {
     if (nodeResult.type === "IfElseCondition" || nodeResult.type === "SwitchCondition") {
-      let startTime = this._detectorControlService.startTimeString;
-      let endTime = this._detectorControlService.endTimeString;
+      let { startTime, endTime } = this.getCorrectTimeRange();
       this.isLoading = true;
       nodeResult.children.forEach(childNode => {
         if (childNode.isActive) {
@@ -333,5 +345,49 @@ export class WorkflowNodeComponent extends NgFlowchartStepComponent<workflowNode
       width: 1000,
       showCloseButton: true
     })
+  }
+
+  getCorrectTimeRange() {
+    let startTime = this._detectorControlService.startTimeString;
+    let endTime = this._detectorControlService.endTimeString;
+
+    let startTimeChildDetector: string = this._activatedRoute.snapshot.queryParams['startTimeChildDetector'];
+    if (!!startTimeChildDetector && startTimeChildDetector.length > 1 && moment.utc(startTimeChildDetector).isValid()) {
+      let startTimeMoment = moment.utc(startTimeChildDetector);
+      startTime = startTimeMoment.format(this.stringFormat);
+    }
+
+    let endTimeChildDetector: string = this._activatedRoute.snapshot.queryParams['endTimeChildDetector'];
+    if (!!endTimeChildDetector && endTimeChildDetector.length > 1 && moment.utc(endTimeChildDetector).isValid()) {
+      let endTimeMoment = moment.utc(endTimeChildDetector);
+      endTime = endTimeMoment.format(this.stringFormat);
+    }
+
+    return { startTime: startTime, endTime: endTime };
+  }
+
+  isDownTimeDetector(detectorResponse: DetectorResponse): boolean {
+    if (detectorResponse == null || detectorResponse.dataset == null || detectorResponse.dataset.length == 0) {
+      return false;
+    }
+
+    let downtimeDetector = detectorResponse.dataset.find(dataset => dataset.renderingProperties.type === RenderingType.DownTime);
+    return downtimeDetector != null;
+  }
+
+  onProgressToNextNode(event: DownTime) {
+    if (event) {
+
+      if (this._activatedRoute == null || this._activatedRoute.firstChild == null || !this._activatedRoute.firstChild.snapshot.paramMap.has('detector') || this._activatedRoute.firstChild.snapshot.paramMap.get('detector').length < 1) {
+        this._router.navigate([`./`], {
+          relativeTo: this._activatedRoute,
+          queryParams: { startTimeChildDetector: event.StartTime.format(this.stringFormat), endTimeChildDetector: event.EndTime.format(this.stringFormat) },
+          queryParamsHandling: 'merge',
+          replaceUrl: true
+        }).then(value => {
+          this.runNext(this.data.children);
+        });
+      }
+    }
   }
 }

--- a/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
+++ b/AngularApp/projects/diagnostic-data/src/lib/models/detector.ts
@@ -271,7 +271,8 @@ export const DowntimeInteractionSource = {
     Dropdown: 'Dropdown',
     DefaultFromDetector: 'DefaultFromDetector',
     DefaultFromQueryParams: 'DefaultFromQueryParams',
-    DefaultFromUI: 'DefaultFromUI'
+    DefaultFromUI: 'DefaultFromUI',
+    Workflow:'Workflow'
 };
 
 export enum GanttChartInnerMarkdownPosition {


### PR DESCRIPTION
## Overview
With this PR

1. We are adding the ability to add a downtime selector in Workflow nodes.
2. Also adding a feature to refresh the detector node variables and variables for the entire workflow.


## Type of change
- [x] New feature (non-breaking change which adds functionality)

### This PR:

## How Can This Be Tested? <span>&#128269;</span>
By running AppLens locally

## Screenshots After Fix (if appropriate):

<img width="769" alt="image" src="https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/8e83fc67-ef28-4f69-bc8c-1b3c6c2a7c92">

When you click on the dropdown...

<img width="477" alt="image" src="https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/57b1f5ee-d521-47dd-b451-d094c5cc7fb3">

And you can also select a range on the graph
<img width="481" alt="image" src="https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/acfbfd5d-9972-4260-aac9-cbd935b92774">

The workflow will wait till a downtime is selected and once a valid downtime is selected, the UI will enable the Next button and only then the workflow moves forward

<img width="770" alt="image" src="https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/assets/5299838/11bc2bed-d6f6-4d58-bd44-4f6600ffd09c">
